### PR TITLE
resolve elemOf for ArrayAccess and Traversable

### DIFF
--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -21,6 +21,44 @@ import (
 // TODO(quasilyte): better handling of an `empty_array` type.
 // Now it's resolved to `array` for expressions that have multiple empty_array.
 
+func TestExprTypeArrayAccess(t *testing.T) {
+	tests := []exprTypeTest{
+		{`$ints[0]`, `int`},
+		{`getInts()[0]`, `int`},
+		{`$self[0]`, `\Self`},
+		{`$self[0][1]`, `\Self`},
+		{`$self[0][1]->offsetGet(2)`, `\Self`},
+	}
+
+	global := `<?php
+function getInts() { return new Ints(); }
+
+class Ints implements ArrayAccess {
+   /** @return bool */
+   public function offsetExists($offset) {}
+   /** @return int */
+   public function offsetGet($offset) {}
+   /** @return void */
+   public function offsetSet($offset, $value) {}
+   /** @return void */
+   public function offsetUnset($offset) {}
+}
+
+class Self implements ArrayAccess {
+   /** @return bool */
+   public function offsetExists($offset) {}
+   /** @return Self */
+   public function offsetGet($offset) {}
+   /** @return void */
+   public function offsetSet($offset, $value) {}
+   /** @return void */
+   public function offsetUnset($offset) {}
+}
+`
+	local := `$ints = new Ints(); $self = new Self();`
+	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
+}
+
 func TestExprTypeAnnotatedProperty(t *testing.T) {
 	tests := []exprTypeTest{
 		{`$x->int`, `int`},

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -43,7 +43,10 @@ $_ = WithProps::$int;
 
 	test.RunAndMatch()
 }
+
 func TestBadModifiers(t *testing.T) {
+	t.Skip("Should be handled by other check, like keywordCase from #138")
+
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 class Foo {
@@ -119,6 +122,63 @@ $m = new Magic();
 $m->method();
 $m->foo->method();
 $m->foo->bar->method();
+`)
+}
+
+func TestIteratorForeach(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+interface Iterator extends Traversable {
+  public function current();
+  public function key();
+  public function next();
+  public function rewind();
+  public function valid();
+}
+
+class SimpleXMLIterator implements Iterator {
+  /** @return int */
+  public function blah($name) { return 0; }
+
+  /** @return SimpleXMLIterator */
+  public function current() {}
+  /** @return int */
+  public function key() {}
+  /** @return void */
+  public function next() {}
+  /** @return void */
+  public function rewind() {}
+  /** @return bool */
+  public function valid() {}
+}
+
+function testForeach($xml_str) {
+  $xml = new SimpleXMLIterator($xml_str);
+  foreach ($xml as $node) {
+    $_ = $node->blah('123');
+  }
+}
+`)
+}
+
+func TestSimpleXMLElementForeach(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class SimpleXMLElement implements Traversable, ArrayAccess {
+  /** @return SimpleXMLElement */
+  private function __get($name) {}
+
+  /** @return static[] */
+  public function xpath ($path) {}
+
+  /** @return SimpleXMLElement */
+  public function offsetGet($i) {}
+}
+
+function testForeach($xml_str) {
+  $xml = new SimpleXMLElement($xml_str);
+  foreach ($xml as $node) {
+    $_ = $node->xpath('blah');
+  }
+}
 `)
 }
 

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -24,7 +24,7 @@ type resolver struct {
 }
 
 func (r *resolver) resolveType(class, typ string) map[string]struct{} {
-	res := r.resolveTypeNoSpecialization(class, typ)
+	res := r.resolveTypeNoLateStaticBinding(class, typ)
 
 	if _, ok := res["static"]; ok {
 		delete(res, "static")
@@ -34,7 +34,7 @@ func (r *resolver) resolveType(class, typ string) map[string]struct{} {
 	return res
 }
 
-func (r *resolver) resolveTypeNoSpecialization(class, typ string) map[string]struct{} {
+func (r *resolver) resolveTypeNoLateStaticBinding(class, typ string) map[string]struct{} {
 	visitedMap := r.visited
 
 	if _, ok := visitedMap[typ]; ok {

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -24,6 +24,17 @@ type resolver struct {
 }
 
 func (r *resolver) resolveType(class, typ string) map[string]struct{} {
+	res := r.resolveTypeNoSpecialization(class, typ)
+
+	if _, ok := res["static"]; ok {
+		delete(res, "static")
+		res[class] = struct{}{}
+	}
+
+	return res
+}
+
+func (r *resolver) resolveTypeNoSpecialization(class, typ string) map[string]struct{} {
 	visitedMap := r.visited
 
 	if _, ok := visitedMap[typ]; ok {
@@ -54,18 +65,29 @@ func (r *resolver) resolveType(class, typ string) map[string]struct{} {
 		}
 	case meta.WArrayOf:
 		for tt := range r.resolveType(class, meta.UnwrapArrayOf(typ)) {
-			if tt == "static" {
-				res[class+"[]"] = struct{}{}
-			} else {
-				res[tt+"[]"] = struct{}{}
-			}
+			res[tt+"[]"] = struct{}{}
 		}
 	case meta.WElemOf:
 		for tt := range r.resolveType(class, meta.UnwrapElemOf(typ)) {
-			if strings.HasSuffix(tt, "[]") {
+			switch {
+			case strings.HasSuffix(tt, "[]"):
 				res[strings.TrimSuffix(tt, "[]")] = struct{}{}
-			} else if tt == "mixed" {
+			case tt == "mixed":
 				res["mixed"] = struct{}{}
+			case Implements(tt, `\ArrayAccess`):
+				offsetGet, _, ok := FindMethod(tt, "offsetGet")
+				if ok {
+					for tt := range r.resolveTypes(tt, offsetGet.Typ) {
+						res[tt] = struct{}{}
+					}
+				}
+			case Implements(tt, `\Traversable`):
+				current, _, ok := FindMethod(tt, "current")
+				if ok {
+					for tt := range r.resolveTypes(tt, current.Typ) {
+						res[tt] = struct{}{}
+					}
+				}
 			}
 		}
 	case meta.WFunctionCall:
@@ -86,11 +108,7 @@ func (r *resolver) resolveType(class, typ string) map[string]struct{} {
 			info, _, ok := FindMethod(className, methodName)
 			if ok {
 				for tt := range r.resolveTypes(className, info.Typ) {
-					if tt == "static" {
-						res[className] = struct{}{}
-					} else {
-						res[tt] = struct{}{}
-					}
+					res[tt] = struct{}{}
 				}
 			}
 		}
@@ -120,11 +138,7 @@ func (r *resolver) resolveType(class, typ string) map[string]struct{} {
 		info, _, ok := FindMethod(className, methodName)
 		if ok {
 			for tt := range r.resolveTypes(className, info.Typ) {
-				if tt == "static" {
-					res[className] = struct{}{}
-				} else {
-					res[tt] = struct{}{}
-				}
+				res[tt] = struct{}{}
 			}
 		}
 	case meta.WStaticPropertyFetch:


### PR DESCRIPTION
For ArrayAccess use return type of offsetGet() method.
For Traversable (Iterator, etc.) use return type of current() method.

This behavior is in sync with what PhpStorm does.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>