### PR TITLE
linter: make arrayKeys check 2 different checks

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -995,14 +995,14 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []node.Node) bool {
 		}
 
 		if _, ok := keys[key]; ok {
-			b.Report(item.Key, LevelWarning, "arrayKeys", "Duplicate array key '%s'", key)
+			b.Report(item.Key, LevelWarning, "dupArrayKeys", "Duplicate array key '%s'", key)
 		}
 
 		keys[key] = struct{}{}
 	}
 
 	if haveImplicitKeys && haveKeys {
-		b.Report(arr, LevelWarning, "arrayKeys", "Mixing implicit and explicit array keys")
+		b.Report(arr, LevelWarning, "mixedArrayKeys", "Mixing implicit and explicit array keys")
 	}
 
 	return true

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -34,9 +34,15 @@ func init() {
 		},
 
 		{
-			Name:    "arrayKeys",
+			Name:    "mixedArrayKeys",
 			Default: true,
-			Comment: `Report array keys related problems.`,
+			Comment: `Report array literals that have both implicit and explicit keys.`,
+		},
+
+		{
+			Name:    "dupArrayKeys",
+			Default: true,
+			Comment: `Report duplicated keys in array literals.`,
 		},
 
 		{


### PR DESCRIPTION
Split arrayKeys into:
- mixedArrayKeys
- dupArrayKeys

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>