### PR TITLE
report old-style constructor usages

### DIFF
--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -143,6 +143,12 @@ func init() {
 			Default: true,
 			Comment: `Report static calls of instance methods and vice versa.`,
 		},
+
+		{
+			Name:    "oldStyleConstructor",
+			Default: true,
+			Comment: `Report old style (PHP4) class constructors.`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -147,7 +147,7 @@ func init() {
 		{
 			Name:    "oldStyleConstructor",
 			Default: true,
-			Comment: `Report old style (PHP4) class constructors.`,
+			Comment: `Report old-style (PHP4) class constructors.`,
 		},
 	}
 

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -645,8 +645,20 @@ func (d *RootWalker) enterClassConstList(s *stmt.ClassConstList) bool {
 	return true
 }
 
+func (d *RootWalker) checkOldStyleConstructor(meth *stmt.ClassMethod, nm string) {
+	lastDelim := strings.IndexByte(d.st.CurrentClass, '\\')
+	if strings.EqualFold(d.st.CurrentClass[lastDelim+1:], nm) {
+		_, isClass := d.currentClassNode.(*stmt.Class)
+		if isClass {
+			d.Report(meth.MethodName, LevelDoNotReject, "oldStyleConstructor", "Old-style constructor usage, use __construct instead")
+		}
+	}
+}
+
 func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 	nm := meth.MethodName.(*node.Identifier).Value
+
+	d.checkOldStyleConstructor(meth, nm)
 
 	pos := meth.GetPosition()
 

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -6,6 +6,32 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestOldStyleConstructor(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+class T1 {
+  /** simple constructor */
+  public function T1() {}
+}
+
+class T2 {
+  /** constructor name is in lower case */
+  public function t2() {}
+}
+
+class t3 {
+  /** inverse of the T2 test case */
+  public function T3() {}
+}
+`)
+	test.Expect = []string{
+		`Old-style constructor usage, use __construct instead`,
+		`Old-style constructor usage, use __construct instead`,
+		`Old-style constructor usage, use __construct instead`,
+	}
+	test.RunAndMatch()
+}
+
 func TestConstructorArgCount(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
PHP5+ code should use __construct() instead.

Fixes #178

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>