### PR TITLE
linter: move phpdoc type checks to a separate diagnostic

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1294,12 +1294,9 @@ func (b *BlockWalker) enterClosure(fun *expr.Closure, haveThis bool, thisType *m
 		sc.AddVarName("this", meta.NewTypesMap("possibly_late_bound"), "possibly late bound $this", true)
 	}
 
-	phpdoc, phpDocError := b.r.parsePHPDoc(fun.PhpDocComment, fun.Params)
-	phpDocParamTypes := phpdoc.types
-
-	for _, err := range phpDocError {
-		b.r.Report(fun, LevelInformation, "phpdocLint", "PHPDoc is incorrect: %s", err)
-	}
+	doc := b.r.parsePHPDoc(fun.PhpDocComment, fun.Params)
+	b.r.reportPhpdocErrors(fun, doc.errs)
+	phpDocParamTypes := doc.types
 
 	var closureUses []node.Node
 	if fun.ClosureUse != nil {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -91,6 +91,12 @@ func init() {
 		},
 
 		{
+			Name:    "phpdocType",
+			Default: true,
+			Comment: `Report potential issues in phpdoc types.`,
+		},
+
+		{
 			Name:    "phpdoc",
 			Default: true,
 			Comment: `Report missing phpdoc on public methods.`,

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -80,8 +80,8 @@ function fav_func($a, $b) {
 }
 `)
 	test.Expect = []string{
-		`PHPDoc is incorrect: malformed @param $a tag (maybe type is missing?)`,
-		`PHPDoc is incorrect: malformed @param $b tag (maybe type is missing?)`,
+		`malformed @param $a tag (maybe type is missing?)`,
+		`malformed @param $b tag (maybe type is missing?)`,
 	}
 	test.RunAndMatch()
 }
@@ -153,10 +153,10 @@ func TestPHPDocProperty(t *testing.T) {
 class Foo {}
 `)
 	test.Expect = []string{
-		`PHPDoc is incorrect: use int type instead of integer on line 2`,
-		`PHPDoc is incorrect: []t type syntax: use [] after the type, e.g. T[] on line 3`,
-		`PHPDoc is incorrect: line 4: @property requires type and property name fields`,
-		`PHPDoc is incorrect: line 5: @property requires type and property name fields`,
+		`use int type instead of integer on line 2`,
+		`[]t type syntax: use [] after the type, e.g. T[] on line 3`,
+		`line 4: @property requires type and property name fields`,
+		`line 5: @property requires type and property name fields`,
 	}
 	test.RunAndMatch()
 }


### PR DESCRIPTION
Split phpdocLint into phpdocLint+phpdocType checks.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>