### PR TITLE
Fix handling of splat arguments

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -693,7 +693,11 @@ func (b *BlockWalker) checkArrayDimFetch(s *expr.ArrayDimFetch) {
 
 func (b *BlockWalker) handleCallArgs(n node.Node, args []node.Node, fn meta.FuncInfo) {
 	if len(args) < fn.MinParamsCnt {
-		b.r.Report(n, LevelWarning, "argCount", "Too few arguments for %s", meta.NameNodeToString(n))
+		// If the last argument is ...$arg, then assume it is an array with
+		// sufficient values for the parameters
+		if len(args) == 0 || !args[len(args)-1].(*node.Argument).Variadic {
+			b.r.Report(n, LevelWarning, "argCount", "Too few arguments for %s", meta.NameNodeToString(n))
+		}
 	}
 
 	for i, arg := range args {

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -453,6 +453,14 @@ func TestFunctionReferenceParamsInAnonymousFunction(t *testing.T) {
 	test.RunAndMatch()
 }
 
+func TestFunctionCallSplatArg(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+function doSomething($a, $b, $c) {}
+$x = [1, 2, 3];
+doSomething(...$x);
+	`)
+}
+
 func TestForeachByRef(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 $xs = [1, 2];


### PR DESCRIPTION
If the last argument in a function call is a splat, e.g., `foo(...$x)`, then assume it is an array with enough elements to match the function's signature.