### PR TITLE
use flag.Args() as index-only targets in git/diff mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ noverify\
     -git-ref=refs/heads/$ref\
     -git-work-tree=.\
     -cache-dir=$HOME/tmp/cache/noverify
+    generated/a.php\
+    generated/web
 ```
 
 Here is the short summary of options used here:
@@ -128,6 +130,12 @@ Here is the short summary of options used here:
  - `-git-ref` is name of pushed branch
  - `-git-work-tree` is an optional parameter that you can specify if you want to be able to analyze uncommited changes too
  - `-cache-dir` is an optional directory for cache (greatly increases indexing speed)
+ - rest arguments are index-only targets (see below)
+
+If you have files that are not a part of a git repository (i.e. they are ignored),
+you need to specify those files explicitly as additional command-line arguments.
+Including these files in git mode will only index them.
+If you want to actually lint them, run NoVerify in a full analysis mode or make them visible to the git.
 
 ### Disable some reports
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ noverify\
     -git-ref=refs/heads/$ref\
     -git-work-tree=.\
     -cache-dir=$HOME/tmp/cache/noverify
-    generated/a.php\
-    generated/web
+    -index-only-files='generated/a.php,generated/web'
 ```
 
 Here is the short summary of options used here:
@@ -130,12 +129,10 @@ Here is the short summary of options used here:
  - `-git-ref` is name of pushed branch
  - `-git-work-tree` is an optional parameter that you can specify if you want to be able to analyze uncommited changes too
  - `-cache-dir` is an optional directory for cache (greatly increases indexing speed)
- - rest arguments are index-only targets (see below)
+ - `-index-only-files` is index-only targets (see below)
 
 If you have files that are not a part of a git repository (i.e. they are ignored),
-you need to specify those files explicitly as additional command-line arguments.
-Including these files in git mode will only index them.
-If you want to actually lint them, run NoVerify in a full analysis mode or make them visible to the git.
+you need to specify those files explicitly via `-index-only-files`.
 
 ### Disable some reports
 

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -56,6 +56,12 @@ var (
 	memProfile string
 )
 
+// filesToAnalyze returns a list of files specified as linter analysis targets.
+// Needed to avoid spreading flag.Args() everywhere.
+func filesToAnalyze() []string {
+	return flag.Args()
+}
+
 func bindFlags() {
 	var enabledByDefault []string
 	declaredChecks := linter.GetDeclaredChecks()

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -46,6 +46,7 @@ var (
 	unusedVarPattern string
 
 	fullAnalysisFiles string
+	indexOnlyFiles    string
 
 	output     string
 	outputJSON bool
@@ -55,12 +56,6 @@ var (
 	cpuProfile string
 	memProfile string
 )
-
-// filesToAnalyze returns a list of files specified as linter analysis targets.
-// Needed to avoid spreading flag.Args() everywhere.
-func filesToAnalyze() []string {
-	return flag.Args()
-}
 
 func bindFlags() {
 	var enabledByDefault []string
@@ -114,6 +109,7 @@ func bindFlags() {
 	flag.StringVar(&phpExtensionsArg, "php-extensions", "php,inc,php5,phtml,inc", "List of PHP extensions to be recognized")
 
 	flag.StringVar(&fullAnalysisFiles, "full-analysis-files", "", "Comma-separated list of files to do full analysis")
+	flag.StringVar(&indexOnlyFiles, "index-only-files", "", "Comma-separated list of files to do indexing")
 
 	flag.StringVar(&output, "output", "", "Output reports to a specified file instead of stderr")
 	flag.BoolVar(&outputJSON, "output-json", false, "Format output as JSON")

--- a/src/cmd/git_main.go
+++ b/src/cmd/git_main.go
@@ -37,6 +37,7 @@ func gitRepoComputeReportsFromCommits(logArgs, diffArgs []string) (oldReports, r
 
 		start = time.Now()
 		linter.ParseFilenames(linter.ReadFilesFromGit(gitRepo, gitCommitFrom, nil))
+		linter.ParseFilenames(linter.ReadFilenames(filesToAnalyze(), nil))
 		log.Printf("Indexed old commit in %s", time.Since(start))
 
 		meta.SetIndexingComplete(true)
@@ -60,6 +61,7 @@ func gitRepoComputeReportsFromCommits(logArgs, diffArgs []string) (oldReports, r
 	} else {
 		start = time.Now()
 		linter.ParseFilenames(linter.ReadFilesFromGit(gitRepo, gitCommitTo, nil))
+		linter.ParseFilenames(linter.ReadFilenames(filesToAnalyze(), nil))
 		log.Printf("Indexing complete in %s", time.Since(start))
 
 		meta.SetIndexingComplete(true)
@@ -103,6 +105,7 @@ func gitRepoComputeReportsFromLocalChanges() (oldReports, reports []*linter.Repo
 
 	start := time.Now()
 	linter.ParseFilenames(linter.ReadFilesFromGit(gitRepo, gitCommitFrom, nil))
+	linter.ParseFilenames(linter.ReadFilenames(filesToAnalyze(), nil))
 	log.Printf("Indexing complete in %s", time.Since(start))
 
 	meta.SetIndexingComplete(true)

--- a/src/cmd/git_main.go
+++ b/src/cmd/git_main.go
@@ -11,6 +11,14 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func parseIndexOnlyFiles() {
+	if indexOnlyFiles == "" {
+		return
+	}
+	filenames := strings.Split(indexOnlyFiles, ",")
+	linter.ParseFilenames(linter.ReadFilenames(filenames, nil))
+}
+
 // Not the best name, and not the best function signature.
 // Refactor this function whenever you get the idea how to separate logic better.
 func gitRepoComputeReportsFromCommits(logArgs, diffArgs []string) (oldReports, reports []*linter.Report, changes []git.Change, changeLog []git.Commit, ok bool) {
@@ -37,7 +45,7 @@ func gitRepoComputeReportsFromCommits(logArgs, diffArgs []string) (oldReports, r
 
 		start = time.Now()
 		linter.ParseFilenames(linter.ReadFilesFromGit(gitRepo, gitCommitFrom, nil))
-		linter.ParseFilenames(linter.ReadFilenames(filesToAnalyze(), nil))
+		parseIndexOnlyFiles()
 		log.Printf("Indexed old commit in %s", time.Since(start))
 
 		meta.SetIndexingComplete(true)
@@ -61,7 +69,7 @@ func gitRepoComputeReportsFromCommits(logArgs, diffArgs []string) (oldReports, r
 	} else {
 		start = time.Now()
 		linter.ParseFilenames(linter.ReadFilesFromGit(gitRepo, gitCommitTo, nil))
-		linter.ParseFilenames(linter.ReadFilenames(filesToAnalyze(), nil))
+		parseIndexOnlyFiles()
 		log.Printf("Indexing complete in %s", time.Since(start))
 
 		meta.SetIndexingComplete(true)
@@ -105,7 +113,7 @@ func gitRepoComputeReportsFromLocalChanges() (oldReports, reports []*linter.Repo
 
 	start := time.Now()
 	linter.ParseFilenames(linter.ReadFilesFromGit(gitRepo, gitCommitFrom, nil))
-	linter.ParseFilenames(linter.ReadFilenames(filesToAnalyze(), nil))
+	parseIndexOnlyFiles()
 	log.Printf("Indexing complete in %s", time.Since(start))
 
 	meta.SetIndexingComplete(true)

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -169,14 +169,14 @@ func mainNoExit() (int, error) {
 		return gitMain()
 	}
 
-	linter.AnalysisFiles = flag.Args()
+	linter.AnalysisFiles = filesToAnalyze()
 
-	log.Printf("Indexing %+v", flag.Args())
-	linter.ParseFilenames(linter.ReadFilenames(flag.Args(), nil))
+	log.Printf("Indexing %+v", filesToAnalyze())
+	linter.ParseFilenames(linter.ReadFilenames(filesToAnalyze(), nil))
 	meta.SetIndexingComplete(true)
 	log.Printf("Linting")
 
-	filenames := flag.Args()
+	filenames := filesToAnalyze()
 	if fullAnalysisFiles != "" {
 		filenames = strings.Split(fullAnalysisFiles, ",")
 	}

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -169,14 +169,14 @@ func mainNoExit() (int, error) {
 		return gitMain()
 	}
 
-	linter.AnalysisFiles = filesToAnalyze()
+	linter.AnalysisFiles = flag.Args()
 
-	log.Printf("Indexing %+v", filesToAnalyze())
-	linter.ParseFilenames(linter.ReadFilenames(filesToAnalyze(), nil))
+	log.Printf("Indexing %+v", flag.Args())
+	linter.ParseFilenames(linter.ReadFilenames(flag.Args(), nil))
 	meta.SetIndexingComplete(true)
 	log.Printf("Linting")
 
-	filenames := filesToAnalyze()
+	filenames := flag.Args()
 	if fullAnalysisFiles != "" {
 		filenames = strings.Split(fullAnalysisFiles, ",")
 	}


### PR DESCRIPTION
Makes it possible to have generated files to living outside of
git repository for indexing purposes.

If no explicit target arguments are provided, linter behaves
as before.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>