### PR TITLE
linttest: use filters when testing specific check

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -648,7 +648,11 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 	}
 
 	if meth.PhpDocComment == "" && modif.accessLevel == meta.Public {
-		d.Report(meth.MethodName, LevelDoNotReject, "phpdoc", "Missing PHPDoc for %q public method", nm)
+		_, insideInterface := d.currentClassNode.(*stmt.Interface)
+		// Permit having "__call" and other magic method without comments.
+		if !insideInterface && !strings.HasPrefix(nm, "_") {
+			d.Report(meth.MethodName, LevelDoNotReject, "phpdoc", "Missing PHPDoc for %q public method", nm)
+		}
 	}
 	phpdocReturnType, phpDocParamTypes, phpDocError := d.parsePHPDoc(meth.PhpDocComment, meth.Params)
 

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -34,6 +34,7 @@ func TestFunctionNotOnlyExits2(t *testing.T) {
 	class RuntimeException {}
 
 	class Something {
+		/** may throw */
 		public static function doExit() {
 			if (rand()) {
 				throw new \RuntimeException("OMG");
@@ -508,4 +509,18 @@ func TestCorrectArrayTypes(t *testing.T) {
 	if !fn.Typ.IsInt() {
 		t.Errorf("Wrong type: %s, excepted int", fn.Typ)
 	}
+}
+
+func runFilterMatch(test *linttest.Suite, name string) {
+	test.Match(filterReports(name, test.RunLinter()))
+}
+
+func filterReports(name string, reports []*linter.Report) []*linter.Report {
+	var out []*linter.Report
+	for _, r := range reports {
+		if r.CheckName() == name {
+			out = append(out, r)
+		}
+	}
+	return out
 }

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -15,6 +15,7 @@ func TestInterfaceConstants(t *testing.T) {
 
 	class TestClass implements TestInterface
 	{
+		/** get returns interface constant */
 		public function get()
 		{
 			return self::TEST;
@@ -66,6 +67,7 @@ func TestVariadic(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 	class TestClass
 	{
+		/** get always returns "." */
 		public function get(): string
 		{
 			return '.';
@@ -126,6 +128,7 @@ func TestMagicMethods(t *testing.T) {
 func TestGenerator(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 	class Generator {
+		/** send sends a message */
 		public function send();
 	}
 
@@ -162,7 +165,7 @@ func TestClosureLateBinding(t *testing.T) {
 		"Undefined variable: a",
 		"Call to undefined method {}->method()",
 	}
-	test.RunAndMatch()
+	runFilterMatch(test, "undefined")
 }
 
 func TestInterfaceInheritance(t *testing.T) {
@@ -202,7 +205,7 @@ func TestInterfaceInheritance(t *testing.T) {
 		"Call to undefined method {}->format()",
 		"Class constant \\TestExInterface::TEST2 does not exist",
 	}
-	test.RunAndMatch()
+	runFilterMatch(test, "undefined")
 }
 
 func TestProtected(t *testing.T) {
@@ -267,7 +270,7 @@ func TestProtected(t *testing.T) {
 		`Cannot access protected method \A->methodFromClosure2()`,
 		`Cannot access protected method \A::staticMethod2()`,
 	}
-	test.RunAndMatch()
+	runFilterMatch(test, "accessLevel")
 }
 
 func TestInvoke(t *testing.T) {
@@ -284,7 +287,7 @@ func TestInvoke(t *testing.T) {
 	(new Example())();
 	`)
 	test.Expect = []string{"Too few arguments"}
-	test.RunAndMatch()
+	runFilterMatch(test, "argCount")
 }
 
 func TestTraversable(t *testing.T) {
@@ -327,7 +330,7 @@ func TestTraversable(t *testing.T) {
 	test.Expect = []string{
 		`Objects returned by \Example::getIterator() must be traversable or implement interface \Iterator`,
 	}
-	test.RunAndMatch()
+	runFilterMatch(test, "stdInterface")
 }
 
 func TestInstanceOf(t *testing.T) {
@@ -382,5 +385,5 @@ func TestInstanceOf(t *testing.T) {
 		`Call to undefined method {}->get2()`,
 		`Call to undefined method {\Element}->callUndefinedMethod()`,
 	}
-	test.RunAndMatch()
+	runFilterMatch(test, "undefined")
 }


### PR DESCRIPTION
Also some minor fixes to public class phpdoc checker:
- Don't require comment for interface methods
- Permit methods with leading "_" to lack phpdoc comment (e.g. __call)

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>