### PR TITLE
Handle malformed type-name pairs in @property phpdoc attrs

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -847,7 +847,7 @@ func (d *RootWalker) parsePHPDocClass(doc string) classPhpDocParseResult {
 		}
 
 		if len(part.Params) >= 2 && strings.HasPrefix(typ, "$") && !strings.HasPrefix(name, "$") {
-			result.errs.pushLint("non-canonical order of variable and type on line %d", part.Line)
+			result.errs.pushLint("non-canonical order of name and type on line %d", part.Line)
 			name, typ = typ, name
 		}
 

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -831,10 +831,27 @@ func (d *RootWalker) parsePHPDocClass(doc string) classPhpDocParseResult {
 			continue
 		}
 
-		// TODO(quasilyte): do same type/var reordering as in @param handling
-		// so we can fix wrong annotation and get types info from it.
-		typ, err := d.fixPHPDocType(part.Params[0])
-		name := part.Params[1]
+		typ := part.Params[0]
+		var name string
+		if len(part.Params) >= 2 {
+			name = part.Params[1]
+		} else {
+			// Either type or var name is missing.
+			if strings.HasPrefix(typ, "$") {
+				result.errs.pushLint("malformed @property %s tag (maybe type is missing?) on line %d",
+					part.Params[0], part.Line)
+				continue
+			} else {
+				result.errs.pushLint("malformed @property tag (maybe field name is missing?) on line %d", part.Line)
+			}
+		}
+
+		if len(part.Params) >= 2 && strings.HasPrefix(typ, "$") && !strings.HasPrefix(name, "$") {
+			result.errs.pushLint("non-canonical order of variable and type on line %d", part.Line)
+			name, typ = typ, name
+		}
+
+		typ, err := d.fixPHPDocType(typ)
 		if err != "" {
 			result.errs.pushType("%s on line %d", err, part.Line)
 			continue

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -156,7 +156,7 @@ class Foo {}
 	test.Expect = []string{
 		`use int type instead of integer on line 2`,
 		`[]t type syntax: use [] after the type, e.g. T[] on line 3`,
-		`non-canonical order of variable and type on line 6`,
+		`non-canonical order of name and type on line 6`,
 		`line 4: @property requires type and property name fields`,
 		`line 5: @property requires type and property name fields`,
 	}

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -149,12 +149,14 @@ func TestPHPDocProperty(t *testing.T) {
  * @property []t ts
  * @property
  * @property string
+ * @property $int string
  */
 class Foo {}
 `)
 	test.Expect = []string{
 		`use int type instead of integer on line 2`,
 		`[]t type syntax: use [] after the type, e.g. T[] on line 3`,
+		`non-canonical order of variable and type on line 6`,
 		`line 4: @property requires type and property name fields`,
 		`line 5: @property requires type and property name fields`,
 	}


### PR DESCRIPTION
Signed-off-by: Yaroslav Yadrishnikov <y.yadrushnikov@corp.vk.com>