### PR TITLE
fix deadCode regression

### DIFF
--- a/src/linter/block_context.go
+++ b/src/linter/block_context.go
@@ -11,23 +11,23 @@ import (
 // When it leaves that block, previous context is restored.
 // The BlockWalker itself is not copied and, instead, re-used as is.
 type blockContext struct {
-	sc *meta.Scope
-
 	exitFlags         int // if block always breaks code flow then there will be exitFlags
 	containsExitFlags int // if block sometimes breaks code flow then there will be containsExitFlags
-
-	innermostLoop loopKind
-	// insideLoop is true if any number of statements above there is enclosing loop.
-	// innermostLoop is not enough for this, since we can be inside switch while
-	// having for loop outside of that switch.
-	insideLoop bool
 
 	// inferred return types if any
 	returnTypes *meta.TypesMap
 
-	customTypes []solver.CustomType
-
 	deadCodeReported bool
+
+	// Fields below should be copied during context cloning.
+
+	sc            *meta.Scope
+	innermostLoop loopKind
+	// insideLoop is true if any number of statements above there is enclosing loop.
+	// innermostLoop is not enough for this, since we can be inside switch while
+	// having for loop outside of that switch.
+	insideLoop  bool
+	customTypes []solver.CustomType
 }
 
 // copyBlockContext returns a copy of the context.

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -33,7 +33,11 @@ func FlagsToString(f int) string {
 		res = append(res, "Throw")
 	}
 
-	return "Exit flags: " + strings.Join(res, ", ") + ", digits: " + fmt.Sprintf("%d", f)
+	if (f & FlagBreak) == FlagBreak {
+		res = append(res, "Break")
+	}
+
+	return "Exit flags: [" + strings.Join(res, ", ") + "], digits: " + fmt.Sprintf("%d", f)
 }
 
 func haveMagicMethod(class string, methodName string) bool {

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1,0 +1,24 @@
+package linttest_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestIssue170(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+
+global $v;
+
+switch ($v) {
+case 1:
+  error(); // no break here
+case 2:
+  $_ = $v;
+  break;
+}
+
+function error() {}
+`)
+}


### PR DESCRIPTION
To fix false positive, iterateNextCases should be called inside
copied (new) block context.

In addition to that, little cleanup:

	* moved cloned fields of block context into one side (grouped them)
	* made FlagsToString properly print "break" flags

Fixes #170

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>