### PR TITLE
linter: use append with ... instead of loop+append

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -149,9 +149,7 @@ func (b *BlockWalker) copy() *BlockWalker {
 		bCopy.custom = append(bCopy.custom, createFn(&BlockContext{w: bCopy}))
 	}
 
-	for _, c := range b.customTypes {
-		bCopy.customTypes = append(bCopy.customTypes, c)
-	}
+	bCopy.customTypes = append(bCopy.customTypes, b.customTypes...)
 
 	return bCopy
 }


### PR DESCRIPTION
This fixes a warning from statitccheck (S1011).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>