### PR TITLE
inherit base method param types

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -16,7 +16,7 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
-const cacheVersion = 24
+const cacheVersion = 25
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -660,13 +660,48 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 		d.Report(meth.MethodName, LevelInformation, "phpdoc", "PHPDoc is incorrect: %s", err)
 	}
 
+	class := d.getClass()
 	params, minParamsCnt := d.parseFuncArgs(meth.Params, phpDocParamTypes, sc)
+
+	if len(class.Interfaces) != 0 {
+		// If we implement interfaces, methods that take a part in this
+		// can borrow types information from them.
+		// Programmers sometimes leave implementing methods without a
+		// comment or use @inheritdoc there.
+		//
+		// If method params are properly documented, it's possible to
+		// derive that information, but we need to know in which
+		// interface we can find that method.
+		//
+		// Since we don't have all interfaces during the indexing phase
+		// and shouldn't update meta after it, we defer type resolving by
+		// using BaseMethodParam here. We would have to lookup
+		// matching interface during the type resolving.
+
+		// Find params without type and annotate them with special
+		// type that will force solver to walk interface types that
+		// current class implements to have a chance of finding relevant type info.
+		for i, p := range params {
+			if !p.Typ.IsEmpty() {
+				continue // Already has a type
+			}
+
+			if i > meta.MaxMethodParamIndex {
+				break // Current implementation limit reached
+			}
+
+			res := make(map[string]struct{})
+			res[meta.WrapBaseMethodParam(i, d.st.CurrentClass, nm)] = struct{}{}
+			params[i].Typ = meta.NewTypesMapFromMap(res)
+			sc.AddVarName(p.Name, params[i].Typ, "param", true)
+		}
+	}
+
 	actualReturnTypes, exitFlags := d.handleFuncStmts(params, nil, meth.Stmts, sc)
 
 	d.addScope(meth, sc)
 
 	// TODO: handle duplicate method
-	class := d.getClass()
 	typ := meta.MergeTypeMaps(phpdocReturnType, actualReturnTypes, specifiedReturnType).Immutable()
 
 	class.Methods[nm] = meta.FuncInfo{

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 
@@ -686,7 +687,7 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 				continue // Already has a type
 			}
 
-			if i > meta.MaxMethodParamIndex {
+			if i > math.MaxUint8 {
 				break // Current implementation limit reached
 			}
 

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -234,6 +234,37 @@ namespace NS {
 	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
 }
 
+func TestExprTypeInterface(t *testing.T) {
+	tests := []exprTypeTest{
+		{"$foo", `\Foo`},
+		{"$foo->getThis()", `\Foo`},
+		{"$foo->acceptThis($foo)", `\TestInterface`},
+		{"$foo->acceptThis($foo)->acceptThis($foo)", `\TestInterface`},
+	}
+
+	global := `<?php
+interface TestInterface {
+  /**
+   * @return self
+   */
+  public function getThis();
+
+  /**
+   * @param \TestInterface $x
+   * @return \TestInterface
+   */
+  public function acceptThis($x);
+}
+
+class Foo implements TestInterface {
+  public function getThis() { return $this; }
+
+  public function acceptThis($x) { return $x->getThis(); }
+}`
+	local := `$foo = new Foo();`
+	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
+}
+
 func TestExprTypeOverride(t *testing.T) {
 	tests := []exprTypeTest{
 		{`array_shift($ints)`, "int"},

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -6,6 +6,37 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestInheritDoc(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+interface TestInterface {
+  /**
+   * @return self
+   */
+  public function getThis();
+
+  /**
+   * @param \TestInterface $x
+   */
+  public function acceptThis($x);
+}
+`)
+	test.AddFile(`<?php
+class Foo implements TestInterface {
+  /** @inheritdoc */
+  public function getThis() { return $this; }
+
+  /** @inheritdoc */
+  public function acceptThis($x) { return $x->getThis(); }
+}
+
+$foo = new Foo();
+$_ = $foo->getThis()->getThis();
+$foo->acceptThis($foo);
+`)
+	test.RunAndMatch()
+}
+
 func TestInterfaceConstants(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 	interface TestInterface

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -19,6 +19,15 @@ interface TestInterface {
    * @param \TestInterface $x
    */
   public function acceptThis($x);
+
+  /**
+   * @param mixed $p1
+   * @param mixed $p2
+   * @param mixed $p3
+   * @param mixed $p4
+   * @param \TestInterface $x
+   */
+  public function acceptThis5($p1, $p2, $p3, $p4, $x);
 }
 `)
 	test.AddFile(`<?php
@@ -28,6 +37,11 @@ class Foo implements TestInterface {
 
   /** @inheritdoc */
   public function acceptThis($x) { return $x->getThis(); }
+
+  /** Should work regardless of "inheritdoc" */
+  public function acceptThis5($p1, $p2, $p3, $p4, $x) {
+    return $x->getThis();
+  }
 }
 
 $foo = new Foo();

--- a/src/meta/encoding_test.go
+++ b/src/meta/encoding_test.go
@@ -1,0 +1,76 @@
+package meta
+
+import (
+	"testing"
+)
+
+func TestTypeEncoding(t *testing.T) {
+	tests := []struct {
+		wrapped     string
+		stringified string
+		unwrapCheck func(typ string) bool
+	}{
+		{`int`, `int`, func(typ string) bool { return typ == `int` }},
+		{`\Foo`, `\Foo`, func(typ string) bool { return typ == `\Foo` }},
+
+		{
+			WrapArrayOf(`int`), `int[]`,
+			func(typ string) bool { return unwrap1(typ) == `int` },
+		},
+
+		{
+			WrapBaseMethodParam(0, `FooClass`, `barMethod`),
+			`param(FooClass)::barMethod[0]`,
+			func(typ string) bool {
+				index, className, methodName := unwrap3(typ)
+				return index == 0 && className == `FooClass` && methodName == `barMethod`
+			},
+		},
+
+		{
+			WrapBaseMethodParam('|', `FooClass`, `barMethod`),
+			`param(FooClass)::barMethod[124]`,
+			func(typ string) bool {
+				index, className, methodName := unwrap3(typ)
+				return index == '|' && className == `FooClass` && methodName == `barMethod`
+			},
+		},
+	}
+
+	for _, test := range tests {
+		stringified := formatType(test.wrapped)
+		if stringified != test.stringified {
+			t.Errorf("formatType %q:\nhave: %q\nwant: %q",
+				test.stringified, stringified, test.stringified)
+			continue
+		}
+
+		if !test.unwrapCheck(test.wrapped) {
+			t.Errorf("unwrap check failed for %q", test.stringified)
+			continue
+		}
+
+		const typeSuffix = "|zzz|zzz[]"
+		m := NewTypesMap(test.stringified + typeSuffix)
+		if m.String() != test.stringified+typeSuffix {
+			t.Errorf("type map string mismatched for %q:\nhave: %q\nwant: %q",
+				test.stringified, m.String(), test.stringified+typeSuffix)
+			continue
+		}
+
+		encoded, err := m.GobEncode()
+		if err != nil {
+			t.Errorf("failed to gob-encode %q: %v", test.stringified, err)
+			continue
+		}
+		decoded := NewEmptyTypesMap(m.Len())
+		if err := decoded.GobDecode(encoded); err != nil {
+			t.Errorf("failed to gob-decode %q: %v", test.stringified, err)
+			continue
+		}
+		if m.String() != decoded.String() {
+			t.Errorf("decoded type string mismatched for %q:\nhave: %q\nwant: %q",
+				test.stringified, decoded.String(), m.String())
+		}
+	}
+}

--- a/src/meta/encoding_test.go
+++ b/src/meta/encoding_test.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -33,6 +34,14 @@ func TestTypeEncoding(t *testing.T) {
 			func(typ string) bool {
 				index, className, methodName := unwrap3(typ)
 				return index == '|' && className == `FooClass` && methodName == `barMethod`
+			},
+		},
+
+		{
+			WrapArrayOf(strings.Repeat(`a`, '|')),
+			strings.Repeat(`a`, '|') + `[]`,
+			func(typ string) bool {
+				return unwrap1(typ) == strings.Repeat(`a`, '|')
 			},
 		},
 	}
@@ -71,6 +80,17 @@ func TestTypeEncoding(t *testing.T) {
 		if m.String() != decoded.String() {
 			t.Errorf("decoded type string mismatched for %q:\nhave: %q\nwant: %q",
 				test.stringified, decoded.String(), m.String())
+		}
+
+		// TODO(quasilyte): do something so we don't need to care about
+		// encoded (wrapped) so much. For now, we need tests below to ensure
+		// that nothing blows up because some <uint8> or type byte look like '|'
+		// when printed as a string.
+		if len(strings.Split(test.wrapped, `|`)) != len(strings.Split(test.stringified, `|`)) {
+			t.Errorf("mismatched |-split parts count for %q:\nhave: %d\nwant: %d",
+				test.stringified,
+				len(strings.Split(test.wrapped, `|`)),
+				len(strings.Split(test.stringified, `|`)))
 		}
 	}
 }

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -81,12 +81,8 @@ func ResolveType(typ string, visitedMap map[string]struct{}) map[string]struct{}
 				}
 			}
 		}
-	case meta.WBaseMethodParam0:
-		return solveBaseMethodParam(0, typ, visitedMap, res)
-	case meta.WBaseMethodParam1:
-		return solveBaseMethodParam(1, typ, visitedMap, res)
-	case meta.WBaseMethodParam2:
-		return solveBaseMethodParam(2, typ, visitedMap, res)
+	case meta.WBaseMethodParam:
+		return solveBaseMethodParam(typ, visitedMap, res)
 	case meta.WStaticMethodCall:
 		className, methodName := meta.UnwrapStaticMethodCall(typ)
 		info, _, ok := FindMethod(className, methodName)
@@ -106,8 +102,8 @@ func ResolveType(typ string, visitedMap map[string]struct{}) map[string]struct{}
 	return res
 }
 
-func solveBaseMethodParam(index int, typ string, visitedMap, res map[string]struct{}) map[string]struct{} {
-	className, methodName := meta.UnwrapBaseMethodParam(typ)
+func solveBaseMethodParam(typ string, visitedMap, res map[string]struct{}) map[string]struct{} {
+	index, className, methodName := meta.UnwrapBaseMethodParam(typ)
 	class, ok := meta.Info.GetClass(className)
 	if ok {
 		// TODO(quasilyte): walk parent interfaces as well?
@@ -120,7 +116,7 @@ func solveBaseMethodParam(index int, typ string, visitedMap, res map[string]stru
 			if !ok {
 				continue
 			}
-			if len(fn.Params) > index {
+			if len(fn.Params) > int(index) {
 				return ResolveTypes(fn.Params[index].Typ, visitedMap)
 			}
 		}


### PR DESCRIPTION
If no other type info about params is available,
walk base types to find matching method and see whether
it has proper types info for that parameter.

Do this only for interfaces.

This makes it possible to resolve both input and output
types of methods that implement some interface. In turn,
this makes "undefined method" go away if method had no
PHPDoc that specified the parameter type that was used.

Phpstorm and phpdoc utility do more or less the same thing.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>