### PR TITLE
use embedded stubs by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 phplinter.sh
 phplinter
 err.log
+src/cmd/stubs/phpstorm-stubs/

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Cache dir is optional, but recommended. Next launch would be much faster with ca
 By default, "embedded" phpstorm-stubs are used.
 If there is some error during the NoVerify run, like "failed to load embedded stubs", try
 to provide explicit (non-empty) `-stubs-dir` argument. That argument expects a path to a cloned
-phpstorm-stubs repository. You can use either [upstream version](https://github.com/JetBrains/phpstorm-stubs) or [VKCOM fork](https://github.com/VKCOM/phpstorm-stubs) that contains
+phpstorm-stubs repository. You can use either the [upstream version](https://github.com/JetBrains/phpstorm-stubs) or [VKCOM fork](https://github.com/VKCOM/phpstorm-stubs) that contains
 several fixes that are important for static analysis.
 
 Running NoVerify with custom phpstorm-stubs can look like this:

--- a/README.md
+++ b/README.md
@@ -45,10 +45,9 @@ using === operator. See [example](/example) folder to see some examples of custo
 
 ## Installation
 
-In order to install NoVerify, you will need the following:
+In order to install NoVerify, you will need the Go toolchain (https://golang.org/).
 
-1. Go toolchain (https://golang.org/)
-2. PHPStorm stubs cloned somewhere (https://github.com/JetBrains/phpstorm-stubs)
+> Optionally, you could also get PHPStorm stubs (https://github.com/JetBrains/phpstorm-stubs).
 
 Once go is installed, you need to execute the following:
 
@@ -66,10 +65,22 @@ translates to `$HOME/go/bin/noverify`.
 In order to get reports for all files in repository, run the following:
 
 ```sh
-$ noverify -stubs-dir=/path/to/phpstorm-stubs -cache-dir=$HOME/tmp/cache/noverify /path/to/your/project/root
+$ noverify -cache-dir=$HOME/tmp/cache/noverify /path/to/your/project/root
 ```
 
-You need to specify path to cloned phpstorm-stubs dir (https://github.com/JetBrains/phpstorm-stubs) and directory for cache. Next launch would be much faster with cache if you specify some cache directory.
+Cache dir is optional, but recommended. Next launch would be much faster with cache if you specify some cache directory.
+
+By default, "embedded" phpstorm-stubs are used.
+If there is some error during the NoVerify run, like "failed to load embedded stubs", try
+to provide explicit (non-empty) `-stubs-dir` argument. That argument expects a path to a cloned
+phpstorm-stubs repository. You can use either [upstream version](https://github.com/JetBrains/phpstorm-stubs) or [VKCOM fork](https://github.com/VKCOM/phpstorm-stubs) that contains
+several fixes that are important for static analysis.
+
+Running NoVerify with custom phpstorm-stubs can look like this:
+
+```sh
+$ noverify -stubs-dir=/path/to/phpstorm-stubs -cache-dir=$HOME/tmp/cache/noverify /path/to/your/project/root
+```
 
 The command will print you some progress messages and reports like that:
 
@@ -107,7 +118,6 @@ noverify\
     -git-commit-to=$ref\
     -git-ref=refs/heads/$ref\
     -git-work-tree=.\
-    -stubs-dir=/path/to/phpstorm-stubs\
     -cache-dir=$HOME/tmp/cache/noverify
 ```
 
@@ -117,7 +127,6 @@ Here is the short summary of options used here:
  - `-git-commit-from` and `-git-commit-to` specify range of commits to analyze
  - `-git-ref` is name of pushed branch
  - `-git-work-tree` is an optional parameter that you can specify if you want to be able to analyze uncommited changes too
- - `-stubs-dir` is the path to phpstorm-stubs dir (https://github.com/JetBrains/phpstorm-stubs)
  - `-cache-dir` is an optional directory for cache (greatly increases indexing speed)
 
 ### Disable some reports
@@ -141,7 +150,7 @@ $x = array($v, 2);
 By default, NoVerify would report 2 issues:
 
 ```sh
-$ noverify -stubs-dir /path/to/stubs hello.php
+$ noverify hello.php
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at /home/quasilyte/CODE/php/hello.php:3
 $x = array($v, 2);
      ^^^^^^^^^^^^
@@ -153,7 +162,7 @@ $x = array($v, 2);
 The `arraySyntax` and `undefined` are so-called "check names" which you can use to disable associated reports.
 
 ```sh
-$ noverify -exclude-checks arraySyntax,undefined -stubs-dir /path/to/stubs hello.php
+$ noverify -exclude-checks arraySyntax,undefined hello.php
 # No warnings
 ```
 
@@ -167,7 +176,7 @@ it by passing your own comma-separated list of check names instead:
 
 ```sh
 # Run only 2 checks, undefined and deadCode.
-$ noverify -allow-checks undefined,deadCode -stubs-dir /path/to/stubs hello.php
+$ noverify -allow-checks undefined,deadCode hello.php
 ```
 
 You can use it in combination with `-exclude-checks`.
@@ -178,7 +187,7 @@ Exclusion rules are applied after inclusion rules are applied.
 If you want to launch noverify in language server mode, launch it in your IDE/editor extension like the following:
 
 ```sh
-$ noverify -lang-server -cores=4 -cache-dir=/path/to/cache -stubs-dir=/path/to/phpstorm-stubs
+$ noverify -lang-server -cores=4 -cache-dir=/path/to/cache
 ```
 
 ## Visual Studio Code integration
@@ -201,7 +210,7 @@ You can install https://github.com/tomv564/LSP using Package Control. Here is an
 {
   "clients": {
     "phpls": {
-      "command": ["/path/to/noverify", "-cache-dir=/path/to/cache", "-stubs-dir=/path/to/phpstorm-stubs", "-cores=4", "-lang-server"],
+      "command": ["/path/to/noverify", "-cache-dir=/path/to/cache", "-cores=4", "-lang-server"],
       "scopes": ["source.php", "embedding.php"],
       "syntaxes": ["Packages/PHP/PHP.sublime-syntax"],
       "languageId": "php"

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -111,7 +111,7 @@ func bindFlags() {
 	flag.IntVar(&linter.MaxConcurrency, "cores", runtime.NumCPU(), "max cores")
 	flag.BoolVar(&linter.LangServer, "lang-server", false, "Run language server for VS Code")
 	flag.StringVar(&linter.DefaultEncoding, "encoding", "UTF-8", "Default encoding. Only UTF-8 and windows-1251 are supported")
-	flag.StringVar(&linter.StubsDir, "stubs-dir", "/path/to/phpstorm-stubs", "phpstorm-stubs directory")
+	flag.StringVar(&linter.StubsDir, "stubs-dir", "", "phpstorm-stubs directory")
 	flag.StringVar(&linter.CacheDir, "cache-dir", "", "Directory for linter cache (greatly improves indexing speed)")
 
 	flag.StringVar(&unusedVarPattern, "unused-var-regex", `^_$`,

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -329,7 +329,8 @@ func loadEmbeddedStubs() error {
 	linter.ParseFilenames(readStubs)
 	meta.Info.InitStubs()
 
-	if errorsCount != 0 {
+	// Using atomic here for consistency.
+	if atomic.LoadInt64(&errorsCount) != 0 {
 		return fmt.Errorf("failed to load %d embedded files", errorsCount)
 	}
 


### PR DESCRIPTION
Use github.com/go-bindata/go-bindata to pack github.com/VKCOM/phpstorm-stubs
into src/cmd/stubs and use it from the compiled binary from default.

To re-generate stubs, the following steps should be used:

	1. Clone github.com/VKCOM/phpstorm-stubs into src/cmd/stubs
	2. Run "go generate"

(Comments inside code tell the same.)

The phpstorm-stubs folder (git repo) is ignored,
generated file (phpstorm_stubs.go) is commited.

If user provides explicit -stubs-dir override, use that instead.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>