### PR TITLE
walk switch "case" clauses during analysis

### DIFF
--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -138,6 +138,14 @@ func TestUnusedInSwitch(t *testing.T) {
 				}
 			}
 		}
+	}
+	function insideCase($a, $b) {
+		$b2 = $b;
+		switch ($a) {
+		case $b2['key']:
+			return 10;
+		}
+		return 20;
 	}`)
 	test.Expect = []string{`Unused variable x`}
 	runFilterMatch(test, "unused")


### PR DESCRIPTION
If we don't do it, we can miss some important code
fragements, like variable usages.

This change modifies getCaseStmts method so it
returns <case cond, body statements> instead of
<isDefault, body statements>. It's still trivial
to check case cond for nil to determine "default"
case, but it's also easy to walk case expression
at the same time.

Fixes #109

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>