### PR TITLE
accept unused-var-regex option

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1746,7 +1746,7 @@ func (b *BlockWalker) flushUnused() {
 
 	visitedMap := make(map[node.Node]struct{})
 	for name, nodes := range b.unusedVars {
-		if name == "_" {
+		if IsDiscardVar(name) {
 			// blank identifier is a way to tell linter (and PHPStorm) that result is explicitly unused
 			continue
 		}

--- a/src/linter/conf.go
+++ b/src/linter/conf.go
@@ -26,6 +26,8 @@ var (
 	DefaultEncoding string
 	PHPExtensions   []string
 
+	IsDiscardVar = isUnderscore
+
 	// actually time.Duration
 	initParseTime int64
 	initWalkTime  int64

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -323,3 +323,7 @@ func reportListToMap(list []*Report) map[string][]*Report {
 
 	return res
 }
+
+func isUnderscore(s string) bool {
+	return s == "_"
+}

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -2,12 +2,33 @@ package linttest_test
 
 import (
 	"log"
+	"strings"
 	"testing"
 
 	"github.com/VKCOM/noverify/src/linter"
 	"github.com/VKCOM/noverify/src/linttest"
 	"github.com/VKCOM/noverify/src/meta"
 )
+
+func TestCustomUnusedVarRegex(t *testing.T) {
+	defer func(isDiscardVar func(string) bool) {
+		linter.IsDiscardVar = isDiscardVar
+	}(linter.IsDiscardVar)
+
+	linter.IsDiscardVar = func(s string) bool {
+		return strings.HasPrefix(s, "_")
+	}
+
+	linttest.SimpleNegativeTest(t, `<?php
+$_unused = 10;
+
+function f() {
+  $_unused2 = 20;
+  $_ = 30;
+  foreach ([1] as $_ => $_user) {}
+}
+`)
+}
 
 func TestClosureCapture(t *testing.T) {
 	test := linttest.NewSuite(t)


### PR DESCRIPTION
Makes it possible to set "_" as a valid prefix for unused variables.

Useful for tuple-like returns that are destructured using list.

Only one value is used:
```
	list($_id, $_name, $email) = getUser(...);
```

If $_ is used everywhere, it's less opparent what fields are ignored:
```
	list($_, $_, $email) = getUser(...);
```

The next step is to warn on usages of variables that are matched
by IsDiscardVar. If such variable is read, it could be a mistake.

By default, only "$_" is permitted, as before.
For arbitrary patterns regexp is used.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>