### PR TITLE
Static inside method

### DIFF
--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -613,7 +613,7 @@ func runExprTypeTest(t *testing.T, ctx *exprTypeTestContext, tests []exprTypeTes
 			t.Errorf("missing f%d info", i)
 			continue
 		}
-		have := solver.ResolveTypes(fn.Typ, make(map[string]struct{}))
+		have := solver.ResolveTypes("", fn.Typ, make(map[string]struct{}))
 		want := makeType(test.expectedType)
 		if !reflect.DeepEqual(have, want) {
 			t.Errorf("type mismatch for %q:\nhave: %q\nwant: %q",

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -327,7 +327,7 @@ foreach ($b->create() as $item) {
 `)
 }
 
-func TestLateStaticBinding(t *testing.T) {
+func TestDerivedLateStaticBinding(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 class Base {
   /** @return static[] */
@@ -346,6 +346,50 @@ $x = new Derived();
 $xs = $x->asArray();
 $_ = $xs[0]->onlyInDerived();
 `)
+}
+
+func TestStaticResolutionInsideSameClass(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	class NotA {
+		/** @return static */
+		public static function instance() {
+			return new static;
+		}
+	}
+
+	class A {
+		/** @return int */
+		public function b() {
+			$a = new static();
+			return $a->c();
+		}
+		protected function fakeB() {
+			$a = NotA::instance();
+			return $a->c();
+		}
+		protected function instance() {
+			return new static;
+		}
+		/** @return int */
+		public function c() {
+			return 1;
+		}
+	}
+
+	class B extends A {
+		protected function derived() {}
+		protected function test() {
+			$this->instance()->derived();
+			$this->instance()->nonDerived();
+		}
+	}`)
+
+	test.Expect = []string{
+		"Call to undefined method {\\NotA}->c()",
+		"Call to undefined method {\\B}->nonDerived()",
+	}
+	test.RunAndMatch()
 }
 
 func TestInterfaceConstants(t *testing.T) {

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -47,7 +47,7 @@ func ExprTypeCustom(sc *meta.Scope, cs *meta.ClassParseState, n node.Node, custo
 			}
 		}()
 
-		for kk := range ResolveType(k, visitedMap) {
+		for kk := range ResolveType(cs.CurrentClass, k, visitedMap) {
 			newMap[kk] = struct{}{}
 		}
 	})

--- a/src/solver/solver_test.go
+++ b/src/solver/solver_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func resolve(typ string) map[string]struct{} {
-	return ResolveType(typ, make(map[string]struct{}))
+	return ResolveType("", typ, make(map[string]struct{}))
 }
 
 func makeTyp(typ string) map[string]struct{} {


### PR DESCRIPTION
Cache version bump in theory may be required if wrong types were cached because of inability to resolve static inside the class before. I am not sure though. If it is required then it is probably very rare.