### PR TITLE
readme: use a link element when referring examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ NoVerify by default has the following checks:
 
 You can write your own checks that can use type information from NoVerify
 and check for complex things, e.g. enforcing that strings are compared only
-using === operator. See `example` folder to see some examples of custom checks. 
+using === operator. See [example](/example) folder to see some examples of custom checks. 
 
 ## Installation
 


### PR DESCRIPTION
Makes "examples" text element clickable.