### PR TITLE
fix false positives with instanceof

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1377,7 +1377,7 @@ func (b *BlockWalker) handleIf(s *stmt.If) bool {
 		for _, instanceof := range a.instanceOfs {
 			if className, ok := solver.GetClassName(b.r.st, instanceof.Class); ok {
 				if v, ok := instanceof.Expr.(*expr.Variable); ok {
-					b.addVar(v, meta.NewTypesMap(className), "instanceof", false)
+					b.sc.AddVar(v, meta.NewTypesMap(className), "instanceof", false)
 				} else {
 					b.customTypes = append(b.customTypes, solver.CustomType{
 						Node: instanceof.Expr,

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -153,6 +153,39 @@ echo "quite reachable\n";
 `)
 }
 
+func TestUnusedInInstanceof(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Foo {}
+
+function f1($cond) {
+  global $g;
+  $x = $g;
+  if ($x instanceof Foo) {
+    // Do nothing.
+  }
+  if ($cond) {
+    $_ = $x; // Use $x
+    if ($x instanceof Foo) {
+      // Should not warn about unused var.
+    }
+  }
+}
+
+function f2() {
+  global $v;
+  return $v instanceof Foo;
+}
+
+function f3() {
+  global $v;
+  if ($v instanceof Foo) {
+    return 1;
+  }
+  return 0;
+}
+`)
+}
+
 func TestUnusedInPropFetch(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
When instanceof is inside if condition, it introduces
a new tracked var via b.addVar().
It seems to be incorrect for cases where added variable
was already used above.
Given that we enter (walk) instanceof LHS before
we add that new variable, instanceof itself doesn't
end up marking that variable as used.

This change makes linter stop tracking instanceof LHS.
(We add it to the scope directly instead.)

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>