### PR TITLE
propagate exit flags from foreach/for/while/etc

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1158,6 +1158,7 @@ func (b *BlockWalker) handleForeach(s *stmt.Foreach) bool {
 		if !bCopy.returnTypes.IsEmpty() {
 			b.returnTypes = b.returnTypes.Append(bCopy.returnTypes)
 		}
+		b.propagateFlags(bCopy)
 	}
 
 	return false
@@ -1188,6 +1189,7 @@ func (b *BlockWalker) handleFor(s *stmt.For) bool {
 		if !bCopy.returnTypes.IsEmpty() {
 			b.returnTypes = b.returnTypes.Append(bCopy.returnTypes)
 		}
+		b.propagateFlags(bCopy)
 	}
 
 	return false
@@ -1255,6 +1257,7 @@ func (b *BlockWalker) handleWhile(s *stmt.While) bool {
 		if !bCopy.returnTypes.IsEmpty() {
 			b.returnTypes = b.returnTypes.Append(bCopy.returnTypes)
 		}
+		b.propagateFlags(bCopy)
 	}
 
 	return false
@@ -1276,6 +1279,11 @@ func (b *BlockWalker) handleDo(s *stmt.Do) bool {
 	}
 
 	return false
+}
+
+// propagateFlags is like propagateFlagsFromBranches, but for a simple single block case.
+func (b *BlockWalker) propagateFlags(other *BlockWalker) {
+	b.containsExitFlags |= other.containsExitFlags
 }
 
 // Propagate premature exit flags from visited branches ("contexts").
@@ -1568,6 +1576,8 @@ func (b *BlockWalker) handleSwitch(s *stmt.Switch) bool {
 	defCounts := make(map[string]int, b.sc.Len())
 
 	for _, ctx := range contexts {
+		b.propagateFlags(ctx)
+
 		cleanFlags := ctx.exitFlags & (^breakFlags)
 		if cleanFlags != 0 {
 			b.returnTypes = b.returnTypes.Append(ctx.returnTypes)

--- a/src/linttest/deadcode_test.go
+++ b/src/linttest/deadcode_test.go
@@ -1,0 +1,501 @@
+package linttest_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestDeadCodeDie(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+global $cond;
+$xs = [1, 2];
+switch ($cond) {
+case 0:
+  trailing_exit_if($xs);
+  echo "unreachable";
+  break;
+case 1:
+  trailing_exit_foreach($xs);
+  echo "unreachable";
+  break;
+case 2:
+  trailing_exit_foreach2($xs);
+  echo "unreachable";
+  break;
+case 3:
+  trailing_throw_if($xs);
+  echo "unreachable";
+  break;
+case 4:
+  trailing_throw_foreach($xs);
+  echo "unreachable";
+  break;
+case 5:
+  trailing_throw_foreach2($xs);
+  echo "unreachable";
+  break;
+case 6:
+  trailing_exit_for($xs);
+  echo "unreachable";
+  break;
+case 7:
+  trailing_exit_while($xs);
+  echo "unreachable";
+  break;
+case 8:
+  trailing_exit_try($xs);
+  echo "unreachable";
+  break;
+case 9:
+  trailing_exit_try2($xs);
+  echo "unreachable";
+  break;
+case 10:
+  trailing_exit_catch($xs);
+  echo "unreachable";
+  break;
+case 11:
+  trailing_exit_switch($xs);
+  echo "unreachable";
+  break;
+}
+
+class Exception {}
+
+function trailing_exit_switch($xs) {
+  switch($xs[0]) {
+  case 1:
+    die("ok");
+  }
+  exit;
+}
+
+function trailing_exit_try($xs) {
+  try {
+    if ($xs) {
+      die("ok");
+    }
+  } catch (Exception $_) {}
+  exit;
+}
+
+function trailing_exit_try2($xs) {
+  try {
+    try {
+      if ($xs) {
+        if ($xs[0] < 1000) {
+          die("ok");
+        }
+      }
+    } catch (Exception $_) {}
+  } catch (Exception $_) {}
+  exit;
+}
+
+function trailing_exit_catch($xs) {
+  try {
+  } catch (Exception $_) {
+    die("ok");
+  }
+  exit;
+}
+
+function trailing_exit_if($xs) {
+  if ($xs) {
+    die("ok");
+  }
+  exit;
+}
+
+function trailing_exit_foreach($xs) {
+  foreach ($xs as $x) {
+    if ($x < 10) {
+      die("ok");
+    }
+  }
+  exit;
+}
+
+function trailing_exit_foreach2($xs) {
+  foreach ([$xs] as $ys) {
+    foreach ($ys as $y) {
+      if ($y < 10) {
+        die("ok");
+      }
+    }
+  }
+  exit;
+}
+
+function trailing_throw_if($xs) {
+  if ($xs) {
+    die("ok");
+  }
+  throw new Exception("oops");
+}
+
+function trailing_throw_foreach($xs) {
+  foreach ($xs as $x) {
+    if ($x < 10) {
+      die("ok");
+    }
+  }
+  throw new Exception("oops");
+}
+
+function trailing_throw_foreach2($xs) {
+  foreach ([$xs] as $ys) {
+    foreach ($ys as $y) {
+      if ($y < 10) {
+        die("ok");
+      }
+    }
+  }
+  throw new Exception("oops");
+}
+
+function trailing_exit_for($xs) {
+  for ($i = 0; $i < 10; $i++) {
+    if ($i == $xs[0]) {
+      die("ok");
+    }
+  }
+  exit;
+}
+
+function trailing_exit_while($xs) {
+  while (1) {
+    if ($xs[0] < 1000) {
+      die("ok");
+    }
+    break;
+  }
+  exit;
+}`)
+
+	test.Expect = []string{
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+	}
+
+	test.RunAndMatch()
+}
+
+func TestDeadCodeNoReturn(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+global $cond;
+$xs = [1, 2];
+switch ($cond) {
+case 0:
+  trailing_exit_if($xs);
+  echo "unreachable";
+  break;
+case 1:
+  trailing_exit_foreach($xs);
+  echo "unreachable";
+  break;
+case 2:
+  trailing_exit_foreach2($xs);
+  echo "unreachable";
+  break;
+case 3:
+  trailing_throw_if($xs);
+  echo "unreachable";
+  break;
+case 4:
+  trailing_throw_foreach($xs);
+  echo "unreachable";
+  break;
+case 5:
+  trailing_throw_foreach2($xs);
+  echo "unreachable";
+  break;
+case 6:
+  trailing_exit_for($xs);
+  echo "unreachable";
+  break;
+case 7:
+  trailing_exit_while($xs);
+  echo "unreachable";
+  break;
+case 8:
+  trailing_exit_try($xs);
+  echo "unreachable";
+  break;
+case 9:
+  trailing_exit_try2($xs);
+  echo "unreachable";
+  break;
+case 10:
+  trailing_exit_catch($xs);
+  echo "unreachable";
+  break;
+case 11:
+  trailing_exit_switch($xs);
+  echo "unreachable";
+  break;
+}
+
+class Exception {}
+
+function trailing_exit_switch($xs) {
+  switch($xs[0]) {
+  case 1:
+    $_ = $xs[0];
+  }
+  exit;
+}
+
+function trailing_exit_try($xs) {
+  try {
+    if ($xs) {
+    }
+  } catch (Exception $_) {}
+  exit;
+}
+
+function trailing_exit_try2($xs) {
+  try {
+    try {
+      if ($xs) {
+        if ($xs[0] < 1000) {
+        }
+      }
+    } catch (Exception $_) {}
+  } catch (Exception $_) {}
+  exit;
+}
+
+function trailing_exit_catch($xs) {
+  try {
+  } catch (Exception $_) {
+  }
+  exit;
+}
+
+function trailing_exit_if($xs) {
+  if ($xs) {
+  }
+  exit;
+}
+
+function trailing_exit_foreach($xs) {
+  foreach ($xs as $x) {
+    if ($x < 10) {
+    }
+  }
+  exit;
+}
+
+function trailing_exit_foreach2($xs) {
+  foreach ([$xs] as $ys) {
+    foreach ($ys as $y) {
+      if ($y < 10) {
+      }
+    }
+  }
+  exit;
+}
+
+function trailing_throw_if($xs) {
+  if ($xs) {
+  }
+  throw new Exception("oops");
+}
+
+function trailing_throw_foreach($xs) {
+  foreach ($xs as $x) {
+    if ($x < 10) {
+    }
+  }
+  throw new Exception("oops");
+}
+
+function trailing_throw_foreach2($xs) {
+  foreach ([$xs] as $ys) {
+    foreach ($ys as $y) {
+      if ($y < 10) {
+      }
+    }
+  }
+  throw new Exception("oops");
+}
+
+function trailing_exit_for($xs) {
+  for ($i = 0; $i < 10; $i++) {
+    if ($i == $xs[0]) {
+    }
+  }
+  exit;
+}
+
+function trailing_exit_while($xs) {
+  while (1) {
+    if ($xs[0] < 1000) {
+    }
+  }
+  exit;
+}`)
+
+	test.Expect = []string{
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+		"Unreachable code",
+	}
+
+	test.RunAndMatch()
+}
+
+func TestTrailingExit(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+$xs = [1, 2];
+trailing_exit_if($xs);
+trailing_exit_foreach($xs);
+trailing_exit_foreach2($xs);
+trailing_throw_if($xs);
+trailing_throw_foreach($xs);
+trailing_throw_foreach2($xs);
+trailing_exit_for($xs);
+trailing_exit_while($xs);
+trailing_exit_try($xs);
+trailing_exit_try2($xs);
+trailing_exit_catch($xs);
+trailing_exit_switch($xs);
+echo "not a dead code";
+
+class Exception {}
+
+function trailing_exit_switch($xs) {
+  switch($xs[0]) {
+  case 1:
+    return "ok";
+  }
+  exit;
+}
+
+function trailing_exit_try($xs) {
+  try {
+    if ($xs) {
+      return "ok";
+    }
+  } catch (Exception $_) {}
+  exit;
+}
+
+function trailing_exit_try2($xs) {
+  try {
+    try {
+      if ($xs) {
+        if ($xs[0] < 1000) {
+          return "ok";
+        }
+      }
+    } catch (Exception $_) {}
+  } catch (Exception $_) {}
+  exit;
+}
+
+function trailing_exit_catch($xs) {
+  try {
+  } catch (Exception $_) {
+    return "ok";
+  }
+  exit;
+}
+
+function trailing_exit_if($xs) {
+  if ($xs) {
+    return "ok";
+  }
+  exit;
+}
+
+function trailing_exit_foreach($xs) {
+  foreach ($xs as $x) {
+    if ($x < 10) {
+      return "ok";
+    }
+  }
+  exit;
+}
+
+function trailing_exit_foreach2($xs) {
+  foreach ([$xs] as $ys) {
+    foreach ($ys as $y) {
+      if ($y < 10) {
+        return "ok";
+      }
+    }
+  }
+  exit;
+}
+
+function trailing_throw_if($xs) {
+  if ($xs) {
+    return "ok";
+  }
+  throw new Exception("oops");
+}
+
+function trailing_throw_foreach($xs) {
+  foreach ($xs as $x) {
+    if ($x < 10) {
+      return "ok";
+    }
+  }
+  throw new Exception("oops");
+}
+
+function trailing_throw_foreach2($xs) {
+  foreach ([$xs] as $ys) {
+    foreach ($ys as $y) {
+      if ($y < 10) {
+        return "ok";
+      }
+    }
+  }
+  throw new Exception("oops");
+}
+
+function trailing_exit_for($xs) {
+  for ($i = 0; $i < 10; $i++) {
+    if ($i == $xs[0]) {
+      return "ok";
+    }
+  }
+  exit;
+}
+
+function trailing_exit_while($xs) {
+  while (1) {
+    if ($xs[0] < 1000) {
+      return "ok";
+    }
+    break;
+  }
+  exit;
+}
+`)
+}


### PR DESCRIPTION
This makes deadCode properly handle "returns sometimes" case
for nested statements that create a nested block context.

Fixes #78

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>