### PR TITLE
linter: add AfterLeaveFile method to RootChecker interface

### DIFF
--- a/example/custom/custom_test.go
+++ b/example/custom/custom_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	linter.RegisterBlockChecker(func(ctx linter.BlockContext) linter.BlockChecker { return &block{ctx: ctx} })
+	linter.RegisterBlockChecker(func(ctx *linter.BlockContext) linter.BlockChecker { return &block{ctx: ctx} })
 	go linter.MemoryLimiterThread()
 }
 

--- a/example/custom/main.go
+++ b/example/custom/main.go
@@ -19,15 +19,16 @@ import (
 
 func main() {
 	log.SetFlags(log.Flags() | log.Lmicroseconds)
-	linter.RegisterBlockChecker(func(ctx linter.BlockContext) linter.BlockChecker { return &block{ctx: ctx} })
+	linter.RegisterBlockChecker(func(ctx *linter.BlockContext) linter.BlockChecker { return &block{ctx: ctx} })
 	cmd.Main()
 }
 
 type block struct {
-	ctx linter.BlockContext
+	linter.BlockCheckerDefaults
+	ctx *linter.BlockContext
 }
 
-func isString(ctx linter.BlockContext, n node.Node) bool {
+func isString(ctx *linter.BlockContext, n node.Node) bool {
 	_, ok := n.(*scalar.String)
 	if ok {
 		return true
@@ -79,7 +80,3 @@ func (b *block) handleInArrayCall(e *expr.FunctionCall) {
 
 	b.ctx.Report(e, linter.LevelWarning, "strictCmp", "3rd argument of in_array must be true when comparing strings")
 }
-
-func (b *block) AfterEnterNode(w walker.Walkable)  {}
-func (b *block) BeforeLeaveNode(w walker.Walkable) {}
-func (b *block) AfterLeaveNode(w walker.Walkable)  {}

--- a/src/langsrv/refsvisitors.go
+++ b/src/langsrv/refsvisitors.go
@@ -77,7 +77,7 @@ func findMethodReferences(className string, methodName string) []vscode.Location
 
 		rootWalker := linter.NewWalkerForReferencesSearcher(
 			filename,
-			func(ctx linter.BlockContext) linter.BlockChecker {
+			func(ctx *linter.BlockContext) linter.BlockChecker {
 				return &blockMethodCallVisitor{
 					ctx:        ctx,
 					className:  className,
@@ -104,7 +104,7 @@ func findPropertyReferences(className string, propName string) []vscode.Location
 
 		rootWalker := linter.NewWalkerForReferencesSearcher(
 			filename,
-			func(ctx linter.BlockContext) linter.BlockChecker {
+			func(ctx *linter.BlockContext) linter.BlockChecker {
 				return &blockPropertyVisitor{
 					ctx:       ctx,
 					className: className,
@@ -325,7 +325,7 @@ func (d *classConstVisitor) LeaveNode(w walker.Walkable) {
 }
 
 type blockMethodCallVisitor struct {
-	ctx linter.BlockContext
+	ctx *linter.BlockContext
 
 	className  string
 	methodName string
@@ -370,7 +370,7 @@ func (d *blockMethodCallVisitor) BeforeLeaveNode(w walker.Walkable) {}
 func (d *blockMethodCallVisitor) AfterLeaveNode(w walker.Walkable)  {}
 
 type blockPropertyVisitor struct {
-	ctx linter.BlockContext
+	ctx *linter.BlockContext
 
 	className string
 	propName  string

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -157,7 +157,7 @@ func (b *BlockWalker) copy() *BlockWalker {
 		ignoreFunctionBodies: b.ignoreFunctionBodies,
 	}
 	for _, createFn := range b.r.customBlock {
-		bCopy.custom = append(bCopy.custom, createFn(bCopy))
+		bCopy.custom = append(bCopy.custom, createFn(&BlockContext{w: bCopy}))
 	}
 
 	for _, c := range b.customTypes {

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -116,6 +116,9 @@ func analyzeFile(filename string, contents []byte, parser *php7.Parser, lineRang
 	if meta.IsIndexingComplete() {
 		AnalyzeFileRootLevel(rootNode, w)
 	}
+	for _, c := range w.custom {
+		c.AfterLeaveFile()
+	}
 
 	for _, e := range parser.GetErrors() {
 		w.Report(nil, LevelError, "syntax", "Syntax error: "+e.String())
@@ -140,7 +143,7 @@ func AnalyzeFileRootLevel(rootNode node.Node, d *RootWalker) {
 	}
 
 	for _, createFn := range d.customBlock {
-		b.custom = append(b.custom, createFn(b))
+		b.custom = append(b.custom, createFn(&BlockContext{w: b}))
 	}
 
 	rootNode.Walk(b)

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -177,7 +177,7 @@ func (d *RootWalker) InitFromParser(contents []byte, parser *php7.Parser) {
 func (d *RootWalker) InitCustom() {
 	d.custom = nil
 	for _, createFn := range customRootLinters {
-		d.custom = append(d.custom, createFn(d))
+		d.custom = append(d.custom, createFn(&RootContext{w: d}))
 	}
 
 	d.customBlock = customBlockLinters
@@ -421,7 +421,7 @@ func (d *RootWalker) handleComment(c comment.Comment) {
 func (d *RootWalker) handleFuncStmts(params []meta.FuncParam, uses, stmts []node.Node, sc *meta.Scope) (returnTypes *meta.TypesMap, prematureExitFlags int) {
 	b := &BlockWalker{sc: sc, r: d, unusedVars: make(map[string][]node.Node), nonLocalVars: make(map[string]struct{})}
 	for _, createFn := range d.customBlock {
-		b.custom = append(b.custom, createFn(b))
+		b.custom = append(b.custom, createFn(&BlockContext{w: b}))
 	}
 
 	for _, useExpr := range uses {


### PR DESCRIPTION
Turn root/block contexts into structs for now.
- Simpler to add more state to the public API bridge.
- Easier to find implementation (jump to relevant impl from the code)

Added XxxDefaults types for embedding to provide a simple
way to add stub interface implementations.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>