### PR TITLE
predefine argc and argv vars for the global scope

### DIFF
--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -146,8 +146,11 @@ func analyzeFile(filename string, contents []byte, parser *php7.Parser, lineRang
 // This method is exposed for language server use, you usually
 // do not need to call it yourself.
 func AnalyzeFileRootLevel(rootNode node.Node, d *RootWalker) {
+	sc := meta.NewScope()
+	sc.AddVarName("argv", meta.NewTypesMap("string[]"), "predefined", true)
+	sc.AddVarName("argc", meta.NewTypesMap("int"), "predefined", true)
 	b := &BlockWalker{
-		sc:                   meta.NewScope(),
+		sc:                   sc,
 		r:                    d,
 		unusedVars:           make(map[string][]node.Node),
 		nonLocalVars:         make(map[string]struct{}),


### PR DESCRIPTION
When doing root level code analysis using BlockWalker,
predefine argc and argv variables, so they don't cause
"undefined variable" warnings inside global scope.

This doesn't break the requirement to do `global $argc`
or `global $argv` when using them from non-global scope.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>