### PR TITLE
fix BlockContext.RootState panic

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -111,7 +111,7 @@ func (b *BlockWalker) PrematureExitFlags() int {
 
 // RootState returns state that was stored in root context (if any) for use in custom hooks.
 func (b *BlockWalker) RootState() map[string]interface{} {
-	return b.r.customState
+	return b.r.State()
 }
 
 // IsRootLevel returns whether or not we currently analyze root level code.


### PR DESCRIPTION
If block context RootState is called before RootContext.State(),
then we're returning nil map that can cause nil map assignment panic.

If block checkers used to collect info and propagate it to the
root context that can handle "before leave file", we should
call State() method that does map allocation in case it's nil.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>