### PR TITLE
meta: optimize typesmap Iterate for common cases

### DIFF
--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -442,8 +442,17 @@ func (m *TypesMap) GobDecode(buf []byte) error {
 
 // Iterate applies cb to all contained types
 func (m *TypesMap) Iterate(cb func(typ string)) {
-	if m == nil {
+	if m == nil || len(m.m) == 0 {
 		return
+	}
+
+	// Fast path for maps of 1 element.
+	// No sorting is needed, no allocations are required.
+	if len(m.m) == 1 {
+		for k := range m.m {
+			cb(k)
+			return
+		}
 	}
 
 	// We need to sort types so that we always iterate classes using the same order.

--- a/src/meta/typesmap_test.go
+++ b/src/meta/typesmap_test.go
@@ -1,0 +1,24 @@
+package meta
+
+import "testing"
+
+func BenchmarkTypesMapIterate(b *testing.B) {
+	tests := []struct {
+		name       string
+		typeString string
+	}{
+		{"0", ""},
+		{"1", "int"},
+		{"2", "int|string"},
+		{"3", "int|string|double"},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			m := NewTypesMap(test.typeString)
+			for i := 0; i < b.N; i++ {
+				m.Iterate(func(typ string) {})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Here are top-10 stats for Iterate method usages on a big PHP project:

```
   len(m.m)  usages
1  len=1  => 2760628
2  len=0  => 1168563
3  len=2  => 733538
4  len=3  => 319204
5  len=4  => 244474
6  len=5  => 169740
7  len=7  => 129250
8  len=6  => 36225
9  len=8  => 31894
10 len=9  => 15453
```

0 and 1 are the most frequent lengths, so it makes sense
to optimize for them.

This change removes allocations from len=0 and len=1 paths completely
and makes them up to 2-3 times faster without causing similar slowdown
for other cases.

```
name                 old time/op    new time/op    delta
TypesMapIterate/0-8     225ns ± 1%      62ns ± 0%   -72.24%  (p=0.000 n=9+10)
TypesMapIterate/1-8     224ns ± 0%      63ns ± 3%   -71.66%  (p=0.000 n=8+10)
TypesMapIterate/2-8     335ns ± 0%     340ns ± 0%    +1.36%  (p=0.000 n=9+9)
TypesMapIterate/3-8     449ns ± 0%     452ns ± 0%    +0.65%  (p=0.000 n=10+9)
[Geo mean]              295ns          157ns        -46.77%

name                 old alloc/op   new alloc/op   delta
TypesMapIterate/0-8     48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
TypesMapIterate/1-8     48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
TypesMapIterate/2-8     64.0B ± 0%     64.0B ± 0%      ~     (all equal)
TypesMapIterate/3-8     80.0B ± 0%     80.0B ± 0%      ~     (all equal)

name                 old allocs/op  new allocs/op  delta
TypesMapIterate/0-8      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
TypesMapIterate/1-8      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
TypesMapIterate/2-8      2.00 ± 0%      2.00 ± 0%      ~     (all equal)
TypesMapIterate/3-8      2.00 ± 0%      2.00 ± 0%      ~     (all equal)
```

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>