### PR TITLE
meta: add TypesMap.Find method

### DIFF
--- a/src/langsrv/langsrv.go
+++ b/src/langsrv/langsrv.go
@@ -565,13 +565,9 @@ func getHoverForMethodCall(n *expr.MethodCall, sc *meta.Scope, cs *meta.ClassPar
 	types := safeExprType(sc, cs, n.Variable)
 
 	var fun meta.FuncInfo
-	ok = false
-
-	types.Iterate(func(t string) {
-		if ok {
-			return
-		}
+	types.Find(func(t string) bool {
 		fun, _, ok = solver.FindMethod(t, id.Value)
+		return ok
 	})
 
 	return linter.FlagsToString(fun.ExitFlags)

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -944,13 +944,10 @@ func (b *BlockWalker) handleMethodCall(e *expr.MethodCall) bool {
 
 	exprType := solver.ExprTypeCustom(b.ctx.sc, b.r.st, e.Variable, b.ctx.customTypes)
 
-	exprType.Iterate(func(typ string) {
-		if foundMethod || magic {
-			return
-		}
-
+	exprType.Find(func(typ string) bool {
 		fn, implClass, foundMethod = solver.FindMethod(typ, methodName)
 		magic = haveMagicMethod(typ, `__call`)
+		return foundMethod || magic
 	})
 
 	e.Variable.Walk(b)
@@ -1070,12 +1067,10 @@ func (b *BlockWalker) handlePropertyFetch(e *expr.PropertyFetch) bool {
 	var info meta.PropertyInfo
 
 	typ := solver.ExprTypeCustom(b.ctx.sc, b.r.st, e.Variable, b.ctx.customTypes)
-	typ.Iterate(func(className string) {
-		if found || magic {
-			return
-		}
+	typ.Find(func(className string) bool {
 		info, implClass, found = solver.FindProperty(className, id.Value)
 		magic = haveMagicMethod(className, `__get`)
+		return found || magic
 	})
 
 	if !found && !magic && !b.r.st.IsTrait && !b.isThisInsideClosure(e.Variable) {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -762,15 +762,8 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 	}
 
 	if nm == "getIterator" && meta.IsIndexingComplete() && solver.Implements(d.st.CurrentClass, `\IteratorAggregate`) {
-		implementsTraversable := false
-		returnType.Iterate(func(typ string) {
-			if implementsTraversable {
-				return
-			}
-
-			if solver.Implements(typ, `\Traversable`) {
-				implementsTraversable = true
-			}
+		implementsTraversable := returnType.Find(func(typ string) bool {
+			return solver.Implements(typ, `\Traversable`)
 		})
 
 		if !implementsTraversable {

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -202,6 +202,21 @@ func (m TypesMap) GobDecode(buf []byte) error {
 	return decoder.Decode(&m.m)
 }
 
+// Find applies a predicate function to every contained type.
+// If callback returns true for any of them, this is a result of Find call.
+// False is returned if none of the contained types made pred function return true.
+//
+// Can only be used in a case where type traversal order does not matter.
+func (m TypesMap) Find(pred func(typ string) bool) bool {
+	for typ := range m.m {
+		if pred(typ) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Iterate applies cb to all contained types
 func (m TypesMap) Iterate(cb func(typ string)) {
 	if m.Len() == 0 {


### PR DESCRIPTION
Some TypesMap.Iterate usages have a pattern of returning early
when they satisfy some predicate. This can be expressed more
elegantly with Find() method, where we have the next advantages:

- Caller can stop traversal with returning "true", no need to
  guard against "already found" in the beginning of the callback.
- No sorting is applied, since these tasks don't require
  predictable traversal to be deterministic.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>