### PR TITLE
linter: don't tread "or die" as unconditional exit

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -393,14 +393,13 @@ func (b *BlockWalker) EnterNode(w walker.Walkable) (res bool) {
 }
 
 func (b *BlockWalker) handleLogicalOr(or *binary.LogicalOr) bool {
-	die, ok := or.Right.(*expr.Die)
-	if !ok {
-		return true // Continue normally
-	}
-
-	// Handle "or die" separately to avoid reporting code after it as unreachable.
-	die.Expr.Walk(b)
 	or.Left.Walk(b)
+
+	// We're going to discard "or" RHS effects on the exit flags.
+	exitFlags := b.exitFlags
+	or.Right.Walk(b)
+	b.exitFlags = exitFlags
+
 	return false
 }
 

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -30,6 +30,14 @@ $undef1 or die($undef2);
 	test.RunAndMatch()
 }
 
+func TestOrExit(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+global $ok;
+$ok or exit("");
+echo "quite reachable\n";
+`)
+}
+
 func TestUnusedInPropFetch(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestOrDie1(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+global $ok;
+$ok or die("not ok");
+echo "quite reachable\n";
+`)
+}
+
+func TestOrDie2(t *testing.T) {
+	// Check that we still check "or" LHS and RHS properly.
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+$undef1 or die($undef2);
+`)
+	test.Expect = []string{
+		"Undefined variable: undef1",
+		"Undefined variable: undef2",
+	}
+	test.RunAndMatch()
+}
+
 func TestUnusedInPropFetch(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
@@ -436,6 +457,24 @@ func TestFunctionExit(t *testing.T) {
 		echo "Dead code";
 	}`)
 	test.Expect = []string{"Unreachable code"}
+	test.RunAndMatch()
+}
+
+func TestFunctionDie(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php function doDie() {
+		die("123");
+		echo "Also unreachable";
+	}
+
+	function doSomething() {
+		doDie();
+		echo "Dead code";
+	}`)
+	test.Expect = []string{
+		"Unreachable code",
+		"Unreachable code",
+	}
 	test.RunAndMatch()
 }
 


### PR DESCRIPTION
It's not correct to report code after "or die" as unreachable.
If it's desired to discourage die usages, it should be done
in a different way. "Unreachable code" error here is confusing.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>