### PR TITLE
linter: remove "modifiers" check

### DIFF
--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -1,6 +1,7 @@
 package linter
 
 import (
+	"log"
 	"sort"
 	"strings"
 	"sync"
@@ -79,12 +80,6 @@ func init() {
 			Name:    "deadCode",
 			Default: true,
 			Comment: `Report potentially unreachable code.`,
-		},
-
-		{
-			Name:    "modifiers",
-			Default: true,
-			Comment: `Report misused modifiers like 'abstract' and 'static'.`,
 		},
 
 		{
@@ -342,4 +337,8 @@ func unquote(s string) string {
 		return s[1 : len(s)-1]
 	}
 	return s
+}
+
+func linterError(filename, format string, args ...interface{}) {
+	log.Printf("error: "+filename+": "+format, args...)
 }

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -619,7 +618,7 @@ func (d *RootWalker) parseMethodModifiers(meth *stmt.ClassMethod) (res methodMod
 		case "final":
 			res.final = true
 		default:
-			d.Report(m, LevelWarning, "modifiers", "Unrecognized method modifier: %s", v)
+			linterError(d.filename, "Unrecognized method modifier: %s", v)
 		}
 	}
 
@@ -956,7 +955,7 @@ func (d *RootWalker) maybeAddNamespace(typStr string) string {
 		}
 
 		if className[0] <= meta.WMax {
-			log.Printf("Bad type: '%s' in file %s", className, d.filename)
+			linterError(d.filename, "Bad type: '%s'", className)
 			classNames[idx] = ""
 			continue
 		}


### PR DESCRIPTION
If php code contains invalid modifier, it would be a syntax error
and code would not be properly parsed.

It means that we can't test/reproduce "modifiers" checker warnings.

Handle unknown modifiers as an internal sanity check inside linter
and give "linterError" instead of an ordinary warning.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>