### PR TITLE
cmd: remove inplace reports filtering

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -206,7 +206,7 @@ func buildCheckMappings() {
 }
 
 func analyzeReports(diff []*linter.Report) (criticalReports int) {
-	filtered := diff[:0]
+	filtered := make([]*linter.Report, 0, len(diff))
 	for _, r := range diff {
 		if !isEnabled(r) {
 			continue


### PR DESCRIPTION
Allocate new slice for results instead.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>