### PR TITLE
linter: add Filename() to the BlockContext

### DIFF
--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -104,7 +104,7 @@ func (ctx *RootContext) State() map[string]interface{} {
 	return ctx.w.State()
 }
 
-// Filename returns the full file name of the file being analyzed.
+// Filename returns the file name of the file being analyzed.
 func (ctx *RootContext) Filename() string {
 	return ctx.w.filename
 }
@@ -148,6 +148,11 @@ func (ctx *BlockContext) IsStatement(n node.Node) bool {
 
 func (ctx *BlockContext) PrematureExitFlags() int {
 	return ctx.w.PrematureExitFlags()
+}
+
+// Filename returns the file name of the file being analyzed.
+func (ctx *BlockContext) Filename() string {
+	return ctx.w.r.filename
 }
 
 // BlockCheckerCreateFunc is a factory function for BlockChecker


### PR DESCRIPTION
Sometimes block-scoped checks need to know the filename as well.

Removed "full name" promise from the documentation as it may not
be the case if linter input was not created inside "cmd", which
does map paths to abs paths. In tests we don't do this, so
Filename() does not return the full name inside them.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>