### PR TITLE
git: fix EOF handling in git.Diff

### DIFF
--- a/src/git/diff.go
+++ b/src/git/diff.go
@@ -203,11 +203,12 @@ func parseDiff(rd *bufio.Reader) ([]Change, error) {
 
 	cur.Valid = true
 
+ParsingLoop:
 	for {
 		ln, skip, err := readShortLine(rd)
 		switch {
 		case err == io.EOF:
-			break
+			break ParsingLoop
 		case err != nil:
 			return nil, err
 		case skip:


### PR DESCRIPTION
Previously, break on EOF was associated to the
enclosing switch, so it resulted to the infinite loop.

Make loop labeled and break using that label to avoid that.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>