### PR TITLE
linter: don't register \- as a param type

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1164,8 +1164,8 @@ func (b *BlockWalker) enterClosure(fun *expr.Closure, haveThis bool, thisType *m
 
 	_, phpDocParamTypes, phpDocError := b.r.parsePHPDoc(fun.PhpDocComment, fun.Params)
 
-	if phpDocError != "" {
-		b.r.Report(fun, LevelInformation, "phpdoc", "PHPDoc is incorrect: %s", phpDocError)
+	for _, err := range phpDocError {
+		b.r.Report(fun, LevelInformation, "phpdoc", "PHPDoc is incorrect: %s", err)
 	}
 
 	for _, useExpr := range fun.Uses {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -839,11 +839,17 @@ func (d *RootWalker) parsePHPDoc(doc string, actualParams []node.Node) (returnTy
 
 		curParam++
 
-		variable = strings.TrimPrefix(variable, "$")
-		types[variable] = phpDocParamEl{
-			optional: optional,
-			typ:      meta.NewTypesMap(d.maybeAddNamespace(typ)),
+		// People sometimes use "-" inside @param lines when there is no
+		// type, it looks like `@param $var - description`.
+		// Use empty type map for them instead of registering `\-` as a type.
+		var param phpDocParamEl
+		if typ != "-" {
+			param.typ = meta.NewTypesMap(d.maybeAddNamespace(typ))
 		}
+		param.optional = optional
+
+		variable = strings.TrimPrefix(variable, "$")
+		types[variable] = param
 	}
 
 	return returnType.Immutable(), types, phpDocError

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -647,6 +647,9 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 		specifiedReturnType = typ
 	}
 
+	if meth.PhpDocComment == "" && modif.accessLevel == meta.Public {
+		d.Report(meth.MethodName, LevelDoNotReject, "phpdoc", "Missing PHPDoc for %q public method", nm)
+	}
 	phpdocReturnType, phpDocParamTypes, phpDocError := d.parsePHPDoc(meth.PhpDocComment, meth.Params)
 
 	for _, err := range phpDocError {

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -1,0 +1,52 @@
+package linttest
+
+import (
+	"testing"
+)
+
+func TestPHPDocSyntax(t *testing.T) {
+	test := NewSuite(t)
+	test.AddFile(`<?php
+	/**
+	 * @param $x int the x param
+	 * @param - $y the y param
+	 * @param $z - the z param
+	 * @param $a
+	 * @param int
+	 */
+	function f($x, $y, $z, $a, $_) {
+		$_ = $x;
+		$_ = $y;
+		$_ = $z;
+	}`)
+	test.Expect = []string{
+		`non-canonical order of variable and type on line 2`,
+		`expected a type, found '-'; if you want to express 'any' type, use 'mixed' on line 3`,
+		`non-canonical order of variable and type on line 4`,
+		`expected a type, found '-'; if you want to express 'any' type, use 'mixed' on line 4`,
+		`malformed @param tag (maybe type is missing?) on line 5`,
+		`malformed @param tag (maybe var is missing?) on line 6`,
+	}
+	test.RunAndMatch()
+}
+
+func TestPHPDocType(t *testing.T) {
+	test := NewSuite(t)
+	test.AddFile(`<?php
+	/**
+	 * @param [][]string $x
+	 * @param double $y
+	 * @return []int
+	 */
+	function f($x, $y) {
+		$_ = $x;
+		$_ = $y;
+		return [1];
+	}`)
+	test.Expect = []string{
+		`[]int type syntax: use [] after the type, e.g. T[]`,
+		`[][]string type syntax: use [] after the type, e.g. T[]`,
+		`use float type instead of double`,
+	}
+	test.RunAndMatch()
+}

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -4,6 +4,35 @@ import (
 	"testing"
 )
 
+func TestPHPDocPresence(t *testing.T) {
+	test := NewSuite(t)
+	test.AddFile(`<?php
+	trait TheTrait {
+		public function traitPub() {}
+	}
+	class TheClass {
+		/**
+		 * This function is a good example.
+		 * It's public and has a phpdoc comment.
+		 */
+		public function documentedPub() {}
+
+		// Not OK.
+		public function pub() {}
+
+		// OK.
+		private function priv() {}
+
+		// OK.
+		protected function prot() {}
+	}`)
+	test.Expect = []string{
+		`Missing PHPDoc for "pub" public method`,
+		`Missing PHPDoc for "traitPub" public method`,
+	}
+	test.RunAndMatch()
+}
+
 func TestPHPDocSyntax(t *testing.T) {
 	test := NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
For functions with `@param` comment line like:

	@param $foo - best foo ever

We would register "-" as a type of $foo,
which breaks other diagnostics that rely on the type inference.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>