### PR TITLE
cmd: add MainConfig with AfterFlagParse hook

### DIFF
--- a/example/custom/main.go
+++ b/example/custom/main.go
@@ -3,6 +3,7 @@ package main
 // This is an example of adding of custom rules
 
 import (
+	"flag"
 	"log"
 
 	"github.com/VKCOM/noverify/src/cmd"
@@ -27,10 +28,21 @@ func init() {
 	})
 }
 
+var customFlag = flag.String("custom-flag", "", "An example of the additional linter flag")
+
 func main() {
 	log.SetFlags(log.Flags() | log.Lmicroseconds)
 
-	cmd.Main()
+	// Config argument can be nil to use "all default" behavior.
+	cmd.Main(&cmd.MainConfig{
+		AfterFlagParse: useCustomFlags,
+	})
+}
+
+func useCustomFlags() {
+	if *customFlag != "" {
+		log.Println("custom flag value:", *customFlag)
+	}
 }
 
 type block struct {

--- a/src/cmd/conf.go
+++ b/src/cmd/conf.go
@@ -1,0 +1,11 @@
+package cmd
+
+// MainConfig describes optional main function config.
+// All zero field values have some defined behavior.
+type MainConfig struct {
+	// AfterFlagParse is called right after flag.Parse() returned.
+	// Can be used to examine flags that were bound prior to the Main() call.
+	//
+	// If nil, behaves as a no-op function.
+	AfterFlagParse func()
+}

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -67,7 +67,7 @@ var (
 	memProfile string
 )
 
-func parseFlags() {
+func bindFlags() {
 	var enabledByDefault []string
 	declaredChecks := linter.GetDeclaredChecks()
 	for _, info := range declaredChecks {
@@ -132,8 +132,6 @@ func parseFlags() {
 
 	flag.StringVar(&cpuProfile, "cpuprofile", "", "write cpu profile to `file`")
 	flag.StringVar(&memProfile, "memprofile", "", "write memory profile to `file`")
-
-	flag.Parse()
 }
 
 func isEnabled(r *linter.Report) bool {
@@ -164,8 +162,18 @@ func canBeDisabled(filename string) bool {
 
 // Main is the actual main function to be run. It is separate from linter so that you can insert your own hooks
 // before running main().
-func Main() {
-	parseFlags()
+//
+// Optionally, non-nil config can be passed to customize function behavior.
+func Main(cfg *MainConfig) {
+	if cfg == nil {
+		cfg = &MainConfig{}
+	}
+
+	bindFlags()
+	flag.Parse()
+	if cfg.AfterFlagParse != nil {
+		cfg.AfterFlagParse()
+	}
 
 	status, err := mainNoExit()
 	if err != nil {


### PR DESCRIPTION
The callback is called after flag.Parse is called
inside cmd.Main function. This makes it easier
to use flags that are defined outside of cmd.Main.

Used config struct instead of global variables
to make the configuration possibility obvious for the users.
This breaks backwards-compatibility though.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>