### PR TITLE
support for Alt* statement forms

### DIFF
--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -6,6 +6,54 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestIssue252(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Foo {
+  public $foo = 10;
+}
+class Bar {
+  public $bar = 20;
+}
+
+function alt_foreach($arr) {
+  foreach ($arr AS $key => $value):
+    $_ = [$key, $value];
+  endforeach;
+}
+
+function alt_if($v) {
+  if ($v instanceof Foo):
+    $_ = $v->foo;
+  elseif ($v instanceof Bar):
+    $_ = $v->bar;
+  endif;
+}
+`)
+
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function alt_for() {
+  for ($i = 0; $i < 10; $i++):
+    $x1 = 10;
+  endfor;
+  $_ = $x1;
+}
+
+function alt_switch($v) {
+  switch ($v):
+  case 1:
+    $v = 3;
+  case 2:
+    return $v;
+  endswitch;
+}`)
+	test.Expect = []string{
+		`Variable might have not been defined: x1`,
+		`Add break or '// fallthrough' to the end of the case`,
+	}
+	test.RunAndMatch()
+}
+
 func TestIssue1(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 	interface TestInterface


### PR DESCRIPTION
Handle Alt* forms like normal statement forms.
Maps AltFor->For, AltWhile->While, etc.

Fixes #253

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>