### PR TITLE
cmd: remove unused -git-local flag

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -31,8 +31,7 @@ var (
 var (
 	outputFp io.Writer = os.Stderr
 
-	gitRepo    string
-	isGitLocal bool
+	gitRepo string
 
 	pprofHost string
 
@@ -100,7 +99,6 @@ func bindFlags() {
 	flag.StringVar(&pprofHost, "pprof", "", "HTTP pprof endpoint (e.g. localhost:8080)")
 
 	flag.StringVar(&gitRepo, "git", "", "Path to git repository to analyze")
-	flag.BoolVar(&isGitLocal, "git-local", false, "Analyze local changes in git (everything not yet pushed)")
 	flag.StringVar(&gitCommitFrom, "git-commit-from", "", "Analyze changes between commits <git-commit-from> and <git-commit-to>")
 	flag.StringVar(&gitCommitTo, "git-commit-to", "", "")
 	flag.StringVar(&gitRef, "git-ref", "", "Ref (e.g. branch) that is being pushed")


### PR DESCRIPTION
It's defined but not used.
Remove for now to avoid misliading info in -help output.

If it's needed, it can be returned back and
be actually implemented.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>