### PR TITLE
handle __construct() method call in argCount diagnostic

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1183,20 +1183,14 @@ func (b *BlockWalker) handleNew(e *expr.New) bool {
 		return true
 	}
 
-	info, ok := meta.Info.GetClass(className)
-	if !ok {
+	if _, ok := meta.Info.GetClass(className); !ok {
 		b.r.Report(e.Class, LevelError, "undefined", "Class not found %s", className)
 	}
 
 	// Check implicitly invoked constructor method arguments count.
-	ctor, ok := info.Methods["__construct"]
+	ctor, _, ok := solver.FindMethod(className, "__construct")
 	if !ok {
-		// TODO(quasilyte): we might want to catch case-insensitivity issues.
-		// Class may be called "Foo", but "foo" method can be its constructor.
-
-		// If constructor method uses className name instead of __construct.
-		nameParts := strings.Split(className, `\`)
-		ctor, ok = info.Methods[nameParts[len(nameParts)-1]]
+		return true
 	}
 	// If new expression is written without (), ArgumentList will be nil.
 	// It's equivalent of 0 arguments constructor call.

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -683,6 +683,17 @@ func (b *BlockWalker) checkArrayDimFetch(s *expr.ArrayDimFetch) {
 	}
 }
 
+func (b *BlockWalker) enoughArgs(args []node.Node, fn meta.FuncInfo) bool {
+	if len(args) < fn.MinParamsCnt {
+		// If the last argument is ...$arg, then assume it is an array with
+		// sufficient values for the parameters
+		if len(args) == 0 || !args[len(args)-1].(*node.Argument).Variadic {
+			return false
+		}
+	}
+	return true
+}
+
 func (b *BlockWalker) handleArgsCount(n node.Node, args []node.Node, fn meta.FuncInfo) {
 	if n, ok := n.(*name.Name); ok {
 		// Make this matching more generalized when we find more such functions.
@@ -695,12 +706,8 @@ func (b *BlockWalker) handleArgsCount(n node.Node, args []node.Node, fn meta.Fun
 		}
 	}
 
-	if len(args) < fn.MinParamsCnt {
-		// If the last argument is ...$arg, then assume it is an array with
-		// sufficient values for the parameters
-		if len(args) == 0 || !args[len(args)-1].(*node.Argument).Variadic {
-			b.r.Report(n, LevelWarning, "argCount", "Too few arguments for %s", meta.NameNodeToString(n))
-		}
+	if !b.enoughArgs(args, fn) {
+		b.r.Report(n, LevelWarning, "argCount", "Too few arguments for %s", meta.NameNodeToString(n))
 	}
 }
 
@@ -1176,8 +1183,29 @@ func (b *BlockWalker) handleNew(e *expr.New) bool {
 		return true
 	}
 
-	if _, ok := meta.Info.GetClass(className); !ok {
+	info, ok := meta.Info.GetClass(className)
+	if !ok {
 		b.r.Report(e.Class, LevelError, "undefined", "Class not found %s", className)
+	}
+
+	// Check implicitly invoked constructor method arguments count.
+	ctor, ok := info.Methods["__construct"]
+	if !ok {
+		// TODO(quasilyte): we might want to catch case-insensitivity issues.
+		// Class may be called "Foo", but "foo" method can be its constructor.
+
+		// If constructor method uses className name instead of __construct.
+		nameParts := strings.Split(className, `\`)
+		ctor, ok = info.Methods[nameParts[len(nameParts)-1]]
+	}
+	// If new expression is written without (), ArgumentList will be nil.
+	// It's equivalent of 0 arguments constructor call.
+	var args []node.Node
+	if e.ArgumentList != nil {
+		args = e.ArgumentList.Arguments
+	}
+	if ok && !b.enoughArgs(args, ctor) {
+		b.r.Report(e, LevelError, "argCount", "Too few arguments for %s constructor", className)
 	}
 
 	return true

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -11,37 +11,31 @@ func TestConstructorArgCount(t *testing.T) {
 	test.AddFile(`<?php
 use A\B;
 
-class OneArgConstruct {
+class OneArg {
   public function __construct($_) {}
 }
 
-class OneArg {
-  /** OneArg constructor */
-  public function OneArg($_) {}
-}
+class OneArgDerived extends OneArg {}
 
 function f() {
-  $_ = new OneArgConstruct();
   $_ = new OneArg();
-  $_ = new \OneArg;
   $_ = new \A\B\TwoArgs();
-  $_ = new B\TwoArgs();
+  $_ = new B\TwoArgs;
+  $_ = new OneArgDerived();
 }
 `)
 	test.AddFile(`<?php
 namespace A\B;
 
 class TwoArgs {
-  /** TwoArgs constructor */
-  public function TwoArgs($_, $_) {}
+  public function __construct($_, $_) {}
 }
 `)
 	test.Expect = []string{
-		`Too few arguments for \OneArgConstruct constructor`,
-		`Too few arguments for \OneArg constructor`,
 		`Too few arguments for \OneArg constructor`,
 		`Too few arguments for \A\B\TwoArgs constructor`,
 		`Too few arguments for \A\B\TwoArgs constructor`,
+		`Too few arguments for \OneArgDerived constructor`,
 	}
 	test.RunAndMatch()
 }

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -6,6 +6,46 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestConstructorArgCount(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+use A\B;
+
+class OneArgConstruct {
+  public function __construct($_) {}
+}
+
+class OneArg {
+  /** OneArg constructor */
+  public function OneArg($_) {}
+}
+
+function f() {
+  $_ = new OneArgConstruct();
+  $_ = new OneArg();
+  $_ = new \OneArg;
+  $_ = new \A\B\TwoArgs();
+  $_ = new B\TwoArgs();
+}
+`)
+	test.AddFile(`<?php
+namespace A\B;
+
+class TwoArgs {
+  /** TwoArgs constructor */
+  public function TwoArgs($_, $_) {}
+}
+`)
+	test.Expect = []string{
+		`Too few arguments for \OneArgConstruct constructor`,
+		`Too few arguments for \OneArg constructor`,
+		`Too few arguments for \OneArg constructor`,
+		`Too few arguments for \A\B\TwoArgs constructor`,
+		`Too few arguments for \A\B\TwoArgs constructor`,
+	}
+	test.RunAndMatch()
+}
+
 func TestPhpdocProperty(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
Do it by analyzing new expressions.

If instantiated object class doesn't define __construct method,
check for a method that have the same name as a type name.

Fixes #176

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>