### PR TITLE
improve handling of invalid phpdoc annotations

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -911,10 +911,10 @@ func (d *RootWalker) parsePHPDoc(doc string, actualParams []node.Node) (returnTy
 			if strings.HasPrefix(typ, "$") {
 				phpDocErrors = append(phpDocErrors, fmt.Sprintf("malformed @param %s tag (maybe type is missing?) on line %d",
 					fields[1], idx+1))
+				continue
 			} else {
 				phpDocErrors = append(phpDocErrors, fmt.Sprintf("malformed @param tag (maybe var is missing?) on line %d", idx+1))
 			}
-			continue
 		}
 
 		if len(fields) >= 3 && strings.HasPrefix(typ, "$") && !strings.HasPrefix(variable, "$") {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -909,10 +909,12 @@ func (d *RootWalker) parsePHPDoc(doc string, actualParams []node.Node) (returnTy
 		} else {
 			// Either type of var name is missing.
 			if strings.HasPrefix(typ, "$") {
-				phpDocErrors = append(phpDocErrors, fmt.Sprintf("malformed @param tag (maybe type is missing?) on line %d", idx+1))
+				phpDocErrors = append(phpDocErrors, fmt.Sprintf("malformed @param %s tag (maybe type is missing?) on line %d",
+					fields[1], idx+1))
 			} else {
 				phpDocErrors = append(phpDocErrors, fmt.Sprintf("malformed @param tag (maybe var is missing?) on line %d", idx+1))
 			}
+			continue
 		}
 
 		if len(fields) >= 3 && strings.HasPrefix(typ, "$") && !strings.HasPrefix(variable, "$") {

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -20,6 +20,26 @@ import (
 // TODO(quasilyte): better handling of an `empty_array` type.
 // Now it's resolved to `array` for expressions that have multiple empty_array.
 
+func TestExprTypeMalformedPhpdoc(t *testing.T) {
+	tests := []exprTypeTest{
+		{`return_mixed(0)`, ``},
+		{`return_int(0)`, `int`},
+	}
+
+	global := `<?php
+/**
+ * @param $x
+ */
+function return_mixed($x) { return $x; }
+
+/**
+ * @param int
+ */
+function return_int($x) { return $x; }
+`
+	runExprTypeTest(t, &exprTypeTestContext{global: global}, tests)
+}
+
 func TestExprTypeMagicGet(t *testing.T) {
 	tests := []exprTypeTest{
 		{`(new Ints)->a`, `int`},
@@ -541,6 +561,10 @@ func runExprTypeTest(t *testing.T, ctx *exprTypeTestContext, tests []exprTypeTes
 }
 
 func makeType(typ string) map[string]struct{} {
+	if typ == "" {
+		return map[string]struct{}{}
+	}
+
 	res := make(map[string]struct{})
 	for _, t := range strings.Split(typ, "|") {
 		res[t] = struct{}{}

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -1,11 +1,41 @@
-package linttest
+package linttest_test
 
 import (
 	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestBadPhpdocTypes(t *testing.T) {
+	// If there is an incorrect phpdoc annotation,
+	// don't use it as a type info.
+	//
+	// Before the fix, NoVerify inferred \$a and \$b to be
+	// types for corresponding params, which is incorrect.
+
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+/**
+ * @param $a
+ * @param $b
+ * @return int
+ */
+function fav_func($a, $b) {
+  if ($a[0] != $b[0]) {
+    return ($a[0] > $b[0]) ? -1 : 1;
+  }
+  return ($a[1] < $b[1]) ? -1 : 1;
+}
+`)
+	test.Expect = []string{
+		`PHPDoc is incorrect: malformed @param $a tag (maybe type is missing?)`,
+		`PHPDoc is incorrect: malformed @param $b tag (maybe type is missing?)`,
+	}
+	test.RunAndMatch()
+}
+
 func TestPHPDocPresence(t *testing.T) {
-	test := NewSuite(t)
+	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 	trait TheTrait {
 		public function traitPub() {}
@@ -34,7 +64,7 @@ func TestPHPDocPresence(t *testing.T) {
 }
 
 func TestPHPDocSyntax(t *testing.T) {
-	test := NewSuite(t)
+	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 	/**
 	 * @param $x int the x param
@@ -53,14 +83,14 @@ func TestPHPDocSyntax(t *testing.T) {
 		`expected a type, found '-'; if you want to express 'any' type, use 'mixed' on line 3`,
 		`non-canonical order of variable and type on line 4`,
 		`expected a type, found '-'; if you want to express 'any' type, use 'mixed' on line 4`,
-		`malformed @param tag (maybe type is missing?) on line 5`,
+		`malformed @param $a tag (maybe type is missing?) on line 5`,
 		`malformed @param tag (maybe var is missing?) on line 6`,
 	}
 	test.RunAndMatch()
 }
 
 func TestPHPDocType(t *testing.T) {
-	test := NewSuite(t)
+	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 	/**
 	 * @param [][]string $x1


### PR DESCRIPTION
When `@param` annotation misses variable type,
we should ignore it instead of using the variable name as a type.

Before this fix, NoVerify inferred \$a to be a type for $a
parameter out of `@param $a` line.

This fix is required to avoid false positives from arrayAccess.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>