### PR TITLE
treat ...$ variadic param as optional

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -980,7 +980,7 @@ func (d *RootWalker) parseFuncArgs(params []node.Node, parTypes phpDocParamsMap,
 
 		typ := parTyp.typ
 
-		if p.DefaultValue == nil && !parTyp.optional {
+		if p.DefaultValue == nil && !parTyp.optional && !p.Variadic {
 			minArgs++
 		}
 

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -255,6 +255,7 @@ func TestVariadic(t *testing.T) {
 	}
 
 	echo a(new TestClass()), "\n";
+	echo a(); // OK to call with 0 arguments.
 	`)
 }
 


### PR DESCRIPTION
This is required to fix argCount warning about
"not enough" arguments when 0 args are passed for
variadic parameter.

Added a test case that covers that.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>