### PR TITLE
Add tests for SimpleXMLElement/Iterator support

### DIFF
--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -20,6 +20,29 @@ import (
 // TODO(quasilyte): better handling of an `empty_array` type.
 // Now it's resolved to `array` for expressions that have multiple empty_array.
 
+func TestExprTypeMagicGet(t *testing.T) {
+	tests := []exprTypeTest{
+		{`(new Ints)->a`, `int`},
+		{`$ints->a`, `int`},
+		{`$ints->b`, `int`},
+		{`(new Chain)->chain`, `\Chain`},
+		{`$chain->chain`, `\Chain`},
+		{`$chain->chain->chain`, `\Chain`},
+	}
+
+	global := `<?php
+class Ints {
+  public function __get($k) { return 0; }
+}
+class Chain {
+  public function __get($k) { return $this; }
+}`
+	local := `
+$ints = new Ints();
+$chain = new Chain();`
+	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
+}
+
 func TestExprTypeLateStaticBinding(t *testing.T) {
 	tests := []exprTypeTest{
 		{`getBase()`, `\Base`},

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -6,6 +6,44 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestSimpleXMLElement(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class SimpleXMLElement {
+  private function __get($name) {}
+  /** @return static[] */
+  public function xpath ($path) {}
+}
+
+class SimpleXMLIterator extends SimpleXMLElement {
+  /** @return SimpleXMLIterator|null */
+  public function current () {}
+}
+
+function simpleElement($xml_str) {
+  $el = new SimpleXMLElement("<a></a>", 0);
+  $iters = $el->xpath("/a");
+  $_ = $iters[0]->foo;
+  $_ = $el->foo;
+}
+
+function simpleIterator($xml_str) {
+  $el = new SimpleXMLIterator("<a></a>", 0);
+  $iters = $el->xpath("/a");
+  $root = $iters[0];
+  $_ = $iters[0]->current();
+  $_ = $root->current();
+  $_ = $root->current()->foo;
+}
+
+function simpleIteratorReassign($xml_string) {
+  $el = new SimpleXMLIterator("<a></a>", 0);
+  $iter = $el->xpath("/a");
+  $iter = $iter[0];
+  $_ = $iter->current();
+}
+`)
+}
+
 func TestLateStaticBindingForeach(t *testing.T) {
 	// This test comes from https://youtrack.jetbrains.com/issue/WI-28728.
 	// Phpstorm currently reports `hello` call in `$item->getC()->hello()`

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -6,9 +6,29 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestMagicGetChaining(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Magic {
+  /** @return Magic */
+  public function __get($key) {
+    return $this;
+  }
+
+  /** Method that does nothing */
+  public function method() {}
+}
+
+$m = new Magic();
+$m->method();
+$m->foo->method();
+$m->foo->bar->method();
+`)
+}
+
 func TestSimpleXMLElement(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 class SimpleXMLElement {
+  /** @return SimpleXMLElement */
   private function __get($name) {}
   /** @return static[] */
   public function xpath ($path) {}
@@ -24,6 +44,8 @@ function simpleElement($xml_str) {
   $iters = $el->xpath("/a");
   $_ = $iters[0]->foo;
   $_ = $el->foo;
+  $_ = $el->foo->bar;
+  $_ = $el->foo->bar->xpath("/a");
 }
 
 function simpleIterator($xml_str) {

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -103,6 +103,14 @@ func (r *resolver) resolveType(class, typ string) map[string]struct{} {
 				for tt := range r.resolveTypes(class, info.Typ) {
 					res[tt] = struct{}{}
 				}
+			} else {
+				// If there is a __get method, it might have
+				// a @return annotation that will help to
+				// get appropriate type for dynamic property lookup.
+				get, _, ok := FindMethod(className, "__get")
+				if ok {
+					return r.resolveTypes(class, get.Typ)
+				}
 			}
 		}
 	case meta.WStaticMethodCall:


### PR DESCRIPTION
Now that NoVerify understands `static` type,
given appropriate annotations, it can handle SimpleXMLElement
without any hacks.

An example of such (proper) types annotation:
	https://github.com/VKCOM/phpstorm-stubs/commit/faff1841c257873c35abfacf09cf8fac2fb3bdaa

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>