### PR TITLE
fix varToString panic on ${"x"} and ${"{$x}"}

### DIFF
--- a/src/linter/basic_test.go
+++ b/src/linter/basic_test.go
@@ -496,3 +496,13 @@ func TestMixedArrayKeys(t *testing.T) {
 		log.Printf("%s", r)
 	}
 }
+
+func TestStringGlobalVarName(t *testing.T) {
+	// Should not panic.
+
+	testParse(t, `first.php`, `<?php
+	function f() {
+		global ${"x"};
+		global ${"${x}_${x}"};
+	}`)
+}

--- a/src/linter/basic_test.go
+++ b/src/linter/basic_test.go
@@ -503,6 +503,6 @@ func TestStringGlobalVarName(t *testing.T) {
 	testParse(t, `first.php`, `<?php
 	function f() {
 		global ${"x"};
-		global ${"${x}_${x}"};
+		global ${"${x}_{$x}"};
 	}`)
 }


### PR DESCRIPTION
Found this case when tried to check phpmyadmin codebase.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>