### PR TITLE
linter,meta: fix panic during isset($$x)

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -377,7 +377,8 @@ func (d *RootWalker) Report(n node.Node, level int, checkName, msg string, args 
 func (d *RootWalker) reportUndefinedVariable(s *expr.Variable, maybeHave bool) {
 	name, ok := s.VarName.(*node.Identifier)
 	if !ok {
-		d.Report(s, LevelInformation, "undefined", "Unknown variable variable used")
+		d.Report(s, LevelInformation, "undefined", "Unknown variable variable %s used",
+			meta.NameNodeToString(s))
 		return
 	}
 

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -377,7 +377,7 @@ func (d *RootWalker) Report(n node.Node, level int, checkName, msg string, args 
 func (d *RootWalker) reportUndefinedVariable(s *expr.Variable, maybeHave bool) {
 	name, ok := s.VarName.(*node.Identifier)
 	if !ok {
-		d.Report(s, LevelInformation, "undefined", "Variable variable used")
+		d.Report(s, LevelInformation, "undefined", "Unknown variable variable used")
 		return
 	}
 

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/z7zmey/php-parser/node"
+	"github.com/z7zmey/php-parser/node/expr"
 	"github.com/z7zmey/php-parser/node/name"
 )
 
@@ -431,6 +432,8 @@ func NameNodeToString(n node.Node) string {
 		return FullyQualifiedToString(n)
 	case *node.Identifier:
 		return n.Value
+	case *expr.Variable:
+		return "$" + NameNodeToString(n.VarName)
 	default:
 		return "<expression>"
 	}


### PR DESCRIPTION
Add support for variable-variable tracking inside a scope
as well, so we don't mark usages of $$x inside if body
as undefined. isset($$x) defines $x along $$x, so usages
of $x are permitted inside that body as well.
Doesn't work for arbitrary indirection level,
isset($$$x) is not supported (but it won't panic, as it did before).

Updates #26

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>