### PR TITLE
Handle late static binding

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1118,7 +1118,7 @@ func (b *BlockWalker) handleNew(e *expr.New) bool {
 
 	className, ok := solver.GetClassName(b.r.st, e.Class)
 	if !ok {
-		// perhaps something like 'new $class', cannot check this
+		// perhaps something like 'new $class', cannot check this.
 		return true
 	}
 

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -755,6 +755,14 @@ func (d *RootWalker) maybeAddNamespace(typStr string) string {
 		switch className {
 		case "bool", "boolean", "true", "false", "double", "float", "string", "int", "array", "resource", "mixed", "null", "callable", "void", "object":
 			continue
+		case "$this":
+			// Handle `$this` as `static` alias in phpdoc context.
+			classNames[idx] = "static"
+			continue
+		case "static":
+			// Don't resolve `static` phpdoc type annotation too early
+			// to make it possible to handle late static binding.
+			continue
 		}
 
 		if className[0] == '\\' {

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -49,6 +49,20 @@ func TestExprTypeLateStaticBinding(t *testing.T) {
 		{`$b->getStaticArrayArray()`, `\Base[][]`},
 		{`$b->getStaticArrayArray()[0][0]`, `\Base`},
 
+		{`$d->getStatic()`, `\Base|\Derived`},
+		{`$d->getStatic()->getStatic()`, `\Base|\Derived`},
+		{`$d->getStaticArray()`, `\Derived[]`},
+		{`$d->getStaticArray()[0]`, `\Derived`},
+		{`$d->getStaticArrayArray()`, `\Derived[][]`},
+		{`$d->getStaticArrayArray()[0][0]`, `\Derived`},
+
+		{`$dd->getStatic()`, `\Base|\DerivedDerived`},
+		{`$dd->getStatic()->getStatic()`, `\Base|\DerivedDerived`},
+		{`$dd->getStaticArray()`, `\DerivedDerived[]`},
+		{`$dd->getStaticArray()[0]`, `\DerivedDerived`},
+		{`$dd->getStaticArrayArray()`, `\DerivedDerived[][]`},
+		{`$dd->getStaticArrayArray()[0][0]`, `\DerivedDerived`},
+
 		{`$b->initAndReturnOther1()`, `\Base`},
 		{`$b->initAndReturnOther2()`, `\Base`},
 

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -17,6 +17,179 @@ import (
 // Tests in this file make it less likely that type solving will break
 // without being noticed.
 
+// TODO(quasilyte): better handling of an `empty_array` type.
+// Now it's resolved to `array` for expressions that have multiple empty_array.
+
+func TestExprTypeLateStaticBinding(t *testing.T) {
+	tests := []exprTypeTest{
+		{`getBase()`, `\Base`},
+		{`getDerived()`, `\Base|\Derived`},
+		{`getBase2()`, `\Base`},
+		{`getDerived2()`, `\Base|\Derived`},
+		{`getBase2()->getStatic()->getStatic()`, `\Base`},
+		{`getDerived2()->getStatic()->getStatic()`, `\Base|\Derived`},
+		{`eitherDerived()`, `\Derived|\DerivedDerived`},
+		{`eitherDerived()->getStatic()`, `\Base|\Derived|\DerivedDerived`},
+
+		{`Base::staticNewStatic()`, `\Base`},
+		{`Base::staticNewStatic()->staticNewStatic()`, `\Base`},
+		{`Derived::staticNewStatic()`, `\Derived`},
+		{`Derived::staticNewStatic()->staticNewStatic()`, `\Derived`},
+		{`DerivedDerived::staticNewStatic()`, `\DerivedDerived`},
+		{`DerivedDerived::staticNewStatic()->staticNewStatic()`, `\DerivedDerived`},
+
+		{`$b->newStatic()`, `\Base`},
+		{`$d->newStatic()`, `\Derived`},
+		{`$dd->newStatic()`, `\DerivedDerived`},
+
+		{`$b->getStatic()`, `\Base`},
+		{`$b->getStatic()->getStatic()`, `\Base`},
+		{`$b->getStaticArray()`, `\Base[]`},
+		{`$b->getStaticArray()[0]`, `\Base`},
+		{`$b->getStaticArrayArray()`, `\Base[][]`},
+		{`$b->getStaticArrayArray()[0][0]`, `\Base`},
+
+		{`$b->initAndReturnOther1()`, `\Base`},
+		{`$b->initAndReturnOther2()`, `\Base`},
+
+		{`(new Base())->getStatic()`, `\Base`},
+		{`(new Derived())->getStatic()`, `\Base|\Derived`},
+
+		{`$d->derivedGetStatic()`, `\Derived`},
+		{`$d->derivedNewStatic()`, `\Derived`},
+		{`$dd->derivedGetStatic()`, `\Derived|\DerivedDerived`},
+		{`$dd->derivedNewStatic()`, `\DerivedDerived`},
+
+		{`$d->getStatic()`, `\Base|\Derived`},
+		{`$d->getStatic()->getStatic()`, `\Base|\Derived`},
+		{`$dd->getStatic()`, `\Base|\DerivedDerived`},
+		{`$dd->getStatic()->getStatic()`, `\Base|\DerivedDerived`},
+
+		{`$d->getStaticForOverride1()`, `null|\Derived`},
+		{`$d->getStaticForOverride2()`, `\Derived`},
+		{`$d->getStaticForOverride3()`, `\Derived`},
+		{`$dd->getStaticForOverride1()`, `null|\DerivedDerived`},
+		{`$dd->getStaticForOverride2()`, `\Derived`}, // Since $this works like `self`
+		{`$dd->getStaticForOverride3()`, `\Derived|\DerivedDerived`},
+
+		{`$dd->asParent()`, `\Derived|\DerivedDerived`},
+		{`$dd->asParent()->newStatic()`, `\Derived|\DerivedDerived`},
+		{`$dd->asParent()->asParent()`, `\Derived|\DerivedDerived`},
+
+		// Resolving of `$this` (which should be identical to `static`).
+		{`$b->getThis()`, `\Base`},
+		{`$d->getThis()`, `\Base|\Derived`},
+		{`$b->getThis()->getThis()`, `\Base`},
+		{`$d->getThis()->getThis()`, `\Base|\Derived`},
+
+		// TODO: resolve $this without @return hint into `static` as well?
+		{`$b->getThisNoHint()`, `\Base`},
+		{`$d->getThisNoHint()`, `\Base`},
+		{`$dd->getThisNoHint()`, `\Base`},
+	}
+
+	global := `
+class Base {
+  /** @return $this */
+  public function getThis() { return $this; }
+
+  public function getThisNoHint() { return $this; }
+
+  /** @return static */
+  public function getStatic() { return $this; }
+
+  /** @return static[] */
+  public function getStaticArray($x) { return []; }
+
+  /** @return static[][] */
+  public function getStaticArrayArray($x) { return []; }
+
+  /** Doesn't require return type hint */
+  public function newStatic() { return new static(); }
+
+  /** @return static */
+  public function getStaticForOverride1() { return $this; }
+
+  /** @return static */
+  public function getStaticForOverride2() { return $this; }
+
+  /** @return static */
+  public function getStaticForOverride3() { return $this; }
+
+  public static function staticNewStatic() { return new static(); }
+
+  public function initAndReturnOther1() {
+    $this->other1 = new static();
+    return $this->other1;
+  }
+
+  public function initAndReturnOther2() {
+    $other2 = new static();
+    return $other2;
+  }
+
+  /** @var static */
+  public $other1;
+}
+
+class Derived extends Base {
+  /** @return static */
+  public function derivedNewStatic() { return new static(); }
+
+  /** @return static */
+  public function derivedGetStatic() { return $this; }
+
+  /** @return static */
+  public function getStaticForOverride1() { return null; }
+
+  public function getStaticForOverride2() { return $this; }
+
+  /** @return $this */
+  public function getStaticForOverride3() { return $this; }
+}
+
+class DerivedDerived extends Derived {
+  /** @return Derived */
+  public function asParent() { return $this; }
+}
+
+function getBase() {
+  return (new Base())->getStatic();
+}
+
+function getDerived() {
+  return (new Derived())->getStatic();
+}
+
+function getBase2() {
+  $b = new Base();
+  $b2 = $b->getStatic();
+  return $b2;
+}
+
+function getDerived2() {
+  $d = new Derived();
+  $d2 = $d->getStatic();
+  return $d2;
+}
+
+function eitherDerived($cond) {
+  if ($cond) {
+    return new Derived();
+  }
+  return new DerivedDerived();
+}
+`
+
+	local := `
+$b = new Base();
+$d = new Derived();
+$dd = new DerivedDerived();
+`
+
+	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
+}
+
 func TestExprTypeSimple(t *testing.T) {
 	tests := []exprTypeTest{
 		{`true`, "bool"},

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -6,6 +6,27 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestLateStaticBinding(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Base {
+  /** @return static[] */
+  public function asArray() { return []; }
+}
+
+class Derived extends Base {
+  /**
+    * Will cause "undefined method" warning if called via instance that
+    * is returned by Base.asArray without late static binding support from NoVerify.
+    */
+  public function onlyInDerived() {}
+}
+
+$x = new Derived();
+$xs = $x->asArray();
+$_ = $xs[0]->onlyInDerived();
+`)
+}
+
 func TestInterfaceConstants(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 	interface TestInterface

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -6,6 +6,50 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestLateStaticBindingForeach(t *testing.T) {
+	// This test comes from https://youtrack.jetbrains.com/issue/WI-28728.
+	// Phpstorm currently reports `hello` call in `$item->getC()->hello()`
+	// as undefined. NoVerify manages to resolve it properly.
+
+	linttest.SimpleNegativeTest(t, `<?php
+class A
+{
+    /**
+     * @return static[]
+     */
+    public static function create()
+    {
+        return [new static()];
+    }
+}
+
+class B extends A
+{
+    /**
+     * @return C
+     */
+    public function getC()
+    {
+        return new C();
+    }
+}
+
+class C
+{
+    /** Hello does nothing */
+    public function hello()
+    {
+        return 'Hello world!';
+    }
+}
+
+$b = new B();
+foreach ($b->create() as $item) {
+    $item->getC()->hello();
+}
+`)
+}
+
 func TestLateStaticBinding(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 class Base {

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -363,6 +363,9 @@ func ExprTypeLocalCustom(sc *meta.Scope, cs *meta.ClassParseState, n node.Node, 
 		f := ExprTypeLocalCustom(sc, cs, n.IfFalse, custom)
 		return meta.NewEmptyTypesMap(t.Len() + f.Len()).Append(t).Append(f)
 	case *expr.New:
+		if meta.NameNodeToString(n.Class) == "static" {
+			return meta.NewTypesMap("static")
+		}
 		nm, ok := GetClassName(cs, n.Class)
 		if ok {
 			return meta.NewTypesMap(nm)

--- a/src/solver/oop.go
+++ b/src/solver/oop.go
@@ -31,10 +31,8 @@ func GetClassName(cs *meta.ClassParseState, classNode node.Node) (className stri
 		return "", false
 	}
 
-	if className == "self" {
+	if className == "self" || className == "static" || className == "$this" {
 		className = cs.CurrentClass
-	} else if className == "static" || className == "$this" {
-		className = "static"
 	} else if className == "parent" {
 		className = cs.CurrentParentClass
 	} else if alias, ok := cs.Uses[firstPart]; ok {

--- a/src/solver/oop.go
+++ b/src/solver/oop.go
@@ -31,8 +31,10 @@ func GetClassName(cs *meta.ClassParseState, classNode node.Node) (className stri
 		return "", false
 	}
 
-	if className == "self" || className == "static" {
+	if className == "self" {
 		className = cs.CurrentClass
+	} else if className == "static" || className == "$this" {
+		className = "static"
 	} else if className == "parent" {
 		className = cs.CurrentParentClass
 	} else if alias, ok := cs.Uses[firstPart]; ok {

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -9,7 +9,23 @@ import (
 )
 
 // ResolveType resolves function calls, method calls and global variables
-func ResolveType(typ string, visitedMap map[string]struct{}) map[string]struct{} {
+func ResolveType(typ string, visitedMap map[string]struct{}) (result map[string]struct{}) {
+	r := resolver{visited: visitedMap}
+	return r.resolveType("", typ)
+}
+
+func ResolveTypes(m *meta.TypesMap, visitedMap map[string]struct{}) map[string]struct{} {
+	r := resolver{visited: visitedMap}
+	return r.resolveTypes("", m)
+}
+
+type resolver struct {
+	visited map[string]struct{}
+}
+
+func (r *resolver) resolveType(class, typ string) map[string]struct{} {
+	visitedMap := r.visited
+
 	if _, ok := visitedMap[typ]; ok {
 		return nil
 	}
@@ -25,23 +41,27 @@ func ResolveType(typ string, visitedMap map[string]struct{}) map[string]struct{}
 	case meta.WGlobal:
 		varTyp, ok := meta.Info.GetVarNameType(meta.UnwrapGlobal(typ))
 		if ok {
-			for tt := range ResolveTypes(varTyp, visitedMap) {
+			for tt := range r.resolveTypes(class, varTyp) {
 				res[tt] = struct{}{}
 			}
 		}
 	case meta.WConstant:
 		ci, ok := meta.Info.GetConstant(meta.UnwrapConstant(typ))
 		if ok {
-			for tt := range ResolveTypes(ci.Typ, visitedMap) {
+			for tt := range r.resolveTypes(class, ci.Typ) {
 				res[tt] = struct{}{}
 			}
 		}
 	case meta.WArrayOf:
-		for tt := range ResolveType(meta.UnwrapArrayOf(typ), visitedMap) {
-			res[tt+"[]"] = struct{}{}
+		for tt := range r.resolveType(class, meta.UnwrapArrayOf(typ)) {
+			if tt == "static" {
+				res[class+"[]"] = struct{}{}
+			} else {
+				res[tt+"[]"] = struct{}{}
+			}
 		}
 	case meta.WElemOf:
-		for tt := range ResolveType(meta.UnwrapElemOf(typ), visitedMap) {
+		for tt := range r.resolveType(class, meta.UnwrapElemOf(typ)) {
 			if strings.HasSuffix(tt, "[]") {
 				res[strings.TrimSuffix(tt, "[]")] = struct{}{}
 			} else if tt == "mixed" {
@@ -57,26 +77,30 @@ func ResolveType(typ string, visitedMap map[string]struct{}) map[string]struct{}
 		}
 
 		if ok {
-			return ResolveTypes(fn.Typ, visitedMap)
+			return r.resolveTypes(class, fn.Typ)
 		}
 	case meta.WInstanceMethodCall:
 		expr, methodName := meta.UnwrapInstanceMethodCall(typ)
 
-		for className := range ResolveType(expr, visitedMap) {
+		for className := range r.resolveType(class, expr) {
 			info, _, ok := FindMethod(className, methodName)
 			if ok {
-				for tt := range ResolveTypes(info.Typ, visitedMap) {
-					res[tt] = struct{}{}
+				for tt := range r.resolveTypes(className, info.Typ) {
+					if tt == "static" {
+						res[className] = struct{}{}
+					} else {
+						res[tt] = struct{}{}
+					}
 				}
 			}
 		}
 	case meta.WInstancePropertyFetch:
 		expr, propertyName := meta.UnwrapInstancePropertyFetch(typ)
 
-		for className := range ResolveType(expr, visitedMap) {
+		for className := range r.resolveType(class, expr) {
 			info, _, ok := FindProperty(className, propertyName)
 			if ok {
-				for tt := range ResolveTypes(info.Typ, visitedMap) {
+				for tt := range r.resolveTypes(class, info.Typ) {
 					res[tt] = struct{}{}
 				}
 			}
@@ -85,16 +109,55 @@ func ResolveType(typ string, visitedMap map[string]struct{}) map[string]struct{}
 		className, methodName := meta.UnwrapStaticMethodCall(typ)
 		info, _, ok := FindMethod(className, methodName)
 		if ok {
-			return ResolveTypes(info.Typ, visitedMap)
+			for tt := range r.resolveTypes(className, info.Typ) {
+				if tt == "static" {
+					res[className] = struct{}{}
+				} else {
+					res[tt] = struct{}{}
+				}
+			}
 		}
 	case meta.WStaticPropertyFetch:
 		className, propertyName := meta.UnwrapStaticPropertyFetch(typ)
 		info, _, ok := FindProperty(className, propertyName)
 		if ok {
-			return ResolveTypes(info.Typ, visitedMap)
+			return r.resolveTypes(class, info.Typ)
 		}
 	default:
 		panic(fmt.Sprintf("Unexpected type: %d", typ[0]))
+	}
+
+	return res
+}
+
+func (r *resolver) resolveTypes(class string, m *meta.TypesMap) map[string]struct{} {
+	res := make(map[string]struct{}, m.Len())
+
+	m.Iterate(func(t string) {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("Panic during parsing '%s'", meta.NewTypesMap(t))
+				panic(r)
+			}
+		}()
+
+		for tt := range r.resolveType(class, t) {
+			res[tt] = struct{}{}
+		}
+	})
+
+	if _, ok := res["empty_array"]; ok {
+		delete(res, "empty_array")
+		specialized := false
+		for tt := range res {
+			if strings.HasSuffix(tt, "[]") {
+				specialized = true
+				break
+			}
+		}
+		if !specialized {
+			res["array"] = struct{}{}
+		}
 	}
 
 	return res
@@ -275,38 +338,5 @@ func findConstant(className string, constName string, visitedClasses map[string]
 func identityType(typ string) map[string]struct{} {
 	res := make(map[string]struct{})
 	res[typ] = struct{}{}
-	return res
-}
-
-func ResolveTypes(m *meta.TypesMap, visitedMap map[string]struct{}) map[string]struct{} {
-	res := make(map[string]struct{}, m.Len())
-
-	m.Iterate(func(t string) {
-		defer func() {
-			if r := recover(); r != nil {
-				log.Printf("Panic during parsing '%s'", meta.NewTypesMap(t))
-				panic(r)
-			}
-		}()
-
-		for tt := range ResolveType(t, visitedMap) {
-			res[tt] = struct{}{}
-		}
-	})
-
-	if _, ok := res["empty_array"]; ok {
-		delete(res, "empty_array")
-		specialized := false
-		for tt := range res {
-			if strings.HasSuffix(tt, "[]") {
-				specialized = true
-				break
-			}
-		}
-		if !specialized {
-			res["array"] = struct{}{}
-		}
-	}
-
 	return res
 }


### PR DESCRIPTION
This change enables more precise handling of `$this` and `static`
types that are quite common in Fluent APIs.

The idea is to carry the current class type along the type resolving
and map "static" pseudo-type into concrete class type.

Fixes #89

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>