### PR TITLE
always use non-ptr version of meta.TypesMap

### DIFF
--- a/src/langsrv/defs.go
+++ b/src/langsrv/defs.go
@@ -26,7 +26,7 @@ type definitionWalker struct {
 	foundScopes []*meta.Scope
 }
 
-func safeExprType(sc *meta.Scope, cs *meta.ClassParseState, n node.Node) (res *meta.TypesMap) {
+func safeExprType(sc *meta.Scope, cs *meta.ClassParseState, n node.Node) (res meta.TypesMap) {
 	defer func() {
 		if r := recover(); r != nil {
 			res = meta.NewTypesMap(fmt.Sprintf("Panic: %s", fmt.Sprint(r)))

--- a/src/langsrv/langsrv.go
+++ b/src/langsrv/langsrv.go
@@ -424,7 +424,7 @@ func handleTextDocumentReferences(req *baseRequest) error {
 	})
 }
 
-func resolveTypesSafe(curStaticClass string, m *meta.TypesMap, visitedMap map[string]struct{}) (res map[string]struct{}) {
+func resolveTypesSafe(curStaticClass string, m meta.TypesMap, visitedMap map[string]struct{}) (res map[string]struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
 			res = make(map[string]struct{})
@@ -671,7 +671,7 @@ func handleTextDocumentCompletion(req *baseRequest) error {
 		if strings.HasSuffix(chStr, "->") {
 			result = append(result, getMethodCompletionItems(&compl.st, chStr, compl.foundScope)...)
 		} else {
-			compl.foundScope.Iterate(func(varName string, typ *meta.TypesMap, alwaysDefined bool) {
+			compl.foundScope.Iterate(func(varName string, typ meta.TypesMap, alwaysDefined bool) {
 				result = append(result, vscode.CompletionItem{
 					Kind:  vscode.CompletionKindVariable,
 					Label: "$" + varName,

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -260,7 +260,7 @@ func (i *info) AddConstantsNonLocked(filename string, m ConstantsMap) {
 }
 
 func (i *info) AddToGlobalScopeNonLocked(filename string, sc *Scope) {
-	sc.Iterate(func(nm string, typ *TypesMap, alwaysDefined bool) {
+	sc.Iterate(func(nm string, typ TypesMap, alwaysDefined bool) {
 		i.AddVarName(nm, typ, "global", alwaysDefined)
 	})
 }
@@ -268,7 +268,7 @@ func (i *info) AddToGlobalScopeNonLocked(filename string, sc *Scope) {
 type FuncParam struct {
 	IsRef bool
 	Name  string
-	Typ   *TypesMap
+	Typ   TypesMap
 }
 
 type PhpDocInfo struct {
@@ -280,7 +280,7 @@ type FuncInfo struct {
 	Pos          ElementPosition
 	Params       []FuncParam
 	MinParamsCnt int
-	Typ          *TypesMap
+	Typ          TypesMap
 	AccessLevel  AccessLevel
 	Static       bool
 	ExitFlags    int // if function has exit/die/throw, then ExitFlags will be <> 0
@@ -326,13 +326,13 @@ type FuncInfoOverride struct {
 
 type PropertyInfo struct {
 	Pos         ElementPosition
-	Typ         *TypesMap
+	Typ         TypesMap
 	AccessLevel AccessLevel
 }
 
 type ConstantInfo struct {
 	Pos         ElementPosition
-	Typ         *TypesMap
+	Typ         TypesMap
 	AccessLevel AccessLevel
 }
 

--- a/src/meta/scope.go
+++ b/src/meta/scope.go
@@ -12,7 +12,7 @@ import (
 var debugScope = false
 
 type scopeVar struct {
-	typesMap      *TypesMap
+	typesMap      TypesMap
 	alwaysDefined bool
 	noReplace     bool // do not replace variable upon assignment (used for phpdoc @var declaration)
 }
@@ -111,7 +111,7 @@ func (s *Scope) SetInClosure(v bool) {
 	s.inClosure = v
 }
 
-func (s *Scope) Iterate(cb func(varName string, typ *TypesMap, alwaysDefined bool)) {
+func (s *Scope) Iterate(cb func(varName string, typ TypesMap, alwaysDefined bool)) {
 	for varName, v := range s.vars {
 		cb(varName, v.typesMap, v.alwaysDefined)
 	}
@@ -122,7 +122,7 @@ func (s *Scope) Len() int {
 }
 
 // AddVar adds variable with specified types to scope
-func (s *Scope) AddVar(v *node.Variable, typ *TypesMap, reason string, alwaysDefined bool) {
+func (s *Scope) AddVar(v *node.Variable, typ TypesMap, reason string, alwaysDefined bool) {
 	name, ok := scopeVarName(v)
 	if !ok {
 		return
@@ -132,7 +132,7 @@ func (s *Scope) AddVar(v *node.Variable, typ *TypesMap, reason string, alwaysDef
 }
 
 // ReplaceVar replaces variable with specified types to scope
-func (s *Scope) ReplaceVar(v *node.Variable, typ *TypesMap, reason string, alwaysDefined bool) {
+func (s *Scope) ReplaceVar(v *node.Variable, typ TypesMap, reason string, alwaysDefined bool) {
 	name, ok := scopeVarName(v)
 	if !ok {
 		return
@@ -160,7 +160,7 @@ func (s *Scope) DelVarName(name, reason string) {
 }
 
 // ReplaceVarName replaces variable with specified types to the scope
-func (s *Scope) ReplaceVarName(name string, typ *TypesMap, reason string, alwaysDefined bool) {
+func (s *Scope) ReplaceVarName(name string, typ TypesMap, reason string, alwaysDefined bool) {
 	oldVar, ok := s.vars[name]
 	if ok && oldVar.noReplace {
 		oldVar.typesMap = oldVar.typesMap.Append(typ)
@@ -174,7 +174,7 @@ func (s *Scope) ReplaceVarName(name string, typ *TypesMap, reason string, always
 }
 
 // AddVarName adds variable with specified types to the scope
-func (s *Scope) addVarName(name string, typ *TypesMap, reason string, alwaysDefined, noReplace bool) {
+func (s *Scope) addVarName(name string, typ TypesMap, reason string, alwaysDefined, noReplace bool) {
 	v, ok := s.vars[name]
 
 	if !ok {
@@ -199,12 +199,12 @@ func (s *Scope) addVarName(name string, typ *TypesMap, reason string, alwaysDefi
 }
 
 // AddVarName adds variable with specified types to the scope
-func (s *Scope) AddVarName(name string, typ *TypesMap, reason string, alwaysDefined bool) {
+func (s *Scope) AddVarName(name string, typ TypesMap, reason string, alwaysDefined bool) {
 	s.addVarName(name, typ, reason, alwaysDefined, false)
 }
 
 // AddVarFromPHPDoc adds variable with specified types to the scope
-func (s *Scope) AddVarFromPHPDoc(name string, typ *TypesMap, reason string) {
+func (s *Scope) AddVarFromPHPDoc(name string, typ TypesMap, reason string) {
 	s.addVarName(name, typ, reason, true, true)
 }
 
@@ -238,10 +238,10 @@ func (s *Scope) HaveVarName(name string) bool {
 }
 
 // GetVarNameType returns type map for variable if it exists
-func (s *Scope) GetVarNameType(name string) (m *TypesMap, ok bool) {
+func (s *Scope) GetVarNameType(name string) (m TypesMap, ok bool) {
 	res, ok := s.vars[name]
 	if !ok {
-		return &TypesMap{}, false
+		return TypesMap{}, false
 	}
 	return res.typesMap, ok
 }
@@ -271,14 +271,8 @@ func (s *Scope) Clone() *Scope {
 
 	res := &Scope{vars: make(map[string]*scopeVar, len(s.vars))}
 	for k, v := range s.vars {
-		m := make(map[string]struct{}, v.typesMap.Len())
-		if v.typesMap != nil {
-			for kk, vv := range v.typesMap.m {
-				m[kk] = vv
-			}
-		}
 		res.vars[k] = &scopeVar{
-			typesMap:      &TypesMap{m: m},
+			typesMap:      v.typesMap.clone(),
 			alwaysDefined: v.alwaysDefined,
 		}
 	}

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -482,6 +482,10 @@ func (m TypesMap) GobDecode(buf []byte) error {
 
 // Iterate applies cb to all contained types
 func (m TypesMap) Iterate(cb func(typ string)) {
+	if m.Len() == 0 {
+		return
+	}
+
 	// We need to sort types so that we always iterate classes using the same order.
 	keys := make([]string, 0, len(m.m))
 	for k := range m.m {

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -27,7 +27,7 @@ func resolveType(curStaticClass, typ string, visitedMap map[string]struct{}) (re
 
 // ResolveTypes resolves function calls, method calls and global variables.
 //   curStaticClass is current class name (if inside the class, otherwise "")
-func ResolveTypes(curStaticClass string, m *meta.TypesMap, visitedMap map[string]struct{}) map[string]struct{} {
+func ResolveTypes(curStaticClass string, m meta.TypesMap, visitedMap map[string]struct{}) map[string]struct{} {
 	r := resolver{visited: visitedMap}
 	return r.resolveTypes(curStaticClass, m)
 }
@@ -189,7 +189,7 @@ func solveBaseMethodParam(curStaticClass, typ string, visitedMap, res map[string
 	return res
 }
 
-func (r *resolver) resolveTypes(class string, m *meta.TypesMap) map[string]struct{} {
+func (r *resolver) resolveTypes(class string, m meta.TypesMap) map[string]struct{} {
 	res := make(map[string]struct{}, m.Len())
 
 	m.Iterate(func(t string) {


### PR DESCRIPTION
TypesMap is 16 bytes on 64-bit systems (8 on 32-bit), there is
no point in passing it around as a pointer, since we already
have Append-like functions returning a new version of TypesMap objects.

The main benefit is that we don't need to guard against nil TypesMap anymore.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>