### PR TITLE
annotate most reports, add -exclude-checks CLI param

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,35 @@ There are multiple ways to disable linter for certain files and lines:
 - Add files or directories into `-exclude` regex (e.g. `-exclude='vendor/|tests/'` or `-exclude="vendor|tests"` for Windows)
 - Enter `@linter disable` in a commit message to disable checks for this commit only (diff mode only).
 
+There is also check-specific disabling mechanism. Every annotated warning can be disabled using
+`-exclude-checks` argument, which is a comma-separated list of checks to be disabled.
+
+Given this PHP file (`hello.php`):
+
+```php
+<?php
+$x = array($v, 2);
+```
+
+By default, NoVerify would report 2 issues:
+
+```sh
+$ noverify -stubs-dir /path/to/stubs hello.php
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at /home/quasilyte/CODE/php/hello.php:3
+$x = array($v, 2);
+     ^^^^^^^^^^^^
+ERROR   undefined: Undefined variable: v at /home/quasilyte/CODE/php/hello.php:3
+$x = array($v, 2);
+           ^^
+```
+
+The `arraySyntax` and `undefined` are so-called "check names" which you can use to disable associated reports.
+
+```sh
+$ noverify -exclude-checks arraySyntax,undefined -stubs-dir /path/to/stubs hello.php
+# No warnings
+```
+
 ### Language server mode (experimental)
 
 If you want to launch noverify in language server mode, launch it in your IDE/editor extension like the following:

--- a/example/custom/custom_test.go
+++ b/example/custom/custom_test.go
@@ -75,7 +75,7 @@ func TestAssignmentAsExpression(t *testing.T) {
 
 	text := reports[0].String()
 
-	if !strings.Contains(text, "3rd argument of in_array must be true when comparing strings (strict comparison)") {
+	if !strings.Contains(text, "3rd argument of in_array must be true when comparing strings") {
 		t.Errorf("Wrong report text: expected '3rd argument of in_array must be true', got '%s'", text)
 	}
 

--- a/example/custom/main.go
+++ b/example/custom/main.go
@@ -42,11 +42,11 @@ func (b *block) BeforeEnterNode(w walker.Walkable) {
 		b.handleFunctionCall(n)
 	case *binary.Equal:
 		if isString(b.ctx, n.Left) || isString(b.ctx, n.Right) {
-			b.ctx.Report(n, linter.LevelWarning, "Strings must be compared using '===' operator")
+			b.ctx.Report(n, linter.LevelWarning, "strictCmp", "Strings must be compared using '===' operator")
 		}
 	case *binary.NotEqual:
 		if isString(b.ctx, n.Left) || isString(b.ctx, n.Right) {
-			b.ctx.Report(n, linter.LevelWarning, "Strings must be compared using '!==' operator")
+			b.ctx.Report(n, linter.LevelWarning, "strictCmp", "Strings must be compared using '!==' operator")
 		}
 	}
 }
@@ -77,7 +77,7 @@ func (b *block) handleInArrayCall(e *expr.FunctionCall) {
 		return
 	}
 
-	b.ctx.Report(e, linter.LevelWarning, "3rd argument of in_array must be true when comparing strings (strict comparison)")
+	b.ctx.Report(e, linter.LevelWarning, "strictCmp", "3rd argument of in_array must be true when comparing strings")
 }
 
 func (b *block) AfterEnterNode(w walker.Walkable)  {}

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -46,7 +46,20 @@ func FlagsToString(f int) string {
 	return "Exit flags: " + strings.Join(res, ", ") + ", digits: " + fmt.Sprintf("%d", f)
 }
 
-// BlockWalker is used to process function/method contents
+// BlockWalker is used to process function/method contents.
+//
+// Current list of annotated checks:
+//	- accessLevel
+//	- argCount
+//	- arrayAccess
+//	- arrayKeys
+//	- arraySyntax
+//	- bareTry
+//	- caseBreak
+//	- deadCode
+//	- phpdoc
+//	- undefined
+//	- unused
 type BlockWalker struct {
 	sc *meta.Scope
 	r  *RootWalker
@@ -176,7 +189,7 @@ func (b *BlockWalker) reportDeadCode(n node.Node) {
 	}
 
 	b.deadCodeReported = true
-	b.r.Report(n, LevelInformation, "Unreachable code")
+	b.r.Report(n, LevelInformation, "deadCode: Unreachable code")
 }
 
 func varToString(v *expr.Variable) string {
@@ -476,7 +489,7 @@ func (b *BlockWalker) handleEmpty(s *expr.Empty) bool {
 
 func (b *BlockWalker) handleTry(s *stmt.Try) bool {
 	if len(s.Catches) == 0 && s.Finally == nil {
-		b.r.Report(s, LevelError, "At least one catch or finally block must be present")
+		b.r.Report(s, LevelError, "bareTry: At least one catch or finally block must be present")
 	}
 
 	contexts := make([]*BlockWalker, 0, len(s.Catches)+1)
@@ -608,13 +621,13 @@ func (b *BlockWalker) checkArrayDimFetch(s *expr.ArrayDimFetch) {
 	})
 
 	if maybeHaveClasses && !haveArrayAccess {
-		b.r.Report(s.Variable, LevelDoNotReject, "Array access to non-array type %s", typ)
+		b.r.Report(s.Variable, LevelDoNotReject, "arrayAccess: Array access to non-array type %s", typ)
 	}
 }
 
 func (b *BlockWalker) handleCallArgs(n node.Node, args []node.Node, fn meta.FuncInfo) {
 	if len(args) < fn.MinParamsCnt {
-		b.r.Report(n, LevelWarning, "Too few arguments for %s", meta.NameNodeToString(n))
+		b.r.Report(n, LevelWarning, "argCount: Too few arguments for %s", meta.NameNodeToString(n))
 	}
 
 	for i, arg := range args {
@@ -693,7 +706,7 @@ func (b *BlockWalker) handleFunctionCall(e *expr.FunctionCall) bool {
 		}
 
 		if !defined {
-			b.r.Report(e.Function, LevelError, "Call to undefined function %s", meta.NameNodeToString(e.Function))
+			b.r.Report(e.Function, LevelError, "undefined: Call to undefined function %s", meta.NameNodeToString(e.Function))
 		}
 	}
 
@@ -781,11 +794,11 @@ func (b *BlockWalker) handleMethodCall(e *expr.MethodCall) bool {
 	e.Method.Walk(b)
 
 	if !foundMethod && !magic && !b.r.st.IsTrait && !b.isThisInsideClosure(e.Variable) {
-		b.r.Report(e.Method, LevelError, "Call to undefined method {%s}->%s()", exprType, methodName)
+		b.r.Report(e.Method, LevelError, "undefined: Call to undefined method {%s}->%s()", exprType, methodName)
 	}
 
 	if foundMethod && !b.canAccess(implClass, fn.AccessLevel) {
-		b.r.Report(e.Method, LevelError, "Cannot access %s method %s->%s()", fn.AccessLevel, implClass, methodName)
+		b.r.Report(e.Method, LevelError, "accessLevel: Cannot access %s method %s->%s()", fn.AccessLevel, implClass, methodName)
 	}
 
 	b.handleCallArgs(e.Method, e.Arguments, fn)
@@ -819,11 +832,11 @@ func (b *BlockWalker) handleStaticCall(e *expr.StaticCall) bool {
 	e.Call.Walk(b)
 
 	if !ok && !haveMagicMethod(className, `__callStatic`) && !b.r.st.IsTrait {
-		b.r.Report(e.Call, LevelError, "Call to undefined method %s::%s()", className, methodName)
+		b.r.Report(e.Call, LevelError, "undefined: Call to undefined method %s::%s()", className, methodName)
 	}
 
 	if ok && !b.canAccess(implClass, fn.AccessLevel) {
-		b.r.Report(e.Call, LevelError, "Cannot access %s method %s::%s()", fn.AccessLevel, implClass, methodName)
+		b.r.Report(e.Call, LevelError, "accessLevel: Cannot access %s method %s::%s()", fn.AccessLevel, implClass, methodName)
 	}
 
 	b.handleCallArgs(e.Call, e.Arguments, fn)
@@ -876,11 +889,11 @@ func (b *BlockWalker) handlePropertyFetch(e *expr.PropertyFetch) bool {
 	})
 
 	if !found && !magic && !b.r.st.IsTrait && !b.isThisInsideClosure(e.Variable) {
-		b.r.Report(e.Property, LevelError, "Property {%s}->%s does not exist", typ, id.Value)
+		b.r.Report(e.Property, LevelError, "undefined: Property {%s}->%s does not exist", typ, id.Value)
 	}
 
 	if found && !b.canAccess(implClass, info.AccessLevel) {
-		b.r.Report(e.Property, LevelError, "Cannot access %s property %s->%s", info.AccessLevel, implClass, id.Value)
+		b.r.Report(e.Property, LevelError, "accessLevel: Cannot access %s property %s->%s", info.AccessLevel, implClass, id.Value)
 	}
 
 	return false
@@ -910,18 +923,18 @@ func (b *BlockWalker) handleStaticPropertyFetch(e *expr.StaticPropertyFetch) boo
 
 	info, implClass, ok := solver.FindProperty(className, "$"+varName.Value)
 	if !ok && !b.r.st.IsTrait {
-		b.r.Report(e.Property, LevelError, "Property %s::$%s does not exist", className, varName.Value)
+		b.r.Report(e.Property, LevelError, "undefined: Property %s::$%s does not exist", className, varName.Value)
 	}
 
 	if ok && !b.canAccess(implClass, info.AccessLevel) {
-		b.r.Report(e.Property, LevelError, "Cannot access %s property %s::$%s", info.AccessLevel, implClass, varName.Value)
+		b.r.Report(e.Property, LevelError, "accessLevel: Cannot access %s property %s::$%s", info.AccessLevel, implClass, varName.Value)
 	}
 
 	return false
 }
 
 func (b *BlockWalker) handleArray(arr *expr.Array) bool {
-	b.r.Report(arr, LevelDoNotReject, "Use of old array syntax (use short form instead)")
+	b.r.Report(arr, LevelDoNotReject, "arraySyntax: Use of old array syntax (use short form instead)")
 	return b.handleArrayItems(arr, arr.Items)
 }
 
@@ -961,14 +974,14 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []node.Node) bool {
 		}
 
 		if _, ok := keys[key]; ok {
-			b.Report(item.Key, LevelWarning, "Duplicate array key '%s'", key)
+			b.Report(item.Key, LevelWarning, "arrayKeys: Duplicate array key '%s'", key)
 		}
 
 		keys[key] = struct{}{}
 	}
 
 	if haveImplicitKeys && haveKeys {
-		b.Report(arr, LevelWarning, "Mixing implicit and explicit array keys")
+		b.Report(arr, LevelWarning, "arrayKeys: Mixing implicit and explicit array keys")
 	}
 
 	return true
@@ -1003,11 +1016,11 @@ func (b *BlockWalker) handleClassConstFetch(e *expr.ClassConstFetch) bool {
 	e.Class.Walk(b)
 
 	if !ok && !b.r.st.IsTrait {
-		b.r.Report(e.ConstantName, LevelError, "Class constant %s::%s does not exist", className, constName.Value)
+		b.r.Report(e.ConstantName, LevelError, "undefined: Class constant %s::%s does not exist", className, constName.Value)
 	}
 
 	if ok && !b.canAccess(implClass, info.AccessLevel) {
-		b.r.Report(e.ConstantName, LevelError, "Cannot access %s constant %s::%s", info.AccessLevel, implClass, constName.Value)
+		b.r.Report(e.ConstantName, LevelError, "accessLevel: Cannot access %s constant %s::%s", info.AccessLevel, implClass, constName.Value)
 	}
 
 	return false
@@ -1021,7 +1034,7 @@ func (b *BlockWalker) handleConstFetch(e *expr.ConstFetch) bool {
 	_, _, defined := solver.GetConstant(b.r.st, e.Constant)
 
 	if !defined {
-		b.r.Report(e.Constant, LevelError, "Undefined constant %s", meta.NameNodeToString(e.Constant))
+		b.r.Report(e.Constant, LevelError, "undefined: Undefined constant %s", meta.NameNodeToString(e.Constant))
 	}
 
 	return true
@@ -1039,7 +1052,7 @@ func (b *BlockWalker) handleNew(e *expr.New) bool {
 	}
 
 	if _, ok := meta.Info.GetClass(className); !ok {
-		b.r.Report(e.Class, LevelError, "Class not found %s", className)
+		b.r.Report(e.Class, LevelError, "undefined: Class not found %s", className)
 	}
 
 	return true
@@ -1120,7 +1133,7 @@ func (b *BlockWalker) enterClosure(fun *expr.Closure, haveThis bool, thisType *m
 	_, phpDocParamTypes, phpDocError := b.r.parsePHPDoc(fun.PhpDocComment, fun.Params)
 
 	if phpDocError != "" {
-		b.r.Report(fun, LevelInformation, "PHPDoc is incorrect: %s", phpDocError)
+		b.r.Report(fun, LevelInformation, "phpdoc: PHPDoc is incorrect: %s", phpDocError)
 	}
 
 	for _, useExpr := range fun.Uses {
@@ -1129,7 +1142,7 @@ func (b *BlockWalker) enterClosure(fun *expr.Closure, haveThis bool, thisType *m
 		varName := v.VarName.(*node.Identifier).Value
 
 		if !b.sc.HaveVar(v) && !u.ByRef {
-			b.r.Report(v, LevelWarning, "Undefined variable %s", varName)
+			b.r.Report(v, LevelWarning, "undefined: Undefined variable %s", varName)
 		}
 
 		typ, ok := b.sc.GetVarNameType(varName)
@@ -1409,7 +1422,7 @@ func (b *BlockWalker) handleSwitch(s *stmt.Switch) bool {
 
 		// allow to omit "break;" in the final statement
 		if idx != len(s.Cases)-1 && bCopy.exitFlags == 0 {
-			b.r.Report(c, LevelInformation, "Case without break")
+			b.r.Report(c, LevelInformation, "caseBreak: Case without break")
 		}
 
 		if (bCopy.exitFlags & (^breakFlags)) == 0 {
@@ -1633,7 +1646,7 @@ func (b *BlockWalker) flushUnused() {
 			}
 
 			visitedMap[n] = struct{}{}
-			b.r.Report(n, LevelUnused, `Unused variable %s (use $_ to ignore this inspection)`, name)
+			b.r.Report(n, LevelUnused, `unused: Unused variable %s (use $_ to ignore this inspection)`, name)
 		}
 	}
 }

--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -26,7 +26,7 @@ type RootChecker interface {
 
 // RootContext is the context for root checker to run on.
 type RootContext interface {
-	Report(n node.Node, level int, msg string, args ...interface{})
+	Report(n node.Node, level int, checkName, msg string, args ...interface{})
 	Scope() *meta.Scope                     // get variables declared at root level
 	ClassParseState() *meta.ClassParseState // get class parse state (namespace, class, etc)
 	State() map[string]interface{}          // state that can be modified and passed into block context
@@ -34,7 +34,7 @@ type RootContext interface {
 
 // BlockContext is the context for block checker.
 type BlockContext interface {
-	Report(n node.Node, level int, msg string, args ...interface{})
+	Report(n node.Node, level int, checkName, msg string, args ...interface{})
 	Scope() *meta.Scope                     // get variables declared in this block
 	ClassParseState() *meta.ClassParseState // get class parse state (namespace, class, etc)
 	RootState() map[string]interface{}      // state from root context

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -118,7 +118,7 @@ func analyzeFile(filename string, contents []byte, parser *php7.Parser, lineRang
 	}
 
 	for _, e := range parser.GetErrors() {
-		w.Report(nil, LevelError, "Syntax error: "+e.String())
+		w.Report(nil, LevelError, "syntax", "Syntax error: "+e.String())
 	}
 
 	atomic.AddInt64(&initWalkTime, int64(time.Since(start)))


### PR DESCRIPTION
This is probably a transitional step into a better support
of named checks. For now, caller of the Report can optionally
prepend check name that can be later extracted using CheckName() method.

As a demonstration of how this can be used, -exclude-checks flag
is implemented.

Even if internal representation of check names and/or Report()
API would change, -exclude-checks behavior will stay the same.

I'm planning to use CheckName() method inside linter tests to filter-out
all unrelated warnings.

Updates #27

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>