### PR TITLE
Remove unused method and const #192

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -125,10 +125,6 @@ func (b *BlockWalker) addStatement(n node.Node) {
 	b.statements[assignment] = struct{}{}
 }
 
-func (b *BlockWalker) copyContext() *blockContext {
-	return copyBlockContext(b.ctx)
-}
-
 func (b *BlockWalker) reportDeadCode(n node.Node) {
 	if b.ctx.deadCodeReported {
 		return


### PR DESCRIPTION
Fixes #192 

I removed unused method and const following golangci-lint said
```
$ golangci-lint run --disable-all -E unused
src/langsrv/langsrv.go:74:38: U1000: func `IMessage` is unused (unused)
func writeMessage(message interface{ IMessage() }) error {
                                     ^
src/linter/block.go:28:2: U1000: const `loopNone` is unused (unused)
	loopNone loopKind = iota
	^
src/linter/block.go:128:23: U1000: func `(*BlockWalker).copyContext` is unused (unused)
func (b *BlockWalker) copyContext() *blockContext {
                      ^
```