### PR TITLE
Rewrite if-else-if-else to switch statements

### DIFF
--- a/src/git/catter.go
+++ b/src/git/catter.go
@@ -135,13 +135,14 @@ func (o *ObjectCatter) Walk(dir string, treeSHA1 string, filenameFilter func(fil
 	for pos < len(obj.Contents) {
 		typ := obj.Contents[pos]
 		pos++
-		if typ == fileTyp {
+		switch typ {
+		case fileTyp:
 			typeBuf = obj.Contents[pos : pos+fileLen]
 			pos += fileLen
-		} else if typ == dirTyp {
+		case dirTyp:
 			typeBuf = obj.Contents[pos : pos+dirLen]
 			pos += dirLen
-		} else {
+		default:
 			return fmt.Errorf("Unknown typ: %c", typ)
 		}
 		pos++ // space

--- a/src/git/diff.go
+++ b/src/git/diff.go
@@ -205,15 +205,17 @@ func parseDiff(rd *bufio.Reader) ([]Change, error) {
 
 	for {
 		ln, skip, err := readShortLine(rd)
-		if err == io.EOF {
+		switch {
+		case err == io.EOF:
 			break
-		} else if err != nil {
+		case err != nil:
 			return nil, err
-		} else if skip {
+		case skip:
 			continue
 		}
 
-		if bytes.HasPrefix(ln, diffOldPrefix) {
+		switch {
+		case bytes.HasPrefix(ln, diffOldPrefix):
 			if cur.OldName != "" {
 				res = append(res, cur)
 				cur.OldName = ""
@@ -224,9 +226,9 @@ func parseDiff(rd *bufio.Reader) ([]Change, error) {
 			}
 
 			cur.parseOld(ln)
-		} else if bytes.HasPrefix(ln, diffNewPrefix) {
+		case bytes.HasPrefix(ln, diffNewPrefix):
 			cur.parseNew(ln)
-		} else if bytes.HasPrefix(ln, patchHeaderPrefix2) && bytes.Contains(ln, patchHeaderSuffix2) {
+		case bytes.HasPrefix(ln, patchHeaderPrefix2) && bytes.Contains(ln, patchHeaderSuffix2):
 			trimmed := bytes.TrimPrefix(ln, patchHeaderPrefix2)
 			suffixIdx := bytes.Index(trimmed, patchHeaderSuffix2)
 			if suffixIdx < 0 {
@@ -235,7 +237,7 @@ func parseDiff(rd *bufio.Reader) ([]Change, error) {
 			if err := cur.parsePatchHeader(trimmed[0:suffixIdx]); err != nil {
 				return nil, err
 			}
-		} else if bytes.HasPrefix(ln, patchHeaderPrefix3) && bytes.Contains(ln, patchHeaderSuffix3) {
+		case bytes.HasPrefix(ln, patchHeaderPrefix3) && bytes.Contains(ln, patchHeaderSuffix3):
 			trimmed := bytes.TrimPrefix(ln, patchHeaderPrefix3)
 			suffixIdx := bytes.Index(trimmed, patchHeaderSuffix3)
 			if suffixIdx < 0 {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1045,11 +1045,12 @@ func (d *RootWalker) handleOverride(s *expr.FunctionCall) bool {
 	}
 
 	var overrideTyp meta.OverrideType
-	if meta.NameEquals(overrideNameNode, `type`) {
+	switch {
+	case meta.NameEquals(overrideNameNode, `type`):
 		overrideTyp = meta.OverrideArgType
-	} else if meta.NameEquals(overrideNameNode, `elementType`) {
+	case meta.NameEquals(overrideNameNode, `elementType`):
 		overrideTyp = meta.OverrideElementType
-	} else {
+	default:
 		return true
 	}
 

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -89,11 +89,12 @@ func internalFuncType(nm string, sc *meta.Scope, cs *meta.ClassParseState, c *ex
 
 func arrayType(items []node.Node) *meta.TypesMap {
 	if len(items) > 0 {
-		if isConstantStringArray(items) {
+		switch {
+		case isConstantStringArray(items):
 			return meta.NewTypesMap("string[]")
-		} else if isConstantIntArray(items) {
+		case isConstantIntArray(items):
 			return meta.NewTypesMap("int[]")
-		} else if isConstantFloatArray(items) {
+		case isConstantFloatArray(items):
 			return meta.NewTypesMap("double[]")
 		}
 	}


### PR DESCRIPTION
This commit rewrites some if-else-if-else chains as a switch.
Based on Go style guide:
https://golang.org/doc/effective_go.html#switch

Found by https://go-critic.github.io/overview#ifElseChain-ref