### PR TITLE
add a test for assignments in for loops

### DIFF
--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -10,6 +10,18 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestAssignmentsInForLoop(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+function increment($i) { return $i + 1; }
+
+for ($i = 0; $i <= 10; $i = increment($i)) {}
+for ($i = increment(0); $i <= 10; $i = $i + 1) {}
+for ($i = 0; $i == 0; $i++) {}
+for ($i = 0; $i == 0; ++$i) {}
+for ($i = 0; $i == 0; $i = $i++) {}
+`)
+}
+
 func TestCustomUnusedVarRegex(t *testing.T) {
 	defer func(isDiscardVar func(string) bool) {
 		linter.IsDiscardVar = isDiscardVar


### PR DESCRIPTION
There are reports that this caused warnings in past.
Can't reproduce them now, but tests are still usefull
to avoid unexpected regression.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>