### PR TITLE
Associate absolute paths with git files

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	_ "net/http/pprof" // it is ok for actually main package
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"runtime/pprof"
@@ -77,6 +78,13 @@ func Main(cfg *MainConfig) {
 
 	bindFlags()
 	flag.Parse()
+	if gitRepo != "" {
+		gitDir, err := filepath.Abs(gitRepo + "/../")
+		if err != nil {
+			log.Fatalf("Find git dir: %v", err)
+		}
+		linter.GitDir = gitDir
+	}
 	if cfg.AfterFlagParse != nil {
 		cfg.AfterFlagParse()
 	}

--- a/src/linter/conf.go
+++ b/src/linter/conf.go
@@ -20,6 +20,10 @@ var (
 	// TODO(quasilyte): avoid having it as a global variable?
 	SrcInput = inputs.NewDefaultSourceInput()
 
+	// GitDir is an absolute path to a directory that contains ".git".
+	// Empty string if NoVerify is executed in a non-git mode.
+	GitDir string
+
 	// settings
 	StubsDir        string
 	Debug           bool

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -288,7 +288,7 @@ func ReadFilesFromGit(repo, commitSHA1 string, ignoreRegex *regexp.Regexp) ReadC
 				}
 
 				ch <- FileInfo{
-					Filename: filename,
+					Filename: filepath.Join(GitDir, filename),
 					Contents: contents,
 				}
 			},
@@ -336,7 +336,7 @@ func ReadOldFilesFromGit(repo, commitSHA1 string, changes []git.Change) ReadCall
 			},
 			func(filename string, contents []byte) {
 				ch <- FileInfo{
-					Filename:   filename,
+					Filename:   filepath.Join(GitDir, filename),
 					Contents:   contents,
 					LineRanges: changedMap[filename],
 				}
@@ -387,7 +387,7 @@ func ReadFilesFromGitWithChanges(repo, commitSHA1 string, changes []git.Change) 
 			},
 			func(filename string, contents []byte) {
 				ch <- FileInfo{
-					Filename:   filename,
+					Filename:   filepath.Join(GitDir, filename),
 					Contents:   contents,
 					LineRanges: changedMap[filename],
 				}


### PR DESCRIPTION
When running NoVerify in normal (non-git) mode,
all filenames are turned into full filenames (abs paths).
It's not the case with git mode, since most code paths
recorded relative names.

Evaluate .git-containing folder once, during linter init
and use it to get absolute path later, when collecting
filenames provided by git catter.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>