### PR TITLE
resolve array to mixed[]

### DIFF
--- a/src/linter/phpdoc_util.go
+++ b/src/linter/phpdoc_util.go
@@ -34,8 +34,10 @@ func (f *phpdocTypeFixer) fix(typ string) string {
 		f.noticef("use int type instead of " + typ)
 		return "int"
 	case "[]":
-		f.noticef("[] is not a valid type, array implied")
-		return "array"
+		f.noticef("[] is not a valid type, mixed[] implied")
+		return "mixed[]"
+	case "array":
+		return "mixed[]"
 	case "-":
 		// This happens when either of these formats is used:
 		// `* @param $name - description`

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -95,11 +95,11 @@ func arrayType(items []node.Node) *meta.TypesMap {
 		//
 		// Should be resolved before used.
 		//
-		// We do this to simplify resolving `array|int[]` to `int[]`.
+		// We do this to simplify resolving `mixed[]|int[]` to `int[]`.
 		// If we know that an array is empty, then it's valid array
 		// for any mono-typed array, so we can just throw away "empty_array"
 		// in that case. If element type is unknown, "empty_array" is
-		// resolved into "array".
+		// resolved into "mixed[]".
 		return meta.NewTypesMap("empty_array")
 	}
 
@@ -114,7 +114,7 @@ func arrayType(items []node.Node) *meta.TypesMap {
 		}
 	}
 
-	return meta.NewTypesMap("array")
+	return meta.NewTypesMap("mixed[]")
 }
 
 func isConstantStringArray(items []node.Node) bool {
@@ -319,7 +319,7 @@ func exprTypeLocalCustom(sc *meta.Scope, cs *meta.ClassParseState, n node.Node, 
 	case *binary.Mod:
 		return binaryMathOpType(sc, cs, n.Left, n.Right, custom)
 	case *cast.Array:
-		return meta.NewTypesMap("array")
+		return meta.NewTypesMap("mixed[]")
 	case *cast.Bool:
 		return meta.NewTypesMap("bool")
 	case *cast.Double:

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -219,7 +219,7 @@ func (r *resolver) resolveTypes(class string, m *meta.TypesMap) map[string]struc
 			}
 		}
 		if !specialized {
-			res["array"] = struct{}{}
+			res["mixed[]"] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
So algorithms that infer array element by stripping [] suffix work
without ad-hoc elemOf("array")=>mixed case.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>