### PR TITLE
linter: add caseBreak check support fallthrough comment

### DIFF
--- a/src/linter/basic_test.go
+++ b/src/linter/basic_test.go
@@ -409,7 +409,7 @@ func TestSwitchBreak(t *testing.T) {
 		t.Errorf("Unexpected number of reports: expected 1, got %d", len(reports))
 	}
 
-	if !hasReport(reports, "Case without break") {
+	if !hasReport(reports, "Add break or '// fallthrough' to the end of the case") {
 		t.Errorf("No error about case without break")
 	}
 

--- a/src/linter/basic_test.go
+++ b/src/linter/basic_test.go
@@ -349,23 +349,68 @@ func TestFunctionThrowsExceptionsAndReturns(t *testing.T) {
 	}
 }
 
+func TestSwitchFallthrough(t *testing.T) {
+	reports := getReportsSimple(t, `<?php
+	function withFallthrough($a) {
+		switch ($a) {
+		case 1:
+			echo "1\n";
+			// With prepended comment line.
+			// fallthrough
+		case 2:
+			echo "2\n";
+			// falls through and continue rolling
+		case 3:
+			echo "3\n";
+			/* fallthrough and blah-blah */
+		case 4:
+			echo "4\n";
+			/* falls through */
+		default:
+			echo "Other\n";
+		}
+	}
+	`)
+
+	if len(reports) != 0 {
+		t.Errorf("Unexpected number of reports: expected 0, got %d", len(reports))
+	}
+
+	for _, r := range reports {
+		log.Printf("%s", r)
+	}
+}
+
 func TestSwitchBreak(t *testing.T) {
 	reports := getReportsSimple(t, `<?php
-	function doSomething($a) {
+	function bad($a) {
+		switch ($a) {
+		case 1:
+			echo "One\n"; // Bad, no break.
+		default:
+			echo "Other\n";
+		}
+	}
+
+	function good($a) {
 		switch ($a) {
 		case 1:
 			echo "One\n";
 			break;
-		default:
+		case 2:
 			echo "Two";
-			break;
+			// No break, but still good, since it's the last case clause.
 		}
 
 		echo "Three";
 	}`)
 
-	if len(reports) != 0 {
-		t.Errorf("Unexpected number of reports: expected 0, got %d", len(reports))
+	if len(reports) != 1 {
+		t.Errorf("Unexpected number of reports: expected 1, got %d", len(reports))
+	}
+
+	if !hasReport(reports, "Case without break") {
+		t.Errorf("No error about case without break")
 	}
 
 	for _, r := range reports {

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -2,6 +2,7 @@ package linter
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/VKCOM/noverify/src/meta"
@@ -1450,7 +1451,11 @@ func (b *BlockWalker) handleSwitch(s *stmt.Switch) bool {
 
 		// allow to omit "break;" in the final statement
 		if idx != len(s.Cases)-1 && bCopy.exitFlags == 0 {
-			b.r.Report(c, LevelInformation, "caseBreak", "Case without break")
+			// allow the fallthrough if appropriate comment is present
+			nextCase := s.Cases[idx+1]
+			if !b.caseHasFallthroughComment(nextCase) {
+				b.r.Report(c, LevelInformation, "caseBreak", "Case without break")
+			}
 		}
 
 		if (bCopy.exitFlags & (^breakFlags)) == 0 {
@@ -1726,4 +1731,26 @@ func (b *BlockWalker) LeaveNode(w walker.Walkable) {
 	for _, c := range b.custom {
 		c.AfterLeaveNode(w)
 	}
+}
+
+var fallthroughMarkerRegex = func() *regexp.Regexp {
+	markers := []string{
+		"fallthrough",
+		"fall through",
+		"falls through",
+		"no break",
+	}
+
+	pattern := `(?:/\*|//)\s?(?:` + strings.Join(markers, `|`) + `)`
+	return regexp.MustCompile(pattern)
+}()
+
+func (b *BlockWalker) caseHasFallthroughComment(n node.Node) bool {
+	for _, comment := range b.r.comments[n] {
+		str := comment.String()
+		if fallthroughMarkerRegex.MatchString(str) {
+			return true
+		}
+	}
+	return false
 }

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1454,7 +1454,7 @@ func (b *BlockWalker) handleSwitch(s *stmt.Switch) bool {
 			// allow the fallthrough if appropriate comment is present
 			nextCase := s.Cases[idx+1]
 			if !b.caseHasFallthroughComment(nextCase) {
-				b.r.Report(c, LevelInformation, "caseBreak", "Case without break")
+				b.r.Report(c, LevelInformation, "caseBreak", "Add break or '// fallthrough' to the end of the case")
 			}
 		}
 


### PR DESCRIPTION
Supported markers:
	"fallthrough",
	"fall through",
	"falls through",
	"no break",

Marker is expected to be a first comment line substring.
Both // and /* comment styles are handled.

Fixes #24

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>