### PR TITLE
add -critical command line argument

### DIFF
--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -32,8 +32,10 @@ var (
 
 	reportsExclude          string
 	reportsExcludeChecks    string
+	reportsCritical         string
 	reportsExcludeChecksSet map[string]bool
 	reportsIncludeChecksSet map[string]bool
+	reportsCriticalSet      map[string]bool
 
 	allowChecks       string
 	allowDisable      string
@@ -81,6 +83,9 @@ func bindFlags() {
 	}
 
 	flag.StringVar(&pprofHost, "pprof", "", "HTTP pprof endpoint (e.g. localhost:8080)")
+
+	flag.StringVar(&reportsCritical, "critical", "",
+		"Comma-separated list of check names that are considered critical (all non-maybe checks by default)")
 
 	flag.StringVar(&gitRepo, "git", "", "Path to git repository to analyze")
 	flag.StringVar(&gitCommitFrom, "git-commit-from", "", "Analyze changes between commits <git-commit-from> and <git-commit-to>")

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -12,6 +12,8 @@ import (
 	"github.com/VKCOM/noverify/src/linter"
 )
 
+const allNonMaybe = "<all-non-maybe>"
+
 var (
 	outputFp io.Writer = os.Stderr
 
@@ -84,7 +86,7 @@ func bindFlags() {
 
 	flag.StringVar(&pprofHost, "pprof", "", "HTTP pprof endpoint (e.g. localhost:8080)")
 
-	flag.StringVar(&reportsCritical, "critical", "",
+	flag.StringVar(&reportsCritical, "critical", allNonMaybe,
 		"Comma-separated list of check names that are considered critical (all non-maybe checks by default)")
 
 	flag.StringVar(&gitRepo, "git", "", "Path to git repository to analyze")

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -222,7 +222,9 @@ func buildCheckMappings() {
 
 	reportsExcludeChecksSet = stringToSet(reportsExcludeChecks)
 	reportsIncludeChecksSet = stringToSet(allowChecks)
-	reportsCriticalSet = stringToSet(reportsCritical)
+	if reportsCritical != allNonMaybe {
+		reportsCriticalSet = stringToSet(reportsCritical)
+	}
 }
 
 func analyzeReports(diff []*linter.Report) (criticalReports int) {

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -270,7 +270,11 @@ func analyzeReports(diff []*linter.Report) (criticalReports int) {
 			fmt.Fprintf(outputFp, "%s\n", err)
 		}
 		for _, r := range filtered {
-			fmt.Fprintf(outputFp, "%s\n", r.String())
+			if isCritical(r) {
+				fmt.Fprintf(outputFp, "<critical> %s\n", r.String())
+			} else {
+				fmt.Fprintf(outputFp, "%s\n", r.String())
+			}
 		}
 	}
 


### PR DESCRIPTION
-critical expects a comma-separated list of check names
that will cause "critical reports" count go up and make
NoVerify perform non-zero exit status in the end.

If no -critical is specified (or empty string is given),
old behavior is used, all reports except of MAYBE level
are considered critical.

Fixes #140
Fixes #66
Updates #58

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>