### PR TITLE
linter: add callStatic check

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -16,7 +16,11 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
-const cacheVersion = 26
+// cacheVersions is a magic number that helps to distinguish incompatible caches.
+//
+// Version log:
+//     27 - added Static field to meta.FuncInfo
+const cacheVersion = 27
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -137,6 +137,12 @@ func init() {
 			Default: false, // Experimental
 			Comment: `Report usages of deprecated symbols.`,
 		},
+
+		{
+			Name:    "callStatic",
+			Default: true,
+			Comment: `Report static calls of instance methods and vice versa.`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -736,6 +736,7 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 		Typ:          typ,
 		MinParamsCnt: minParamsCnt,
 		AccessLevel:  modif.accessLevel,
+		Static:       modif.static,
 		ExitFlags:    exitFlags,
 		Doc:          phpdoc.info,
 	}

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -10,6 +10,37 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestCallStaticParent(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?ph
+	class Base { protected function f() { return 1; } }
+	class Derived extends Base {
+		private function g() {
+			return parent::f() + 1;
+		}
+	}
+`)
+	runFilterMatch(test, "callStatic")
+}
+
+func TestCallStatic(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	class T {
+		public static function sf($_) {}
+		public function f($_) {}
+	}
+	$v = new T();
+	$v->sf(1);
+	T::f(1);
+	`)
+	test.Expect = []string{
+		`Calling static method as instance method`,
+		`Calling instance method as static method`,
+	}
+	runFilterMatch(test, "callStatic")
+}
+
 func TestForeachList(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -174,7 +174,7 @@ class A
     /**
      * @return static[]
      */
-    public static function create()
+    public function create()
     {
         return [new static()];
     }

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -274,6 +274,7 @@ type FuncInfo struct {
 	MinParamsCnt int
 	Typ          *TypesMap
 	AccessLevel  AccessLevel
+	Static       bool
 	ExitFlags    int // if function has exit/die/throw, then ExitFlags will be <> 0
 	Doc          PhpDocInfo
 }


### PR DESCRIPTION
Detect when static methods are called using "->" syntax
and instance methods that are called using "::" syntax.

It's not always a mistake, but could be a sign of a code smell.
Also, it makes code harder to read, since it's not apparent
what happens before called method signature is reviewed.

parent:: syntax is permitted to call base class instance method.

Added "Static" field to meta.FuncInfo to make this check possible.

Re-work of #53

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>