### PR TITLE
linter: fixed a bug in typesmap decoding + added a test

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -156,19 +156,25 @@ func createMetaCacheFile(filename, cacheFile string, root *RootWalker) error {
 	return nil
 }
 
-func restoreMetaFromCache(filename string, rd io.Reader) error {
-	var m fileMeta
-
-	bufrd := bufio.NewReader(rd)
+func readMetaCache(r io.Reader, filename string, dst *fileMeta) error {
+	bufrd := bufio.NewReader(r)
 	if err := readMetaCacheHeader(bufrd); err != nil {
 		return err
 	}
 
 	dec := gob.NewDecoder(bufrd)
-	if err := dec.Decode(&m); err != nil {
+	if err := dec.Decode(dst); err != nil {
 		return err
 	}
 	if err := customCachersDecode(filename, bufrd); err != nil {
+		return err
+	}
+	return nil
+}
+
+func restoreMetaFromCache(filename string, rd io.Reader) error {
+	var m fileMeta
+	if err := readMetaCache(rd, filename, &m); err != nil {
 		return err
 	}
 

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1055,6 +1055,10 @@ func (d *RootWalker) parseTypeNode(n node.Node) (typ meta.TypesMap, ok bool) {
 }
 
 func (d *RootWalker) parseFuncArgs(params []node.Node, parTypes phpDocParamsMap, sc *meta.Scope) (args []meta.FuncParam, minArgs int) {
+	if len(params) == 0 {
+		return nil, 0
+	}
+
 	args = make([]meta.FuncParam, 0, len(params))
 	for _, param := range params {
 		p := param.(*node.Parameter)

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -182,7 +182,7 @@ func (m TypesMap) GobEncode() ([]byte, error) {
 }
 
 // GobDecode is custom gob unmarshaller
-func (m TypesMap) GobDecode(buf []byte) error {
+func (m *TypesMap) GobDecode(buf []byte) error {
 	r := bytes.NewBuffer(buf)
 	decoder := gob.NewDecoder(r)
 	err := decoder.Decode(&m.immutable)


### PR DESCRIPTION
- GodDecode should be a pointer receiver to update a
  struct that is being decoded. We still can use non-ptr
  TypesMap everywhere, gob will do the right thing
  when calling GobDecode even if we have maps of
  non-pointer TypesMap.

- Extended TestCache to check for decoded meta correctness

- Added consts to cache test sources.
  (We still need to extend the coverage even further.)

- Return nil slice for func params for 0-length param slices.
  This is primarily to avoid complications with
  serialization/de-serialization testing, since nil
  slices are a default zero value.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>