### PR TITLE
improve type inference

### DIFF
--- a/src/linter/block_context.go
+++ b/src/linter/block_context.go
@@ -14,9 +14,6 @@ type blockContext struct {
 	exitFlags         int // if block always breaks code flow then there will be exitFlags
 	containsExitFlags int // if block sometimes breaks code flow then there will be containsExitFlags
 
-	// inferred return types if any
-	returnTypes *meta.TypesMap
-
 	deadCodeReported bool
 
 	// Fields below should be copied during context cloning.

--- a/src/linter/phpdoc_util.go
+++ b/src/linter/phpdoc_util.go
@@ -1,0 +1,65 @@
+package linter
+
+import (
+	"fmt"
+	"strings"
+)
+
+type phpdocTypeFixer struct {
+	notice string
+}
+
+// Fix tries to return a corrected version of typ.
+// If typ was already correct, it returned unchanged.
+// Returns first correction notice in addition to the fixed type.
+func (f *phpdocTypeFixer) Fix(typ string) (fixed, notice string) {
+	f.notice = ""
+	fixedTyp := f.fix(typ)
+	return fixedTyp, f.notice
+}
+
+func (f *phpdocTypeFixer) fix(typ string) string {
+	// Check commonly misspelled types and other unfortunate cases.
+	switch typ {
+	case "callback":
+		f.noticef("use callable type instead of callback")
+		return "callable"
+	case "boolean":
+		f.noticef("use bool type instead of boolean")
+		return "bool"
+	case "double", "real":
+		f.noticef("use float type instead of " + typ)
+		return "float"
+	case "long", "integer":
+		f.noticef("use int type instead of " + typ)
+		return "int"
+	case "[]":
+		f.noticef("[] is not a valid type, array implied")
+		return "array"
+	case "-":
+		// This happens when either of these formats is used:
+		// `* @param $name - description`
+		// `* @param - $name description`
+		// We don't want to make "-" slip as a type name.
+		f.noticef("expected a type, found '-'; if you want to express 'any' type, use 'mixed'")
+		return "mixed"
+	case "":
+		return "mixed"
+	}
+
+	// Fix []T -> T[]
+	if strings.HasPrefix(typ, "[]") && typ != "[]" {
+		f.noticef("%s type syntax: use [] after the type, e.g. T[]", typ)
+		typ = strings.TrimPrefix(typ, "[]")
+		typ += "[]"
+		return f.fix(typ)
+	}
+
+	return typ
+}
+
+func (f *phpdocTypeFixer) noticef(format string, args ...interface{}) {
+	if f.notice == "" {
+		f.notice = fmt.Sprintf(format, args...)
+	}
+}

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -861,7 +861,7 @@ $_ = $bad1;
 		`Undefined variable: bad1`, // At global scope
 		`Undefined variable: bad2`,
 		`Undefined variable: bad3`,
-		`Property {}->x does not exist`,
+		`Property {mixed}->x does not exist`,
 		`Variable might have not been defined: y1`,
 	}
 	test.RunAndMatch()

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -535,7 +535,7 @@ func TestClosureLateBinding(t *testing.T) {
 	`)
 	test.Expect = []string{
 		"Undefined variable: a",
-		"Call to undefined method {}->method()",
+		"Call to undefined method {mixed}->method()",
 	}
 	runFilterMatch(test, "undefined")
 }
@@ -574,7 +574,7 @@ func TestIssue16(t *testing.T) {
 	}`)
 	test.Expect = []string{
 		`Call to undefined method {\TestExInterface}->nonexistent()`,
-		"Call to undefined method {}->format()",
+		"Call to undefined method {mixed}->format()",
 		"Class constant \\TestExInterface::TEST2 does not exist",
 	}
 	runFilterMatch(test, "undefined")
@@ -814,7 +814,7 @@ func TestInstanceOf(t *testing.T) {
 		}
 	}`)
 	test.Expect = []string{
-		`Call to undefined method {}->get2()`,
+		`Call to undefined method {void}->get2()`,
 		`Call to undefined method {\Element}->callUndefinedMethod()`,
 	}
 	runFilterMatch(test, "undefined")

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -10,6 +10,12 @@ import (
 	"strings"
 )
 
+// Preallocated and shared immutable type maps.
+var (
+	MixedType = NewTypesMap("mixed").Immutable()
+	VoidType  = NewTypesMap("void").Immutable()
+)
+
 const (
 	// Constants for lazy ("wrap") types:
 	// Here "<string>" means 2 bytes of length followed by string contents.

--- a/src/solver/solver_test.go
+++ b/src/solver/solver_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func resolve(typ string) map[string]struct{} {
-	return ResolveType("", typ, make(map[string]struct{}))
+	return resolveType("", typ, make(map[string]struct{}))
 }
 
 func makeTyp(typ string) map[string]struct{} {
@@ -49,10 +49,6 @@ func TestSolver(t *testing.T) {
 	meta.Info.AddToGlobalScopeNonLocked("test", sc)
 	meta.Info.AddFunctionsNonLocked("test", fm)
 	meta.Info.AddClassesNonLocked("test", cm)
-
-	if typ := resolve(meta.WrapFunctionCall(`\my_func`)); !typesEqual(typ, `array|bool|float`) {
-		t.Errorf("My func wrong type: %+v", typ)
-	}
 
 	if typ := resolve(meta.WrapGlobal(`MC`)); !typesEqual(typ, `Memcache`) {
 		t.Errorf("Global $MC wrong: %+v", typ)

--- a/src/solver/solver_test.go
+++ b/src/solver/solver_test.go
@@ -50,6 +50,10 @@ func TestSolver(t *testing.T) {
 	meta.Info.AddFunctionsNonLocked("test", fm)
 	meta.Info.AddClassesNonLocked("test", cm)
 
+	if typ := resolve(meta.WrapFunctionCall(`\my_func`)); !typesEqual(typ, `array|bool|float`) {
+		t.Errorf("My func wrong type: %+v", typ)
+	}
+
 	if typ := resolve(meta.WrapGlobal(`MC`)); !typesEqual(typ, `Memcache`) {
 		t.Errorf("Global $MC wrong: %+v", typ)
 	}


### PR DESCRIPTION
An attempt to improve type inference.

```
Currently, if an expression has type T, it doesn't mean:
    "expression always have type T"
it only states that
    "expressions might have type T in some cases"
```

So, the function below is believed to return "int" type:

	function f($cond) {
		if ($cond) { return 10; }
		return $cond;
	}

The bad part is that it can return a value of type($cond).
The right answer would be `int|type($cond)`, but `int|mixed`
would still be better for now.

- try to fix misspelled types instead of just complaining about them

- make functions/expressions always have type.
  When precise type can't be inferred, use void/mixed.
  To avoid tons of new allocations, void and mixed type maps are shared
  as immutable type maps.

- move returnTypes from block context into the block itself,
  since now block checker lives for the entire function scope.
  It makes messing up with merging context impossible.
  We had several issues with type inference due to that
  (fixed in this change, tests are included).

- add left/right shifts type inference

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>