### PR TITLE
linter: unexport some root/block methods

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -74,43 +74,6 @@ type BlockWalker struct {
 	nonLocalVars map[string]struct{} // static, global and other vars that have complex control flow
 }
 
-// Scope returns block-level variable scope if it exists.
-func (b *BlockWalker) Scope() *meta.Scope {
-	return b.ctx.sc
-}
-
-// PrematureExitFlags returns information about whether or not all code branches have exit/return/throw/etc.
-// You need to check what exactly you expect from a block to have (or not to have) by checking Flag* bits.
-func (b *BlockWalker) PrematureExitFlags() int {
-	return b.ctx.exitFlags
-}
-
-// RootState returns state that was stored in root context (if any) for use in custom hooks.
-func (b *BlockWalker) RootState() map[string]interface{} {
-	return b.r.State()
-}
-
-// IsRootLevel returns whether or not we currently analyze root level code.
-func (b *BlockWalker) IsRootLevel() bool {
-	return b.rootLevel
-}
-
-// Report registers a single report message about some found problem.
-func (b *BlockWalker) Report(n node.Node, level int, checkName, msg string, args ...interface{}) {
-	b.r.Report(n, level, checkName, msg, args...)
-}
-
-// ClassParseState returns class parse state (namespace, current class, etc)
-func (b *BlockWalker) ClassParseState() *meta.ClassParseState {
-	return b.r.st
-}
-
-// IsStatement checks whether or not the specified node is a top-level or a block-level statement.
-func (b *BlockWalker) IsStatement(n node.Node) bool {
-	_, ok := b.statements[n]
-	return ok
-}
-
 func (b *BlockWalker) addStatement(n node.Node) {
 	if b.statements == nil {
 		b.statements = make(map[node.Node]struct{})
@@ -1123,14 +1086,14 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 		}
 
 		if _, ok := keys[key]; ok {
-			b.Report(item.Key, LevelWarning, "dupArrayKeys", "Duplicate array key '%s'", key)
+			b.r.Report(item.Key, LevelWarning, "dupArrayKeys", "Duplicate array key '%s'", key)
 		}
 
 		keys[key] = struct{}{}
 	}
 
 	if haveImplicitKeys && haveKeys {
-		b.Report(arr, LevelWarning, "mixedArrayKeys", "Mixing implicit and explicit array keys")
+		b.r.Report(arr, LevelWarning, "mixedArrayKeys", "Mixing implicit and explicit array keys")
 	}
 
 	return false
@@ -2005,5 +1968,5 @@ func (b *BlockWalker) caseHasFallthroughComment(n node.Node) bool {
 }
 
 func (b *BlockWalker) isBool(n node.Node) bool {
-	return solver.ExprType(b.r.Scope(), b.r.st, n).Is("bool")
+	return solver.ExprType(b.r.scope(), b.r.st, n).Is("bool")
 }

--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -119,17 +119,17 @@ func (ctx *RootContext) Report(n node.Node, level int, checkName, msg string, ar
 
 // Scope returns variables declared at root level.
 func (ctx *RootContext) Scope() *meta.Scope {
-	return ctx.w.Scope()
+	return ctx.w.scope()
 }
 
 // ClassParseState returns class parse state (namespace, class, etc).
 func (ctx *RootContext) ClassParseState() *meta.ClassParseState {
-	return ctx.w.ClassParseState()
+	return ctx.w.st
 }
 
 // State returns state that can be modified and passed into block context
 func (ctx *RootContext) State() map[string]interface{} {
-	return ctx.w.State()
+	return ctx.w.state()
 }
 
 // Filename returns the file name of the file being analyzed.
@@ -154,36 +154,37 @@ type BlockContext struct {
 // chechName is a key that identifies the "checker" (diagnostic name) that found
 // issue being reported.
 func (ctx *BlockContext) Report(n node.Node, level int, checkName, msg string, args ...interface{}) {
-	ctx.w.Report(n, level, checkName, msg, args...)
+	ctx.w.r.Report(n, level, checkName, msg, args...)
 }
 
 // Scope returns variables declared in this block.
 func (ctx *BlockContext) Scope() *meta.Scope {
-	return ctx.w.Scope()
+	return ctx.w.r.scope()
 }
 
 // ClassParseState returns class parse state (namespace, class, etc).
 func (ctx *BlockContext) ClassParseState() *meta.ClassParseState {
-	return ctx.w.ClassParseState()
+	return ctx.w.r.st
 }
 
 // RootState returns state from root context.
 func (ctx *BlockContext) RootState() map[string]interface{} {
-	return ctx.w.RootState()
+	return ctx.w.r.state()
 }
 
 // IsRootLevel reports whether we are analysing root-level code currently.
 func (ctx *BlockContext) IsRootLevel() bool {
-	return ctx.w.IsRootLevel()
+	return ctx.w.rootLevel
 }
 
 // IsStatement reports whether or not specified node is a statement.
 func (ctx *BlockContext) IsStatement(n node.Node) bool {
-	return ctx.w.IsStatement(n)
+	_, ok := ctx.w.statements[n]
+	return ok
 }
 
 func (ctx *BlockContext) PrematureExitFlags() int {
-	return ctx.w.PrematureExitFlags()
+	return ctx.w.ctx.exitFlags
 }
 
 // Filename returns the file name of the file being analyzed.

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -161,16 +161,16 @@ func (d *RootWalker) UpdateMetaInfo() {
 	updateMetaInfo(d.filename, &d.meta)
 }
 
-// Scope returns root-level variable scope if applicable.
-func (d *RootWalker) Scope() *meta.Scope {
+// scope returns root-level variable scope if applicable.
+func (d *RootWalker) scope() *meta.Scope {
 	if d.meta.Scope == nil {
 		d.meta.Scope = meta.NewScope()
 	}
 	return d.meta.Scope
 }
 
-// State allows for custom hooks to store state between entering root context and block context.
-func (d *RootWalker) State() map[string]interface{} {
+// state allows for custom hooks to store state between entering root context and block context.
+func (d *RootWalker) state() map[string]interface{} {
 	if d.customState == nil {
 		d.customState = make(map[string]interface{})
 	}
@@ -180,11 +180,6 @@ func (d *RootWalker) State() map[string]interface{} {
 // GetReports returns collected reports for this file.
 func (d *RootWalker) GetReports() []*Report {
 	return d.reports
-}
-
-// ClassParseState returns class parse state (namespace, current class, etc)
-func (d *RootWalker) ClassParseState() *meta.ClassParseState {
-	return d.st
 }
 
 // EnterNode is invoked at every node in hierarchy
@@ -248,7 +243,7 @@ func (d *RootWalker) EnterNode(w walker.Walkable) (res bool) {
 			break
 		}
 
-		d.Scope().AddVar(v, solver.ExprTypeLocal(d.meta.Scope, d.st, n.Expression), "global variable", true)
+		d.scope().AddVar(v, solver.ExprTypeLocal(d.meta.Scope, d.st, n.Expression), "global variable", true)
 	case *stmt.Function:
 		res = d.enterFunction(n)
 	case *stmt.PropertyList:


### PR DESCRIPTION
These methods are only invoked through context that
doesn't need them to be exported.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>