### PR TITLE
all: use inputs.SourceInput for PHP reading

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,5 +11,5 @@ func main() {
 
 	// You can register your own rules here, see src/linter/custom.go
 
-	cmd.Main()
+	cmd.Main(nil)
 }

--- a/src/inputs/inputs.go
+++ b/src/inputs/inputs.go
@@ -1,0 +1,74 @@
+package inputs
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// SourceInput interface describes linter source code inputs that can come from
+// files and buffers.
+//
+// One of the responsibilities of the SourceInput is to return readers
+// that can be treated like they always have UTF-8 encoded data.
+// If real data has different encoding, it's up to the implementation
+// to detect and fix that.
+type SourceInput interface {
+	NewReader(filename string) (ReadCloseSizer, error)
+	NewBytesReader(filename string, data []byte) (ReadCloseSizer, error)
+}
+
+// ReadCloseSizer is the interface that groups io.ReadCloser and Size methods.
+type ReadCloseSizer interface {
+	io.ReadCloser
+	Size() int
+}
+
+// NewReadCloseSizer turns ReadCloser into ReadCloserSizer by adding Size method
+// that always returns initially bound size.
+func NewReadCloseSizer(r io.ReadCloser, size int) ReadCloseSizer {
+	return readCloserSizer{
+		ReadCloser: r,
+		size:       size,
+	}
+}
+
+// NewDefaultSourceInput returns the default SourceInput implementation that
+// operates with filesystem directly.
+//
+// It assumes that all sources are UTF-8 encoded.
+func NewDefaultSourceInput() SourceInput {
+	return defaultSourceInput{}
+}
+
+type defaultSourceInput struct{}
+
+func (defaultSourceInput) NewReader(filename string) (ReadCloseSizer, error) {
+	fp, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("could not open file %s: %v", filename, err)
+	}
+
+	st, err := fp.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("could not stat file %s: %v", filename, err)
+	}
+
+	size := int(st.Size())
+	return NewReadCloseSizer(fp, size), nil
+}
+
+func (defaultSourceInput) NewBytesReader(filename string, data []byte) (ReadCloseSizer, error) {
+	return NewReadCloseSizer(ioutil.NopCloser(bytes.NewReader(data)), len(data)), nil
+}
+
+type readCloserSizer struct {
+	io.ReadCloser
+	size int
+}
+
+func (r readCloserSizer) Size() int {
+	return r.size
+}

--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -35,9 +35,9 @@ type fileMeta struct {
 }
 
 // Parse file and fill in the meta info. Can use cache.
-func Parse(filename string, contents []byte, encoding string) error {
+func Parse(filename string, contents []byte) error {
 	if CacheDir == "" {
-		_, w, err := ParseContents(filename, contents, encoding, nil)
+		_, w, err := ParseContents(filename, contents, nil)
 		if w != nil {
 			updateMetaInfo(filename, &w.meta)
 		}
@@ -76,7 +76,7 @@ func Parse(filename string, contents []byte, encoding string) error {
 	start := time.Now()
 	fp, err := os.Open(cacheFile)
 	if err != nil {
-		_, w, err := ParseContents(filename, contents, encoding, nil)
+		_, w, err := ParseContents(filename, contents, nil)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func Parse(filename string, contents []byte, encoding string) error {
 		// do not really care about why exactly reading from cache failed
 		os.Remove(cacheFile)
 
-		_, w, err := ParseContents(filename, contents, encoding, nil)
+		_, w, err := ParseContents(filename, contents, nil)
 		if err != nil {
 			return err
 		}
@@ -127,13 +127,12 @@ func createMetaCacheFile(filename, cacheFile string, m *fileMeta) error {
 	if err := wr.Flush(); err != nil {
 		return err
 	}
-	
+
 	// Windows clearly does not want to allow to rename unclosed files
 	if runtime.GOOS == "windows" {
 		fp.Close()
 		os.Remove(cacheFile)
 	}
-
 
 	if err := os.Rename(tmpPath, cacheFile); err != nil {
 		return err

--- a/src/linter/conf.go
+++ b/src/linter/conf.go
@@ -1,5 +1,9 @@
 package linter
 
+import (
+	"github.com/VKCOM/noverify/src/inputs"
+)
+
 var (
 	// LangServer represents whether or not we run in a language server mode.
 	LangServer bool
@@ -8,6 +12,11 @@ var (
 
 	// AnalysisFiles is a list of files that are being analyzed (in non-git mode)
 	AnalysisFiles []string
+
+	// SrcInput implements source code reading from files and buffers.
+	//
+	// TODO(quasilyte): avoid having it as a global variable?
+	SrcInput = inputs.NewDefaultSourceInput()
 
 	// settings
 	StubsDir        string

--- a/src/linttest/linttest.go
+++ b/src/linttest/linttest.go
@@ -178,7 +178,7 @@ func parseTestFile(t *testing.T, f TestFile) (rootNode node.Node, w *linter.Root
 	once.Do(func() { go linter.MemoryLimiterThread() })
 
 	var err error
-	rootNode, w, err = linter.ParseContents(f.Name, f.Data, "UTF-8", nil)
+	rootNode, w, err = linter.ParseContents(f.Name, f.Data, nil)
 	if err != nil {
 		t.Fatalf("could not parse %s: %v", f.Name, err.Error())
 	}


### PR DESCRIPTION
Add inputs package that defines SourceInput interface.
That interface is used inside linter to read PHP files.

Readers returned from that interface should yield UTF-8 encoded
data. If other encodings are needed, it's possible to handle
them inside linter extensions by providing custom implementation
and assigning it to linter.SrcInput.

Example that adds win-1251 encoding support will be added soon
to show how it can be done.

This is experimental part of the linter and can be a subject of
changes in future. Only UTF-8 support is guaranteed.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>