### PR TITLE
linter: report usages of array() literals

### DIFF
--- a/src/linter/basic_test.go
+++ b/src/linter/basic_test.go
@@ -18,6 +18,21 @@ func hasReport(reports []*Report, substr string) bool {
 	return false
 }
 
+func TestArrayLiteral(t *testing.T) {
+	reports := getReportsSimple(t, `<?php
+	function traditional_array_literal() {
+		return array(1, 2);
+	}`)
+
+	if len(reports) != 1 {
+		t.Errorf("Unexpected number of reports: expected 1, got %d", len(reports))
+	}
+
+	if !hasReport(reports, "Use of old array syntax") {
+		t.Errorf("No error about array() syntax")
+	}
+}
+
 func TestUnused(t *testing.T) {
 	reports := getReportsSimple(t, `<?php
 	function unused_test($arg1, $arg2) {

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -246,7 +246,7 @@ func (b *BlockWalker) EnterNode(w walker.Walkable) (res bool) {
 	case *assign.Reference:
 		res = b.handleAssignReference(s)
 	case *expr.Array:
-		res = b.handleArrayItems(s, s.Items)
+		res = b.handleArray(s)
 	case *expr.ShortArray:
 		res = b.handleArrayItems(s, s.Items)
 	case *stmt.Foreach:
@@ -918,6 +918,11 @@ func (b *BlockWalker) handleStaticPropertyFetch(e *expr.StaticPropertyFetch) boo
 	}
 
 	return false
+}
+
+func (b *BlockWalker) handleArray(arr *expr.Array) bool {
+	b.r.Report(arr, LevelDoNotReject, "Use of old array syntax (use short form instead)")
+	return b.handleArrayItems(arr, arr.Items)
 }
 
 func (b *BlockWalker) handleArrayItems(arr node.Node, items []node.Node) bool {


### PR DESCRIPTION
Suggest using short [] form instead.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>