### PR TITLE
Fix "modifiers" check tag.

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -590,7 +590,7 @@ func (d *RootWalker) parseMethodModifiers(meth *stmt.ClassMethod) (res methodMod
 		case "final":
 			res.final = true
 		default:
-			d.Report(m, LevelWarning, "modifiers: Unrecognized method modifier: %s", v)
+			d.Report(m, LevelWarning, "modifiers", "Unrecognized method modifier: %s", v)
 		}
 	}
 

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -6,6 +6,21 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestBadModifiers(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+class Foo {
+  /***/
+  PUBLIC Static function f() {}
+}
+`)
+	test.Expect = []string{
+		`Unrecognized method modifier: PUBLIC`,
+		`Unrecognized method modifier: Static`,
+	}
+	test.RunAndMatch()
+}
+
 func TestInheritDoc(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
It was using old convention where tag was a part of the
message separated by `:`.

Unfortunately, both tag and message have string type,
therefore code continued to compile, but tag was invalid
and the check never worked since it's registered by a different tag.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>