### PR TITLE
linter: move Report type and util funcs

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -44,25 +44,6 @@ const (
 	FlagDie
 )
 
-// FlagsToString is designed for debugging flags.
-func FlagsToString(f int) string {
-	var res []string
-
-	if (f & FlagReturn) == FlagReturn {
-		res = append(res, "Return")
-	}
-
-	if (f & FlagDie) == FlagDie {
-		res = append(res, "Die")
-	}
-
-	if (f & FlagThrow) == FlagThrow {
-		res = append(res, "Throw")
-	}
-
-	return "Exit flags: " + strings.Join(res, ", ") + ", digits: " + fmt.Sprintf("%d", f)
-}
-
 // BlockWalker is used to process function/method contents.
 type BlockWalker struct {
 	ctx *blockContext
@@ -1107,11 +1088,6 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []node.Node) bool {
 	}
 
 	return true
-}
-
-func haveMagicMethod(class string, methodName string) bool {
-	_, _, ok := solver.FindMethod(class, methodName)
-	return ok
 }
 
 func (b *BlockWalker) handleClassConstFetch(e *expr.ClassConstFetch) bool {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -1,6 +1,8 @@
 package linter
 
 import (
+	"encoding/json"
+	"fmt"
 	"log"
 	"sort"
 	"strings"
@@ -140,6 +142,91 @@ func init() {
 	for _, info := range allChecks {
 		DeclareCheck(info)
 	}
+}
+
+// Report is a linter report message.
+type Report struct {
+	checkName  string
+	startLn    string
+	startChar  int
+	startLine  int
+	endChar    int
+	level      int
+	msg        string
+	filename   string
+	isDisabled bool // user-defined flag that file should not be linted
+}
+
+// CheckName returns report associated check name.
+func (r *Report) CheckName() string {
+	return r.checkName
+}
+
+// MarshalJSON is used to write report in its JSON representation.
+//
+// Used for -output-json option.
+func (r *Report) MarshalJSON() ([]byte, error) {
+	type jsonReport struct {
+		CheckName string `json:"check_name"`
+		Severity  string `json:"severity"`
+		Context   string `json:"context"`
+		Message   string `json:"message"`
+		Filename  string `json:"filename"`
+		Line      int    `json:"line"`
+		StartChar int    `json:"start_char"`
+		EndChar   int    `json:"end_char"`
+	}
+
+	b, err := json.Marshal(jsonReport{
+		CheckName: r.checkName,
+		Severity:  strings.TrimSpace(severityNames[r.level]),
+		Context:   r.startLn,
+		Message:   r.msg,
+		Filename:  r.filename,
+		Line:      r.startLine,
+		StartChar: r.startChar,
+		EndChar:   r.endChar,
+	})
+	return b, err
+}
+
+func (r *Report) String() string {
+	contextLn := strings.Builder{}
+	for i, ch := range string(r.startLn) {
+		if i == r.startChar {
+			break
+		}
+		if ch == '\t' {
+			contextLn.WriteRune(ch)
+		} else {
+			contextLn.WriteByte(' ')
+		}
+	}
+
+	if r.endChar > r.startChar {
+		contextLn.WriteString(strings.Repeat("^", r.endChar-r.startChar))
+	}
+
+	msg := r.msg
+	if r.checkName != "" {
+		msg = r.checkName + ": " + msg
+	}
+	return fmt.Sprintf("%s %s at %s:%d\n%s\n%s", severityNames[r.level], msg, r.filename, r.startLine, r.startLn, contextLn.String())
+}
+
+// IsCritical returns whether or not we need to reject whole commit when found this kind of report.
+func (r *Report) IsCritical() bool {
+	return r.level != LevelDoNotReject
+}
+
+// IsDisabledByUser returns whether or not user thinks that this file should not be checked
+func (r *Report) IsDisabledByUser() bool {
+	return r.isDisabled
+}
+
+// GetFilename returns report filename
+func (r *Report) GetFilename() string {
+	return r.filename
 }
 
 // DiffReports returns only reports that are new.

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -1,0 +1,46 @@
+package linter
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/VKCOM/noverify/src/solver"
+	"github.com/z7zmey/php-parser/node"
+	"github.com/z7zmey/php-parser/printer"
+)
+
+// FmtNode is used for debug purposes and returns string representation of a specified node.
+func FmtNode(n node.Node) string {
+	var b bytes.Buffer
+	printer.NewPrettyPrinter(&b, " ").Print(n)
+	return b.String()
+}
+
+// FlagsToString is designed for debugging flags.
+func FlagsToString(f int) string {
+	var res []string
+
+	if (f & FlagReturn) == FlagReturn {
+		res = append(res, "Return")
+	}
+
+	if (f & FlagDie) == FlagDie {
+		res = append(res, "Die")
+	}
+
+	if (f & FlagThrow) == FlagThrow {
+		res = append(res, "Throw")
+	}
+
+	return "Exit flags: " + strings.Join(res, ", ") + ", digits: " + fmt.Sprintf("%d", f)
+}
+
+func haveMagicMethod(class string, methodName string) bool {
+	_, _, ok := solver.FindMethod(class, methodName)
+	return ok
+}
+
+func isQuote(r rune) bool {
+	return r == '"' || r == '\''
+}


### PR DESCRIPTION
- Move Report type to report.go

- Move utility functions from block.go and root.go to utils.go,
  since their usage (and scope) is not limited to either
  (and some of them are even exported).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>