### PR TITLE
Add -git-include-untracked switch to diff mode

### DIFF
--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -29,6 +29,7 @@ var (
 	gitWorkTree         string
 	gitSkipFetch        bool
 	gitFullDiff         bool
+	gitIncludeUntracked bool
 
 	phpExtensionsArg string
 
@@ -98,6 +99,7 @@ func bindFlags() {
 	flag.StringVar(&gitWorkTree, "git-work-tree", "", "Work tree. If specified, local changes will also be examined.")
 	flag.BoolVar(&gitSkipFetch, "git-skip-fetch", false, "Do not fetch ORIGIN_MASTER (use this option if you already fetch to ORIGIN_MASTER before that)")
 	flag.BoolVar(&gitFullDiff, "git-full-diff", false, "Compute full diff: analyze all files, not just changed ones")
+	flag.BoolVar(&gitIncludeUntracked, "git-include-untracked", true, "Include untracked (new, uncommited files) into analysis")
 
 	flag.StringVar(&reportsExclude, "exclude", "", "Exclude regexp for filenames in reports list")
 	flag.StringVar(&reportsExcludeChecks, "exclude-checks", "", "Comma-separated list of check names to be excluded")

--- a/src/cmd/git_main.go
+++ b/src/cmd/git_main.go
@@ -11,6 +11,19 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func gitParseUntracked() []*linter.Report {
+	if !gitIncludeUntracked {
+		return nil
+	}
+
+	filenames, err := git.UntrackedFiles(gitRepo)
+	if err != nil {
+		log.Fatalf("get untracked files: %v", err)
+	}
+
+	return linter.ParseFilenames(linter.ReadFilenames(filenames, nil))
+}
+
 // Not the best name, and not the best function signature.
 // Refactor this function whenever you get the idea how to separate logic better.
 func gitRepoComputeReportsFromCommits(logArgs, diffArgs []string) (oldReports, reports []*linter.Report, changes []git.Change, changeLog []git.Commit, ok bool) {
@@ -114,11 +127,13 @@ func gitRepoComputeReportsFromLocalChanges() (oldReports, reports []*linter.Repo
 	start = time.Now()
 	meta.SetIndexingComplete(false)
 	linter.ParseFilenames(linter.ReadChangesFromWorkTree(gitWorkTree, changes))
+	gitParseUntracked()
 	meta.SetIndexingComplete(true)
 	log.Printf("Indexed new files versions for %s", time.Since(start))
 
 	start = time.Now()
 	reports = linter.ParseFilenames(linter.ReadChangesFromWorkTree(gitWorkTree, changes))
+	reports = append(reports, gitParseUntracked()...)
 	log.Printf("Parsed new file versions in %s", time.Since(start))
 
 	return oldReports, reports, changes, true

--- a/src/git/ls.go
+++ b/src/git/ls.go
@@ -1,0 +1,25 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// UntrackedFiles returns filenames of untracked files obtained with git ls-files command.
+func UntrackedFiles(gitDir string) ([]string, error) {
+	args := []string{
+		"--git-dir=" + gitDir,
+		"ls-files",
+		"--others",
+		"--exclude-standard",
+	}
+
+	out, err := exec.Command("git", args...).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%v: %v", err, string(out))
+	}
+
+	filenames := strings.Split(strings.TrimSpace(string(out)), "\n")
+	return filenames, nil
+}


### PR DESCRIPTION
With -git-include-untracked (default=true) unstaged files are
indexed and analyzed.

The switch is only applied to gitRepoComputeReportsFromLocalChanges,
because untracked files can only exist if work tree have any changes.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>