### PR TITLE
split phpdoc into phpdoc and phpdocLint

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1222,7 +1222,7 @@ func (b *BlockWalker) enterClosure(fun *expr.Closure, haveThis bool, thisType *m
 	phpDocParamTypes := phpdoc.types
 
 	for _, err := range phpDocError {
-		b.r.Report(fun, LevelInformation, "phpdoc", "PHPDoc is incorrect: %s", err)
+		b.r.Report(fun, LevelInformation, "phpdocLint", "PHPDoc is incorrect: %s", err)
 	}
 
 	for _, useExpr := range fun.Uses {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -82,9 +82,15 @@ func init() {
 		},
 
 		{
-			Name:    "phpdoc",
+			Name:    "phpdocLint",
 			Default: true,
 			Comment: `Report malformed phpdoc comments.`,
+		},
+
+		{
+			Name:    "phpdoc",
+			Default: true,
+			Comment: `Report missing phpdoc on public methods.`,
 		},
 
 		{

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -657,7 +657,7 @@ func (d *RootWalker) enterPropertyList(pl *stmt.PropertyList) bool {
 
 		typ, errText := d.parsePHPDocVar(p.PhpDocComment)
 		if errText != "" {
-			d.Report(p.Variable, LevelWarning, "phpdoc", errText)
+			d.Report(p.Variable, LevelWarning, "phpdocLint", errText)
 		}
 
 		if p.Expr != nil {
@@ -745,7 +745,7 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 	phpDocParamTypes := phpdoc.types
 
 	for _, err := range phpDocError {
-		d.Report(meth.MethodName, LevelInformation, "phpdoc", "PHPDoc is incorrect: %s", err)
+		d.Report(meth.MethodName, LevelInformation, "phpdocLint", "PHPDoc is incorrect: %s", err)
 	}
 
 	class := d.getClass()
@@ -1136,7 +1136,7 @@ func (d *RootWalker) enterFunction(fun *stmt.Function) bool {
 	phpDocParamTypes := phpdoc.types
 
 	for _, err := range phpDocError {
-		d.Report(fun.FunctionName, LevelInformation, "phpdoc", "PHPDoc is incorrect: %s", err)
+		d.Report(fun.FunctionName, LevelInformation, "phpdocLint", "PHPDoc is incorrect: %s", err)
 	}
 
 	if d.meta.Functions == nil {


### PR DESCRIPTION
phpdoc only checks for phpdoc existence.
phpdocLint checks phpdoc comment correctness.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>