### PR TITLE
cmd: add -allow-checks argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,22 @@ $ noverify -exclude-checks arraySyntax,undefined -stubs-dir /path/to/stubs hello
 # No warnings
 ```
 
+### Using in CI / using explicit checks enable list
+
+For CI purposes it's usually more reliable to use an explicit list of checks to be executed,
+so updating a linter doesn't break your build only because new checks were added.
+
+The `-allow-checks` argument by default includes all stable checks, but you can override
+it by passing your own comma-separated list of check names instead:
+
+```sh
+# Run only 2 checks, undefined and deadCode.
+$ noverify -allow-checks undefined,deadCode -stubs-dir /path/to/stubs hello.php
+```
+
+You can use it in combination with `-exclude-checks`.
+Exclusion rules are applied after inclusion rules are applied.
+
 ### Language server mode (experimental)
 
 If you want to launch noverify in language server mode, launch it in your IDE/editor extension like the following:

--- a/example/custom/main.go
+++ b/example/custom/main.go
@@ -17,8 +17,7 @@ import (
 	"github.com/z7zmey/php-parser/walker"
 )
 
-func main() {
-	log.SetFlags(log.Flags() | log.Lmicroseconds)
+func init() {
 	linter.RegisterBlockChecker(func(ctx *linter.BlockContext) linter.BlockChecker { return &block{ctx: ctx} })
 
 	linter.DeclareCheck(linter.CheckInfo{
@@ -26,6 +25,10 @@ func main() {
 		Default: true,
 		Comment: "Report not-strict-enough comparisons.",
 	})
+}
+
+func main() {
+	log.SetFlags(log.Flags() | log.Lmicroseconds)
 
 	cmd.Main()
 }

--- a/example/custom/main.go
+++ b/example/custom/main.go
@@ -20,6 +20,13 @@ import (
 func main() {
 	log.SetFlags(log.Flags() | log.Lmicroseconds)
 	linter.RegisterBlockChecker(func(ctx *linter.BlockContext) linter.BlockChecker { return &block{ctx: ctx} })
+
+	linter.DeclareCheck(linter.CheckInfo{
+		Name:    "strictCmp",
+		Default: true,
+		Comment: "Report not-strict-enough comparisons.",
+	})
+
 	cmd.Main()
 }
 

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -63,7 +63,7 @@ var (
 	version bool
 )
 
-func init() {
+func parseFlags() {
 	var enabledByDefault []string
 	for _, info := range linter.GetDeclaredChecks() {
 		if info.Default {
@@ -105,6 +105,8 @@ func init() {
 	flag.StringVar(&linter.CacheDir, "cache-dir", "", "Directory for linter cache (greatly improves indexing speed)")
 
 	flag.BoolVar(&version, "version", false, "Show version info and exit")
+
+	flag.Parse()
 }
 
 func isEnabled(r *linter.Report) bool {
@@ -136,7 +138,7 @@ func canBeDisabled(filename string) bool {
 // Main is the actual main function to be run. It is separate from linter so that you can insert your own hooks
 // before running main().
 func Main() {
-	flag.Parse()
+	parseFlags()
 
 	if version {
 		fmt.Printf("PHP Linter\nBuilt on %s\nOS %s\nCommit %s\n", BuildTime, BuildOSUname, BuildCommit)

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -48,19 +48,6 @@ func FlagsToString(f int) string {
 }
 
 // BlockWalker is used to process function/method contents.
-//
-// Current list of annotated checks:
-//	- accessLevel
-//	- argCount
-//	- arrayAccess
-//	- arrayKeys
-//	- arraySyntax
-//	- bareTry
-//	- caseBreak
-//	- deadCode
-//	- phpdoc
-//	- undefined
-//	- unused
 type BlockWalker struct {
 	sc *meta.Scope
 	r  *RootWalker

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -13,6 +13,104 @@ const (
 	IgnoreLinterMessage = "@linter disable"
 )
 
+func init() {
+	rootChecks := []CheckInfo{
+		{
+			Name:    "accessLevel",
+			Default: true,
+			Comment: `Report erroneous member access.`,
+		},
+
+		{
+			Name:    "argCount",
+			Default: true,
+			Comment: `Report mismatching args count inside call expressions.`,
+		},
+
+		{
+			Name:    "arrayAccess",
+			Default: true,
+			Comment: `Report array access to non-array objects.`,
+		},
+
+		{
+			Name:    "arrayKeys",
+			Default: true,
+			Comment: `Report array keys related problems.`,
+		},
+
+		{
+			Name:    "arraySyntax",
+			Default: true,
+			Comment: `Report usages of old array() syntax.`,
+		},
+
+		{
+			Name:    "bareTry",
+			Default: true,
+			Comment: `Report try blocks without catch/finally.`,
+		},
+
+		{
+			Name:    "caseBreak",
+			Default: true,
+			Comment: `Report switch cases without break.`,
+		},
+
+		{
+			Name:    "complexity",
+			Default: true,
+			Comment: `Report funcs/methods that are too complex.`,
+		},
+
+		{
+			Name:    "deadCode",
+			Default: true,
+			Comment: `Report potentially unreachable code.`,
+		},
+
+		{
+			Name:    "modifiers",
+			Default: true,
+			Comment: `Report misused modifiers like 'abstract' and 'static'.`,
+		},
+
+		{
+			Name:    "phpdoc",
+			Default: true,
+			Comment: `Report malformed phpdoc comments.`,
+		},
+
+		{
+			Name:    "stdInterface",
+			Default: true,
+			Comment: `Report issues related to std PHP interfaces.`,
+		},
+
+		{
+			Name:    "syntax",
+			Default: true,
+			Comment: `Report syntax errors.`,
+		},
+
+		{
+			Name:    "undefined",
+			Default: true,
+			Comment: `Report usages of potentially undefined symbols.`,
+		},
+
+		{
+			Name:    "unused",
+			Default: true,
+			Comment: `Report potentially unused variabled.`,
+		},
+	}
+
+	for _, info := range rootChecks {
+		DeclareCheck(info)
+	}
+}
+
 // DiffReports returns only reports that are new.
 // Pass diffArgs=nil if we are called from diff in working copy.
 func DiffReports(gitRepo string, diffArgs []string, changesList []git.Change, changeLog []git.Commit, oldList, newList []*Report, maxConcurrency int) (res []*Report, err error) {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -31,14 +31,6 @@ const (
 )
 
 // RootWalker is used to analyze root scope. Mostly defines, function and class definitions are analyzed.
-//
-// Current list of annotated checks:
-//	- complexity
-//	- modifiers
-//	- phpdoc
-//	- stdInterface
-//	- syntax
-//	- unused
 type RootWalker struct {
 	filename string
 	comments comment.Comments


### PR DESCRIPTION
Makes possible to run some checks in a separation,
which is useful in CI and while testing a new check.

Also makes it possible to have "disabled by default" checks
that are useful, but not for every linter user. It's also
easier to leave some checks disabled by default if they have
some correctness issues that can't be solved in a short period of time.

To figure out what checks are enabled by default we introduce
structured diagnostics info, linter.CheckInfo.
It's not mandatory to register a check with linter.DeclareCheck,
but it's the only way to associate metadata with diagnostics
implemented by any checker.

Non-declared checks can't be enabled by default, so
explicit -allow-checks entry should be specified for them.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>