### PR TITLE
Use unquote that removes at most one '/"

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1022,7 +1022,7 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []node.Node) bool {
 
 		switch k := item.Key.(type) {
 		case *scalar.String:
-			key = strings.TrimFunc(k.Value, isQuote)
+			key = unquote(k.Value)
 			constKey = true
 		case *scalar.Lnumber:
 			key = k.Value

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -327,3 +327,11 @@ func reportListToMap(list []*Report) map[string][]*Report {
 func isUnderscore(s string) bool {
 	return s == "_"
 }
+
+// unquote returns unquoted version of s, if there are any quotes.
+func unquote(s string) string {
+	if len(s) >= 2 && s[0] == '\'' || s[0] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -320,6 +320,15 @@ func TestAllowAssignmentInForLoop(t *testing.T) {
 	`)
 }
 
+func TestDuplicateArrayKeyGood(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+$valid_quotes = [
+  '"' => 1,
+  "'" => 1,
+];
+`)
+}
+
 func TestDuplicateArrayKey(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
Fixes dupArrayKeys false positive where 2 keys, ' and "
were considered as equal due to the quote trimming
(both were trimmed to the empty string).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>