### PR TITLE
linter: don't report undefined class for new self/static inside trait

### DIFF
--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -431,21 +431,6 @@ func TestVariadic(t *testing.T) {
 	`)
 }
 
-func TestTraitProperties(t *testing.T) {
-	linttest.SimpleNegativeTest(t, `<?php
-	declare(strict_types=1);
-
-	trait Example
-	{
-		private static $property = 'some';
-
-		protected function some(): string
-		{
-			return self::$property;
-		}
-	}`)
-}
-
 func TestMagicMethods(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 	class Magic

--- a/src/linttest/trait_test.go
+++ b/src/linttest/trait_test.go
@@ -1,0 +1,58 @@
+package linttest_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestTraitProperties(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+	declare(strict_types=1);
+
+	trait Example
+	{
+		private static $property = 'some';
+
+		protected function some(): string
+		{
+			return self::$property;
+		}
+	}`)
+}
+
+func TestTraitSelf(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+define('null', 0);
+
+function define($name, $v) {}
+
+trait SingletonSelf {
+    /** @var self */
+    private static $instance = null;
+
+    /** @return self */
+    public static function instance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+}
+
+trait SingletonStatic {
+    /** @var static */
+    private static $instance = null;
+
+    /** @return static */
+    public static function instance() {
+        if (static::$instance === null) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+}
+`)
+}

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -447,6 +447,20 @@ func NameNodeToString(n node.Node) string {
 	}
 }
 
+// NameNodeEquals checks whether n node name value is identical to s.
+func NameNodeEquals(n node.Node, s string) bool {
+	switch n := n.(type) {
+	case *name.Name:
+		return NameEquals(n, s)
+	case *node.Identifier:
+		return n.Value == s
+	case *name.FullyQualified:
+		return FullyQualifiedToString(n) == s
+	default:
+		return false
+	}
+}
+
 func NameEquals(n *name.Name, s string) bool {
 	if len(n.Parts) != strings.Count(s, `\`)+1 {
 		return false


### PR DESCRIPTION
Don't try to resolve "new self" or "new static" inside the trait context.

Also move trait tests to trait_test.go.

Fixes #182

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>