### PR TITLE
linter: handle mt_rand in argCount check

### DIFF
--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -10,6 +10,24 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestArgsCount(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function f() {
+$_ = mt_rand();        // OK
+$_ = mt_rand(1);       // Not OK
+$_ = mt_rand(1, 2);    // OK
+$_ = mt_rand(1, 2, 3); // Not OK
+}
+
+function mt_rand($x = 0, $y = 0) {}`)
+	test.Expect = []string{
+		`mt_rand expects 0 or 2 args`,
+		`mt_rand expects 0 or 2 args`,
+	}
+	test.RunAndMatch()
+}
+
 func TestMethodComplexity(t *testing.T) {
 	funcCode := strings.Repeat("$_ = 0;\n", 9999)
 	test := linttest.NewSuite(t)


### PR DESCRIPTION
The list of more strictly checked functions might extend over time.
If it gets big, we probably may want to discuss how to express
this kind of constraints in phpstorm meta files (stubs),
so that info can be reused in both phpstorm and noverify.

Fixes #163

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>