### PR TITLE
added syntax check in function definition argument list

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1046,6 +1046,29 @@ func (d *RootWalker) parseTypeNode(n node.Node) (typ *meta.TypesMap, ok bool) {
 	return typ, typ != nil
 }
 
+// checkFuncArgs checks syntax of argument list in function definition, and reports found errors
+// so far checks only default values for valid array syntax
+func (d *RootWalker) checkFuncArgs(params []node.Node) {
+	for _, param := range params {
+		p := param.(*node.Parameter)
+		if p.DefaultValue != nil {
+			switch s := p.DefaultValue.(type) {
+			case *expr.Array:
+				b := &BlockWalker{
+					r: d,
+				}
+				b.handleArray(s)
+			case *expr.ShortArray:
+				b := &BlockWalker{
+					r: d,
+				}
+				b.handleArrayItems(s, s.Items)
+			default:
+			}
+		}
+	}
+}
+
 func (d *RootWalker) parseFuncArgs(params []node.Node, parTypes phpDocParamsMap, sc *meta.Scope) (args []meta.FuncParam, minArgs int) {
 	args = make([]meta.FuncParam, 0, len(params))
 	for _, param := range params {
@@ -1110,6 +1133,8 @@ func (d *RootWalker) enterFunction(fun *stmt.Function) bool {
 	d.reportPhpdocErrors(fun.FunctionName, doc.errs)
 	phpdocReturnType := doc.returnType
 	phpDocParamTypes := doc.types
+
+	d.checkFuncArgs(fun.Params)
 
 	if d.meta.Functions == nil {
 		d.meta.Functions = make(meta.FunctionsMap)

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -88,6 +88,16 @@ function mt_rand($x = 0, $y = 0) {}`)
 	test.RunAndMatch()
 }
 
+func TestArgsArraysSyntax(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function f($a = array()) {}`)
+	test.Expect = []string{
+		`Use of old array syntax (use short form instead)`,
+	}
+	test.RunAndMatch()
+}
+
 func TestMethodComplexity(t *testing.T) {
 	funcCode := strings.Repeat("$_ = 0;\n", 9999)
 	test := linttest.NewSuite(t)


### PR DESCRIPTION
Should fix #93 

Added `checkFuncArgs` function to check and report argument list syntax (could be expanded later with more checks). It goes after phpdoc checks, but before type inference/checks in `parseFuncArgs`.
Reused blockWalker `handleArray` for checks, which should also warn for duplicate keys etc.