### PR TITLE
linter: add redundantCast check

### DIFF
--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -14,7 +14,7 @@ const (
 )
 
 func init() {
-	rootChecks := []CheckInfo{
+	allChecks := []CheckInfo{
 		{
 			Name:    "accessLevel",
 			Default: true,
@@ -104,9 +104,15 @@ func init() {
 			Default: true,
 			Comment: `Report potentially unused variabled.`,
 		},
+
+		{
+			Name:    "redundantCast",
+			Default: false,
+			Comment: `Report redundant type casts`,
+		},
 	}
 
-	for _, info := range rootChecks {
+	for _, info := range allChecks {
 		DeclareCheck(info)
 	}
 }

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -417,6 +417,46 @@ func TestFunctionThrowsExceptionsAndReturns(t *testing.T) {
 	}
 }
 
+func TestRedundantCast(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	function bad($a) {
+		$int = 1;
+		$double = 1.0;
+		$string = '1';
+		$bool = ($a == 0);
+		$array = [1, 'a', 3.0]; // Mixed elems on purpose
+		$a = (int)$int;
+		$a = (double)$double;
+		$a = (string)$string;
+		$a = (bool)$bool;
+		$a = (array)$array;
+		$_ = $a;
+	}
+
+	function good($a) {
+		$int = 1;
+		$double = 1.0;
+		$string = '1';
+		$bool = ($a == 0);
+		$array = [1, 'a', 3.0];
+		$a = (int)$double;
+		$a = (double)$array;
+		$a = (string)$bool;
+		$a = (bool)$string;
+		$a = (array)$int;
+		$_ = $a;
+	}`)
+	test.Expect = []string{
+		`expression already has array type`,
+		`expression already has double type`,
+		`expression already has int type`,
+		`expression already has string type`,
+		`expression already has bool type`,
+	}
+	test.RunAndMatch()
+}
+
 func TestSwitchBreak(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
Finds expressions of form `(T)v` where `v` already
known to have a type of `T`. In those cases, type cast
can be removed.

Severity is minimal.
Not enabled by default.
Use -allow-checks redundantCast to run it.

Feature-request by @atercattus

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>