### PR TITLE
Update expected value in phpdoc parser test

### DIFF
--- a/src/phpdoc/parser_test.go
+++ b/src/phpdoc/parser_test.go
@@ -7,8 +7,18 @@ import (
 
 func TestParseSimple(t *testing.T) {
 	expected := []CommentPart{
-		{Name: "param", Params: []string{"$param", "int", "Here", "goes", "the", "description"}},
-		{Name: "return", Params: []string{"int", "some", "result"}},
+		{
+			Line:       4,
+			Name:       "param",
+			Params:     []string{"$param", "int", "Here", "goes", "the", "description"},
+			ParamsText: "$param int  Here goes the description",
+		},
+		{
+			Line:       5,
+			Name:       "return",
+			Params:     []string{"int", "some", "result"},
+			ParamsText: "int   some    result",
+		},
 	}
 
 	actual := Parse(`/**


### PR DESCRIPTION
The Line and ParamsText fields were added without updating the expected value,
resulting in the test failing.