### PR TITLE
linter: add callStatic check

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -16,7 +16,11 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
-const cacheVersion = 24
+// cacheVersions is a magic number that helps to distinguish incompatible caches.
+//
+// Version log:
+//     25 - added Static field to meta.FuncInfo
+const cacheVersion = 25
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")
@@ -127,13 +131,12 @@ func createMetaCacheFile(filename, cacheFile string, m *fileMeta) error {
 	if err := wr.Flush(); err != nil {
 		return err
 	}
-	
+
 	// Windows clearly does not want to allow to rename unclosed files
 	if runtime.GOOS == "windows" {
 		fp.Close()
 		os.Remove(cacheFile)
 	}
-
 
 	if err := os.Rename(tmpPath, cacheFile); err != nil {
 		return err

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -110,6 +110,12 @@ func init() {
 			Default: false,
 			Comment: `Report redundant type casts.`,
 		},
+
+		{
+			Name:    "callStatic",
+			Default: true,
+			Comment: `Report static calls of instance methods and vice versa.`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -668,6 +668,7 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 		Typ:          typ,
 		MinParamsCnt: minParamsCnt,
 		AccessLevel:  modif.accessLevel,
+		Static:       modif.static,
 		ExitFlags:    exitFlags,
 	}
 

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestCallStatic(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	class T {
+		public static function sf($_) {}
+		public function f($_) {}
+	}
+	$v = new T();
+	$v->sf(1);
+	T::f(1);
+	`)
+	test.Expect = []string{
+		`Calling static method as instance method`,
+		`Calling instance method as static method`,
+	}
+	test.RunAndMatch()
+}
+
 func TestBuiltinConstant(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -269,6 +269,7 @@ type FuncInfo struct {
 	MinParamsCnt int
 	Typ          *TypesMap
 	AccessLevel  AccessLevel
+	Static       bool
 	ExitFlags    int // if function has exit/die/throw, then ExitFlags will be <> 0
 }
 


### PR DESCRIPTION
Detect when static methods are called using "->" syntax
and instance methods that are called using "::" syntax.

It's not always a mistake, but could be a sign of a code smell.
Also, it makes code harder to read, since it's not apparent
what happens before called method signature is reviewed.

Added "Static" field to meta.FuncInfo to make this check possible.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>