### PR TITLE
add custom meta cacher support

### DIFF
--- a/src/langsrv/state.go
+++ b/src/langsrv/state.go
@@ -114,7 +114,7 @@ func concurrentParseChanges(changes []vscode.FileEvent) {
 		wg.Add(1)
 		go func() {
 			for filename := range filenamesCh {
-				err := linter.Parse(filename, nil)
+				err := linter.IndexFile(filename, nil)
 				if err != nil {
 					lintdebug.Send("Could not parse %s: %s", filename, err.Error())
 				}

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -457,7 +457,7 @@ func doParseFile(f FileInfo, needReports bool) (reports []*Report) {
 			reports = w.GetReports()
 		}
 	} else {
-		err = Parse(f.Filename, f.Contents)
+		err = IndexFile(f.Filename, f.Contents)
 	}
 
 	if err != nil {


### PR DESCRIPTION
If a custom root checker records some info during the
indexing phase that is required during the analysis, it
must be written to cache, because otherwise that
checker is not going to be executed if cache exists while
that cache would still not contain relevant data.

Make it possible to register a checker along with
associated MetaCacher that can write needed parts
to the cache files and load that info during
cache file reading.

MetaCacher also includes a Version() method
that can be used to implement cache invalidation.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>