### PR TITLE
meta: remove TypesMap.IsInt and TypesMap.IsString

### DIFF
--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -1034,7 +1034,7 @@ func TestCorrectArrayTypes(t *testing.T) {
 		t.Errorf("Unexpected number of types: %d, excepted 1", l)
 	}
 
-	if !fn.Typ.IsInt() {
+	if !fn.Typ.Is("int") {
 		t.Errorf("Wrong type: %s, excepted int", fn.Typ)
 	}
 }

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -74,16 +74,6 @@ func (m TypesMap) Len() int {
 	return len(m.m)
 }
 
-// IsInt checks if map contains only int type
-func (m TypesMap) IsInt() bool {
-	return m.Is("int") || m.Is("integer")
-}
-
-// IsString checks if map contains only string type
-func (m TypesMap) IsString() bool {
-	return m.Is("string")
-}
-
 // Is reports whether m contains exactly one specified type.
 func (m TypesMap) Is(typ string) bool {
 	if m.Len() != 1 {

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -15,14 +15,14 @@ import (
 )
 
 func unaryMathOpType(sc *meta.Scope, cs *meta.ClassParseState, x node.Node, custom []CustomType) meta.TypesMap {
-	if ExprTypeLocalCustom(sc, cs, x, custom).IsInt() {
+	if ExprTypeLocalCustom(sc, cs, x, custom).Is("int") {
 		return meta.NewTypesMap("int")
 	}
 	return meta.NewTypesMap("float")
 }
 
 func binaryMathOpType(sc *meta.Scope, cs *meta.ClassParseState, left, right node.Node, custom []CustomType) meta.TypesMap {
-	if ExprTypeLocalCustom(sc, cs, left, custom).IsInt() && ExprTypeLocalCustom(sc, cs, right, custom).IsInt() {
+	if ExprTypeLocalCustom(sc, cs, left, custom).Is("int") && ExprTypeLocalCustom(sc, cs, right, custom).Is("int") {
 		return meta.NewTypesMap("int")
 	}
 	return meta.NewTypesMap("float")


### PR DESCRIPTION
We have TypesMap.Is method that can replace them.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>