### PR TITLE
add "deprecated" check for functions and methods

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -16,7 +16,7 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
-const cacheVersion = 25
+const cacheVersion = 26
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -122,6 +122,12 @@ func init() {
 			Default: true,
 			Comment: `Report suspicious 'continue' usages inside switch cases.`,
 		},
+
+		{
+			Name:    "deprecated",
+			Default: false, // Experimental
+			Comment: `Report usages of deprecated symbols.`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -6,6 +6,58 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestDeprecatedMethod(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+class Foo {
+  /**
+   * @deprecated use newMethod instead
+   */
+  public function legacyMethod1() {}
+
+  /**
+   * @deprecated
+   */
+  public function legacyMethod2() {}
+}
+
+(new Foo())->legacyMethod1();
+function f() {
+  (new Foo())->legacyMethod2();
+}
+`)
+	test.Expect = []string{
+		`Call to deprecated method {\Foo}->legacyMethod1() (use newMethod instead)`,
+		`Call to deprecated method {\Foo}->legacyMethod2()`,
+	}
+	test.RunAndMatch()
+}
+
+func TestDeprecatedFunction(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+/**
+ * @deprecated use new_function instead
+ */
+function legacy_function1() {}
+
+/**
+ * @deprecated
+ */
+function legacy_function2() {}
+
+legacy_function1();
+function f() {
+  legacy_function2();
+}
+`)
+	test.Expect = []string{
+		`Call to deprecated function legacy_function1 (use new_function instead)`,
+		`Call to deprecated function legacy_function2`,
+	}
+	test.RunAndMatch()
+}
+
 func TestBadPhpdocTypes(t *testing.T) {
 	// If there is an incorrect phpdoc annotation,
 	// don't use it as a type info.

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -263,6 +263,11 @@ type FuncParam struct {
 	Typ   *TypesMap
 }
 
+type PhpDocInfo struct {
+	Deprecated      bool
+	DeprecationNote string
+}
+
 type FuncInfo struct {
 	Pos          ElementPosition
 	Params       []FuncParam
@@ -270,6 +275,7 @@ type FuncInfo struct {
 	Typ          *TypesMap
 	AccessLevel  AccessLevel
 	ExitFlags    int // if function has exit/die/throw, then ExitFlags will be <> 0
+	Doc          PhpDocInfo
 }
 
 type OverrideType int


### PR DESCRIPTION
This change adds basic support for detecting usages of
deprecated functions and methods.

We might extend it to also warn about different
deprecated symbols (like classes), but initial feature
request only asked about functions.

For this code:

	mysql('a', 'b', 'c');

Gives a warning:

	Call to deprecated function mysql (5.3.0 Use mysql_db_query instead.)

Updates #15

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>