### PR TITLE
make encoding handling customizable

### DIFF
--- a/example/custom/custom_test.go
+++ b/example/custom/custom_test.go
@@ -1,47 +1,15 @@
 package main
 
 import (
-	"log"
-	"strings"
 	"testing"
 
-	"github.com/VKCOM/noverify/src/linter"
-	"github.com/VKCOM/noverify/src/meta"
-	"github.com/z7zmey/php-parser/node"
+	"github.com/VKCOM/noverify/src/linttest"
 )
 
-func init() {
-	linter.RegisterBlockChecker(func(ctx *linter.BlockContext) linter.BlockChecker { return &block{ctx: ctx} })
-	go linter.MemoryLimiterThread()
-}
-
-func testParse(t *testing.T, filename string, contents string) (rootNode node.Node, w *linter.RootWalker) {
-	var err error
-	rootNode, w, err = linter.ParseContents(filename, []byte(contents), "UTF-8", nil)
-	if err != nil {
-		t.Errorf("Could not parse %s: %s", filename, err.Error())
-		t.Fail()
-	}
-
-	if !meta.IsIndexingComplete() {
-		w.UpdateMetaInfo()
-	}
-
-	return rootNode, w
-}
-
-func singleFileReports(t *testing.T, contents string) []*linter.Report {
-	meta.ResetInfo()
-
-	testParse(t, `first.php`, contents)
-	meta.SetIndexingComplete(true)
-	_, w := testParse(t, `first.php`, contents)
-
-	return w.GetReports()
-}
-
 func TestAssignmentAsExpression(t *testing.T) {
-	reports := singleFileReports(t, `<?php
+	test := linttest.NewSuite(t)
+
+	test.AddFile(`<?php
 	// phpdoc annotations are not required for NoVerify in simple cases
 	function something() {
 		$a = "test";
@@ -59,29 +27,12 @@ func TestAssignmentAsExpression(t *testing.T) {
 		if (something() == $b[1]) {
 			echo "must be ===";
 		}
-	}
-	`)
+	}`)
 
-	for _, r := range reports {
-		log.Printf("%s", r)
-	}
-
-	if len(reports) != 2 {
-		t.Errorf("Unexpected number of reports: expected 2, got %d", len(reports))
-		if len(reports) < 2 {
-			t.FailNow()
-		}
+	test.Expect = []string{
+		"3rd argument of in_array must be true when comparing strings",
+		"Strings must be compared using '===' operator",
 	}
 
-	text := reports[0].String()
-
-	if !strings.Contains(text, "3rd argument of in_array must be true when comparing strings") {
-		t.Errorf("Wrong report text: expected '3rd argument of in_array must be true', got '%s'", text)
-	}
-
-	text = reports[1].String()
-
-	if !strings.Contains(text, "Strings must be compared using '===' operator") {
-		t.Errorf("Wrong report text: expected 'Strings must be compared using '===' operator', got '%s'", text)
-	}
+	test.RunAndMatch()
 }

--- a/example/custom/main.go
+++ b/example/custom/main.go
@@ -30,7 +30,15 @@ func init() {
 func main() {
 	log.SetFlags(log.Flags() | log.Lmicroseconds)
 
+	bindCustomFlags()
+	cmd.MainHooks.AfterFlagParse = func() {
+		// Can use custom flags here to complete custom checks initialization.
+	}
 	cmd.Main()
+}
+
+func bindCustomFlags() {
+	// Can bind custom flags here.
 }
 
 type block struct {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"bufio"
+	"io"
 	"log"
+	"sync"
 
 	"github.com/VKCOM/noverify/src/cmd"
+	"github.com/VKCOM/noverify/src/linter"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/transform"
 )
 
 func main() {
@@ -11,5 +17,40 @@ func main() {
 
 	// You can register your own rules here, see src/linter/custom.go
 
+	var fw fileReaderWrapper
+	cmd.MainHooks.AfterFlagParse = func() {
+		fw.encoding = linter.DefaultEncoding
+		linter.WrapFileReader = fw.WrapFileReader
+	}
 	cmd.Main()
+}
+
+func (fw *fileReaderWrapper) WrapFileReader(filename string, r io.ReadCloser) io.ReadCloser {
+	if fw.encoding != "windows-1251" {
+		return r
+	}
+
+	bufRd := fw.bufPool.Get().(*bufio.Reader)
+	bufRd.Reset(r)
+	return &readCloser{
+		Reader: transform.NewReader(r, charmap.Windows1251.NewDecoder()),
+		closeFunc: func() error {
+			fw.bufPool.Put(bufRd)
+			return r.Close()
+		},
+	}
+}
+
+type fileReaderWrapper struct {
+	bufPool  sync.Pool
+	encoding string
+}
+
+type readCloser struct {
+	io.Reader
+	closeFunc func() error
+}
+
+func (rc *readCloser) Close() error {
+	return rc.closeFunc()
 }

--- a/src/cmd/conf.go
+++ b/src/cmd/conf.go
@@ -1,0 +1,7 @@
+package cmd
+
+// MainHooks provides integration points into cmd.Main for custom linters.
+var MainHooks struct {
+	// AfterFlagParse is called right after flag.Parse is invoked inside cmd.Main.
+	AfterFlagParse func()
+}

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -166,6 +166,9 @@ func canBeDisabled(filename string) bool {
 // before running main().
 func Main() {
 	parseFlags()
+	if MainHooks.AfterFlagParse != nil {
+		MainHooks.AfterFlagParse()
+	}
 
 	status, err := mainNoExit()
 	if err != nil {

--- a/src/linter/conf.go
+++ b/src/linter/conf.go
@@ -16,6 +16,7 @@ var (
 	MaxFileSize     int
 	DefaultEncoding string
 	PHPExtensions   []string
+	WrapFileReader  = defaultWrapFileReader
 
 	// actually time.Duration
 	initParseTime int64


### PR DESCRIPTION
Make it possible for noverify extensions to specify
their own scheme for handling encodings.
Do this by providing file reader wrapping callback
that can, depending on the external logic,
either return original reader, or a new reader
that can handle input encoding by using internal
knowledge and read it as UTF-8 that linter expects.

This is especially useful in projects where more than
one encoding can be found inside project tree.

Changes overview:

- Move win-1251 encoding handling away from linter.
  It might go away in a next few releases, if that
  feature turns out to be unused by users.

- Add cmd.Main AfterFlagParse hook to simplify
  linter extension flags handling.
  Now user can bind new flags in main and
  use them inside AfterFlagParse function to
  finish initialization.

- Update /example. Use linttest package
  and demonstrate new cmd.Main hooks.

We also use io.ReadCloser instead of just Reader to make it
possible for custom wrappers of the reader to have some finalization
after reader is not needed anymore.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>