### PR TITLE
call AfterEnterNode for block checkers even if res=false

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -366,10 +366,8 @@ func (b *BlockWalker) EnterNode(w walker.Walkable) (res bool) {
 		// b.d.debug(`  Statement: %T`, s)
 	}
 
-	if res {
-		for _, c := range b.custom {
-			c.AfterEnterNode(w)
-		}
+	for _, c := range b.custom {
+		c.AfterEnterNode(w)
 	}
 
 	return res


### PR DESCRIPTION
This is consistent with root checker.
res only controls whether we enter children nodes, it should
not affect "after enter" callback.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>