### PR TITLE
linter: better warning for undefined null/false/true

### DIFF
--- a/src/linter/basic_test.go
+++ b/src/linter/basic_test.go
@@ -18,6 +18,33 @@ func hasReport(reports []*Report, substr string) bool {
 	return false
 }
 
+func TestBuiltinConstant(t *testing.T) {
+	reports := getReportsSimple(t, `<?php
+	function f() {
+		$_ = NULL;
+		$_ = True;
+		$_ = FaLsE;
+	}`)
+
+	if len(reports) != 3 {
+		t.Errorf("Unexpected number of reports: expected 3, got %d", len(reports))
+	}
+
+	if !hasReport(reports, "Use null instead of NULL") {
+		t.Errorf("No error about null")
+	}
+	if !hasReport(reports, "Use true instead of True") {
+		t.Errorf("No error about true")
+	}
+	if !hasReport(reports, "Use false instead of FaLsE") {
+		t.Errorf("No error about false")
+	}
+
+	for _, r := range reports {
+		log.Printf("%s", r)
+	}
+}
+
 func TestArrayLiteral(t *testing.T) {
 	reports := getReportsSimple(t, `<?php
 	function traditional_array_literal() {

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1047,7 +1047,7 @@ func (b *BlockWalker) handleConstFetch(e *expr.ConstFetch) bool {
 			// TODO(quasilyte): should probably issue not "undefined" warning
 			// here, but something else, like "constCase" or something.
 			// Since it *was* "undefined" before, leave it as is for now,
-			// only make error message user-friendly helpful.
+			// only make error message more user-friendly.
 			lcName := strings.ToLower(name)
 			b.r.Report(e.Constant, LevelError, "undefined", "Use %s instead of %s", lcName, name)
 		default:

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1041,7 +1041,18 @@ func (b *BlockWalker) handleConstFetch(e *expr.ConstFetch) bool {
 	_, _, defined := solver.GetConstant(b.r.st, e.Constant)
 
 	if !defined {
-		b.r.Report(e.Constant, LevelError, "undefined", "Undefined constant %s", meta.NameNodeToString(e.Constant))
+		// If it's builtin constant, give a more precise report message.
+		switch name := meta.NameNodeToString(e.Constant); strings.ToLower(name) {
+		case "null", "true", "false":
+			// TODO(quasilyte): should probably issue not "undefined" warning
+			// here, but something else, like "constCase" or something.
+			// Since it *was* "undefined" before, leave it as is for now,
+			// only make error message user-friendly helpful.
+			lcName := strings.ToLower(name)
+			b.r.Report(e.Constant, LevelError, "undefined", "Use %s instead of %s", lcName, name)
+		default:
+			b.r.Report(e.Constant, LevelError, "undefined", "Undefined constant %s", name)
+		}
 	}
 
 	return true


### PR DESCRIPTION
If we are about to emit undefined const warning,
check if that const is actually one of [null,false,true].
In that case, report invalid const name case instead
of saying that referenced constant is undefined.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>