### PR TITLE
improve handling of if conditions

### DIFF
--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -645,6 +645,49 @@ func TestIssetVarVar1(t *testing.T) {
 	test.RunAndMatch()
 }
 
+func TestIssetShortCircuit(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+class Value {
+  public $x;
+}
+
+function count($arr) { return 0; }
+
+function good($v) {
+  if (isset($good) && count($good) == 1) {}
+
+  if ($v instanceof Value && $v->x) {}
+  if (isset($y) && $y instanceof Value && $y->x) {}
+}
+
+function bad1($v) {
+  if (isset($bad0) && $bad0) {}
+  $_ = $bad0; // Used outside of if body
+
+  if (count($bad1) == 1 && isset($bad1)) {}
+  if (isset($good) && count($bad2) == 1 && isset($bad2)) {}
+  if (isset($bad3) || count($bad3) == 1) {}
+
+  if ($v->x && $v instanceof Value) {}
+
+  if ($y1 instanceof Value && isset($y1) && $y1->x) {}
+}
+
+$_ = $bad1;
+`)
+	test.Expect = []string{
+		`Undefined variable: bad0`,
+		`Undefined variable: bad1`, // At local scope
+		`Undefined variable: bad1`, // At global scope
+		`Undefined variable: bad2`,
+		`Undefined variable: bad3`,
+		`Property {}->x does not exist`,
+		`Variable might have not been defined: y1`,
+	}
+	test.RunAndMatch()
+}
+
 func TestUnused(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
Move isset/!empty/instanceof handling inside andWalker,
so we check all expressions and define vars sequentially,
following the && operator short-circuit behavior.

Helps to avoid false positives in:

	if (isset($x) && use($x)) {...}

Fixes #128

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>