### PR TITLE
handle func params in block walker

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1063,29 +1063,6 @@ func (d *RootWalker) parseTypeNode(n node.Node) (typ *meta.TypesMap, ok bool) {
 	return typ, typ != nil
 }
 
-// checkFuncArgs checks syntax of argument list in function definition, and reports found errors
-// so far checks only default values for valid array syntax
-func (d *RootWalker) checkFuncArgs(params []node.Node) {
-	for _, param := range params {
-		p := param.(*node.Parameter)
-		if p.DefaultValue != nil {
-			switch s := p.DefaultValue.(type) {
-			case *expr.Array:
-				b := &BlockWalker{
-					r: d,
-				}
-				b.handleArray(s)
-			case *expr.ShortArray:
-				b := &BlockWalker{
-					r: d,
-				}
-				b.handleArrayItems(s, s.Items)
-			default:
-			}
-		}
-	}
-}
-
 func (d *RootWalker) parseFuncArgs(params []node.Node, parTypes phpDocParamsMap, sc *meta.Scope) (args []meta.FuncParam, minArgs int) {
 	args = make([]meta.FuncParam, 0, len(params))
 	for _, param := range params {
@@ -1150,8 +1127,6 @@ func (d *RootWalker) enterFunction(fun *stmt.Function) bool {
 	d.reportPhpdocErrors(fun.FunctionName, doc.errs)
 	phpdocReturnType := doc.returnType
 	phpDocParamTypes := doc.types
-
-	d.checkFuncArgs(fun.Params)
 
 	if d.meta.Functions == nil {
 		d.meta.Functions = make(meta.FunctionsMap)


### PR DESCRIPTION
With this, we don't create block walkers for
every function parameter in root walker.

(It's better to keep walkers construction limited,
since we want to better understand their lifetime and scope.)

follow-up for #243

CC @whisk 