### PR TITLE
linter: add caseContinue check

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -20,6 +20,21 @@ import (
 	"github.com/z7zmey/php-parser/walker"
 )
 
+// loopKind describes current looping statement context.
+type loopKind int
+
+const (
+	// loopNone is "there is no enclosing loop" context.
+	loopNone loopKind = iota
+
+	// loopFor is for all usual loops in PHP, like for/foreach loops.
+	loopFor
+
+	// loopSwitch is for switch statement, that is considered to
+	// be a looping construction in PHP.
+	loopSwitch
+)
+
 const (
 	// FlagReturn shows whether or not block has "return"
 	FlagReturn = 1 << iota
@@ -69,7 +84,7 @@ type BlockWalker struct {
 	// inferred return types if any
 	returnTypes *meta.TypesMap
 
-	isLoopBody bool
+	innermostLoop loopKind
 
 	// block flags
 	exitFlags         int // if block always breaks code flow then there will be exitFlags
@@ -140,7 +155,7 @@ func (b *BlockWalker) copy() *BlockWalker {
 	bCopy := &BlockWalker{
 		sc:                   b.sc.Clone(),
 		r:                    b.r,
-		isLoopBody:           b.isLoopBody,
+		innermostLoop:        b.innermostLoop,
 		unusedVars:           b.unusedVars,
 		nonLocalVars:         b.nonLocalVars,
 		ignoreFunctionBodies: b.ignoreFunctionBodies,
@@ -357,6 +372,8 @@ func (b *BlockWalker) EnterNode(w walker.Walkable) (res bool) {
 		solver.ExprTypeLocalCustom(b.sc, b.r.st, s.Expr, b.customTypes).Iterate(func(t string) {
 			b.returnTypes = b.returnTypes.AppendString(t)
 		})
+	case *stmt.Continue:
+		b.handleContinue(s)
 	default:
 		// b.d.debug(`  Statement: %T`, s)
 	}
@@ -368,6 +385,12 @@ func (b *BlockWalker) EnterNode(w walker.Walkable) (res bool) {
 	}
 
 	return res
+}
+
+func (b *BlockWalker) handleContinue(s *stmt.Continue) {
+	if s.Expr == nil && b.innermostLoop == loopSwitch {
+		b.r.Report(s, LevelError, "caseContinue", "'continue' inside switch is 'break'")
+	}
 }
 
 func (b *BlockWalker) addNonLocalVar(v *expr.Variable) {
@@ -395,7 +418,7 @@ func (b *BlockWalker) replaceVar(v *expr.Variable, typ *meta.TypesMap, reason st
 
 	// Writes to variables that are done in a loop should not count as unused variables
 	// because they can be read on the next iteration (ideally we should check for that too :))
-	if !b.isLoopBody {
+	if b.innermostLoop == loopNone {
 		b.unusedVars[name.Value] = append(b.unusedVars[name.Value], v)
 	}
 }
@@ -416,7 +439,7 @@ func (b *BlockWalker) addVar(v *expr.Variable, typ *meta.TypesMap, reason string
 
 	// Writes to variables that are done in a loop should not count as unused variables
 	// because they can be read on the next iteration (ideally we should check for that too :))
-	if !b.isLoopBody {
+	if b.innermostLoop == loopNone {
 		b.unusedVars[name.Value] = append(b.unusedVars[name.Value], v)
 	}
 }
@@ -1107,7 +1130,7 @@ func (b *BlockWalker) handleForeach(s *stmt.Foreach) bool {
 	// foreach body can do 0 cycles so we need a separate context for that
 	if s.Stmt != nil {
 		bCopy := b.copy()
-		bCopy.isLoopBody = true
+		bCopy.innermostLoop = loopFor
 
 		if _, ok := s.Stmt.(*stmt.StmtList); !ok {
 			bCopy.addStatement(s.Stmt)
@@ -1141,7 +1164,7 @@ func (b *BlockWalker) handleFor(s *stmt.For) bool {
 	// for body can do 0 cycles so we need a separate context for that
 	if s.Stmt != nil {
 		bCopy := b.copy()
-		bCopy.isLoopBody = true
+		bCopy.innermostLoop = loopFor
 		s.Stmt.Walk(bCopy)
 		b.maybeAddAllVars(bCopy.sc, "while body")
 		if !bCopy.returnTypes.IsEmpty() {
@@ -1207,7 +1230,7 @@ func (b *BlockWalker) handleWhile(s *stmt.While) bool {
 	// while body can do 0 cycles so we need a separate context for that
 	if s.Stmt != nil {
 		bCopy := b.copy()
-		bCopy.isLoopBody = true
+		bCopy.innermostLoop = loopFor
 		s.Stmt.Walk(bCopy)
 		b.maybeAddAllVars(bCopy.sc, "while body")
 		if !bCopy.returnTypes.IsEmpty() {
@@ -1220,10 +1243,10 @@ func (b *BlockWalker) handleWhile(s *stmt.While) bool {
 
 func (b *BlockWalker) handleDo(s *stmt.Do) bool {
 	if s.Stmt != nil {
-		oldIsLoopBody := b.isLoopBody
-		b.isLoopBody = true
+		oldInnermostLoop := b.innermostLoop
+		b.innermostLoop = loopFor
 		s.Stmt.Walk(b)
-		b.isLoopBody = oldIsLoopBody
+		b.innermostLoop = oldInnermostLoop
 	}
 
 	if s.Cond != nil {
@@ -1465,16 +1488,13 @@ func (b *BlockWalker) handleSwitch(s *stmt.Switch) bool {
 		}
 
 		bCopy := b.copy()
+		bCopy.innermostLoop = loopSwitch
 		contexts = append(contexts, bCopy)
 
 		for _, s := range list {
 			if s != nil {
 				bCopy.addStatement(s)
 				s.Walk(bCopy)
-				s, ok := s.(*stmt.Continue)
-				if ok && s.Expr == nil {
-					b.r.Report(s, LevelError, "caseContinue", "'continue' inside switch is 'break'")
-				}
 			}
 		}
 

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1467,10 +1467,14 @@ func (b *BlockWalker) handleSwitch(s *stmt.Switch) bool {
 		bCopy := b.copy()
 		contexts = append(contexts, bCopy)
 
-		for _, stmt := range list {
-			if stmt != nil {
-				bCopy.addStatement(stmt)
-				stmt.Walk(bCopy)
+		for _, s := range list {
+			if s != nil {
+				bCopy.addStatement(s)
+				s.Walk(bCopy)
+				s, ok := s.(*stmt.Continue)
+				if ok && s.Expr == nil {
+					b.r.Report(s, LevelError, "caseContinue", "'continue' inside switch is 'break'")
+				}
 			}
 		}
 

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -110,6 +110,12 @@ func init() {
 			Default: false,
 			Comment: `Report redundant type casts.`,
 		},
+
+		{
+			Name:    "caseContinue",
+			Default: true,
+			Comment: `Report suspicious 'continue' usages inside switch cases.`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestSwitchContinue(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	global $x;
+	switch ($x) {
+	case 10:
+		continue;
+	}
+
+	// OK, "continue 2" does the right thing.
+	// Phpstorm finds incorrect label "level" values,
+	// but it doesn't report 'continue' (without level) as being bad.
+	for ($i = 0; $i < 3; $i++) {
+		switch ($x) {
+		case 10:
+			continue 2;
+		}
+	}`)
+	test.Expect = []string{`'continue' inside switch is 'break'`}
+	test.RunAndMatch()
+}
+
 func TestBuiltinConstant(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -9,13 +9,49 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
-func TestSwitchContinue(t *testing.T) {
+func TestSwitchContinue1(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	global $x;
+	global $y;
+
+	switch ($x) {
+	case 10:
+		continue;
+	}
+
+	switch ($x) {
+	case 10:
+		if ($x == $y) {
+			continue;
+		}
+	}
+
+	for ($i = 0; $i < 10; $i++) {
+		switch ($i) {
+		case 5:
+			continue;
+		}
+	}`)
+	test.Expect = []string{
+		`'continue' inside switch is 'break'`,
+		`'continue' inside switch is 'break'`,
+		`'continue' inside switch is 'break'`,
+	}
+	test.RunAndMatch()
+}
+
+func TestSwitchContinue2(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 	global $x;
 	switch ($x) {
 	case 10:
-		continue;
+		for ($i = 0; $i < 10; $i++) {
+			if ($i == $x) {
+				continue; // OK, bound to 'for'
+			}
+		}
 	}
 
 	// OK, "continue 2" does the right thing.
@@ -27,7 +63,6 @@ func TestSwitchContinue(t *testing.T) {
 			continue 2;
 		}
 	}`)
-	test.Expect = []string{`'continue' inside switch is 'break'`}
 	test.RunAndMatch()
 }
 


### PR DESCRIPTION
Detects "continue" (without level) usage inside switch
that behaves identically to "break".

As a consequence, it's either a bad style (if it's used
instead of break on purpose) or a bug (if "continue"
was intended, if there is a "for" loop outside).
Since both cases are bad, we report any continue (w/o level)
usage inside switch cases.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>