### PR TITLE
linter: handle all type aliases inside phpdoc check

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -794,10 +794,12 @@ func (d *RootWalker) checkPHPDocType(typ string) string {
 
 	// Check commonly mispelled types and other unfortunate cases.
 	switch typ {
-	case "double":
-		return "use float type instead of double"
-	case "long":
-		return "use int/integer type instead of long"
+	case "boolean":
+		return "use bool type instead of boolean"
+	case "double", "real":
+		return "use float type instead of " + typ
+	case "long", "integer":
+		return "use int type instead of " + typ
 	case "-":
 		// This happend when either of those formats is used:
 		// `* @param $name - description`

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -63,19 +63,24 @@ func TestPHPDocType(t *testing.T) {
 	test := NewSuite(t)
 	test.AddFile(`<?php
 	/**
-	 * @param [][]string $x
-	 * @param double $y
+	 * @param [][]string $x1
+	 * @param double $x2
+	 * @param real $x3
+	 * @param integer $x4
+	 * @param boolean $x5
 	 * @return []int
 	 */
-	function f($x, $y) {
-		$_ = $x;
-		$_ = $y;
+	function f($x1, $x2, $x3, $x4, $x5) {
+		$_ = [$x1, $x2, $x3, $x4, $x5];
 		return [1];
 	}`)
 	test.Expect = []string{
 		`[]int type syntax: use [] after the type, e.g. T[]`,
 		`[][]string type syntax: use [] after the type, e.g. T[]`,
 		`use float type instead of double`,
+		`use float type instead of real`,
+		`use int type instead of integer`,
+		`use bool type instead of boolean`,
 	}
 	test.RunAndMatch()
 }


### PR DESCRIPTION
Using type alias inside type hint (php7) have unexpected
results. To avoid confusion during php5->php7 transition,
require users to use real primitive type names instead of their aliases.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>