### PR TITLE
Recognize variable uses in property name subexpressions

### DIFF
--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -270,6 +270,46 @@ func TestUnusedInPropFetch(t *testing.T) {
 	runFilterMatch(test, "unused")
 }
 
+func TestUnusedInVarPropFetch(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Foo {}
+function foo(Foo $x) {
+	$y = "propname";
+	return $x->$y;
+}
+	`)
+}
+
+func TestUnusedInVarPropAssign(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Foo {}
+function foo(Foo $x) {
+	$y = "propname";
+	$x->$y = "propval";
+}
+	`)
+}
+
+func TestUnusedInStaticVarPropFetch(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Foo {}
+function foo() {
+	$x = "propname";
+	return Foo::$$x;
+}
+	`)
+}
+
+func TestUnusedInStaticVarPropAssign(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Foo {}
+function foo() {
+	$x = "propname";
+	Foo::$$x = "propval";
+}
+	`)
+}
+
 func TestUnusedInSwitch(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
This fixes false positives saying that `$x` is unused when it is used as a property (or static property) name, e.g., `->$x` or `::$$x`.