### PR TITLE
all: add dynamic rules support (initial implementation)

### DIFF
--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -36,9 +36,9 @@ var (
 	reportsExclude          string
 	reportsExcludeChecks    string
 	reportsCritical         string
-	reportsExcludeChecksSet map[string]bool
-	reportsIncludeChecksSet map[string]bool
-	reportsCriticalSet      map[string]bool
+	reportsExcludeChecksSet = map[string]bool{}
+	reportsIncludeChecksSet = map[string]bool{}
+	reportsCriticalSet      = map[string]bool{}
 
 	allowChecks       string
 	allowDisable      string
@@ -48,6 +48,8 @@ var (
 
 	fullAnalysisFiles string
 	indexOnlyFiles    string
+
+	rulesList string
 
 	output     string
 	outputJSON bool
@@ -90,6 +92,9 @@ func bindFlags() {
 
 	flag.StringVar(&reportsCritical, "critical", allNonMaybe,
 		"Comma-separated list of check names that are considered critical (all non-maybe checks by default)")
+
+	flag.StringVar(&rulesList, "rules", "",
+		"Comma-separated list of rules files")
 
 	flag.StringVar(&gitRepo, "git", "", "Path to git repository to analyze")
 	flag.StringVar(&gitCommitFrom, "git-commit-from", "", "Analyze changes between commits <git-commit-from> and <git-commit-to>")

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -17,6 +17,7 @@ import (
 	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
 	"github.com/VKCOM/noverify/src/php/parser/walker"
 	"github.com/VKCOM/noverify/src/phpdoc"
+	"github.com/VKCOM/noverify/src/rules"
 	"github.com/VKCOM/noverify/src/solver"
 )
 
@@ -298,6 +299,17 @@ func (b *BlockWalker) EnterNode(w walker.Walkable) (res bool) {
 
 	for _, c := range b.custom {
 		c.AfterEnterNode(w)
+	}
+
+	if meta.IsIndexingComplete() && b.r.anyRset != nil {
+		// Note: no need to check localRset for nil.
+		kind := rules.CategorizeNode(n)
+		if kind != rules.KindNone {
+			b.r.runRules(n, b.ctx.sc, b.r.anyRset.RulesByKind[kind])
+			if !b.rootLevel {
+				b.r.runRules(n, b.ctx.sc, b.r.localRset.RulesByKind[kind])
+			}
+		}
 	}
 
 	return res

--- a/src/linter/conf.go
+++ b/src/linter/conf.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 
 	"github.com/VKCOM/noverify/src/inputs"
+	"github.com/VKCOM/noverify/src/rules"
 )
 
 var (
@@ -19,6 +20,9 @@ var (
 	//
 	// TODO(quasilyte): avoid having it as a global variable?
 	SrcInput = inputs.NewDefaultSourceInput()
+
+	// Rules is a set of dynamically loaded linter diagnostics.
+	Rules = &rules.Set{}
 
 	// settings
 	StubsDir        string

--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sort"
 
+	"github.com/VKCOM/noverify/src/linter/lintapi"
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/php/parser/node"
 	"github.com/VKCOM/noverify/src/php/parser/walker"
@@ -199,13 +200,13 @@ type BlockCheckerCreateFunc func(*BlockContext) BlockChecker
 type RootCheckerCreateFunc func(*RootContext) RootChecker
 
 const (
-	LevelError       = 1
-	LevelWarning     = 2
-	LevelInformation = 3
-	LevelHint        = 4
-	LevelUnused      = 5
-	LevelDoNotReject = 6 // do not treat this warning as a reason to reject if we get this kind of warning
-	LevelSyntax      = 7
+	LevelError       = lintapi.LevelError
+	LevelWarning     = lintapi.LevelWarning
+	LevelInformation = lintapi.LevelInformation
+	LevelHint        = lintapi.LevelHint
+	LevelUnused      = lintapi.LevelUnused
+	LevelDoNotReject = lintapi.LevelMaybe
+	LevelSyntax      = lintapi.LevelSyntax
 )
 
 var vscodeLevelMap = map[int]int{

--- a/src/linter/lintapi/lintapi.go
+++ b/src/linter/lintapi/lintapi.go
@@ -1,0 +1,20 @@
+package lintapi
+
+// This file exists to detach some parts from linter package
+// and avoid cyclic package dependencies.
+//
+// For instance, rules package needs warning levels to create
+// rule objects. Linter uses rules, so it can't simply import linter package.
+//
+// TODO: might want to replace this package with "reports" and move
+// linter.Report type in here, as well as some related utilities.
+
+const (
+	LevelError       = 1
+	LevelWarning     = 2
+	LevelInformation = 3
+	LevelHint        = 4
+	LevelUnused      = 5
+	LevelMaybe       = 6 // do not treat this warning as a reason to reject if we get this kind of warning
+	LevelSyntax      = 7
+)

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -121,6 +121,13 @@ func analyzeFile(filename string, contents []byte, parser *php7.Parser, lineRang
 		filename:   filename,
 		lineRanges: lineRanges,
 		st:         &meta.ClassParseState{},
+
+		// We need to clone rules since phpgrep matchers
+		// contain mutable state that we don't want to share
+		// between goroutines.
+		anyRset:   Rules.Any.Clone(),
+		rootRset:  Rules.Root.Clone(),
+		localRset: Rules.Local.Clone(),
 	}
 
 	w.InitFromParser(contents, parser)

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/php/parser/node"
 	"github.com/VKCOM/noverify/src/php/parser/node/expr"
 	"github.com/VKCOM/noverify/src/php/parser/node/scalar"
@@ -90,4 +91,25 @@ func varToString(v node.Node) string {
 	default:
 		return ""
 	}
+}
+
+func typeIsCompatible(actual meta.TypesMap, want string) bool {
+	if actual.Len() != 1 {
+		return false
+	}
+
+	return actual.Find(func(typ string) bool {
+		if typ == want {
+			return true
+		}
+
+		switch want {
+		case "mixed[]", "array":
+			if strings.HasSuffix(typ, "[]") {
+				return true
+			}
+		}
+
+		return false
+	})
 }

--- a/src/linttest/rules_test.go
+++ b/src/linttest/rules_test.go
@@ -1,0 +1,145 @@
+package linttest_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linter"
+	"github.com/VKCOM/noverify/src/linttest"
+	"github.com/VKCOM/noverify/src/rules"
+)
+
+func TestAnyRules(t *testing.T) {
+	rfile := `<?php
+/** @warning suspicious order of stripos function arguments */
+stripos(${"str"}, ${"*"});
+
+/** @warning duplicated sub-expressions inside boolean expression */
+$x && $x;
+
+/**
+ * @warning don't call explode with empty delimiter
+ * @scope any
+ */
+explode("", ${"*"});
+`
+
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function stripos($haystack, $needle, $offset = 0) { return 0; }
+function explode($delimeter, $s, $limit = 0) { return []; }
+
+function f($x, $y) {
+  $_ = stripos("needle", $x); // Bad
+  $_ = stripos($x, "needle"); // Good
+  $_ = stripos($x, $y);       // Good
+
+  $_ = $x && $x; // Bad
+  $_ = 1 && $x;  // Good
+  $_ = $x && $y; // Good
+}
+
+$s = "123";
+$_ = explode("", $s);
+`)
+
+	test.Expect = []string{
+		`duplicated sub-expressions inside boolean expression`,
+		`suspicious order of stripos function arguments`,
+		`don't call explode with empty delimiter`,
+	}
+	runRulesTest(t, test, rfile)
+}
+
+func TestLocalRules(t *testing.T) {
+	rfile := `<?php
+/**
+ * @warning suspicious empty body of the if statement
+ * @scope local
+ */
+if ($_);
+`
+
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+if (123); // No warning
+
+function f() {
+  if (123); // Warning
+}
+`)
+
+	test.Expect = []string{
+		`suspicious empty body of the if statement`,
+	}
+	runRulesTest(t, test, rfile)
+}
+
+func TestRootRules(t *testing.T) {
+	rfile := `<?php
+/**
+ * @warning self-assignment
+ * @scope root
+ */
+$x = $x;
+
+/**
+ * @maybe use require_once instead of require
+ * @scope root
+ */
+require($_);
+
+/**
+ * @warning duplicated then/else parts in ternary expression
+ * @scope root
+ */
+$_ ? $x : $x;
+
+/**
+ * @info the linter is spelled NoVerify
+ */
+"noverify";
+`
+
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function f1() {
+  $xs = [];
+  $xs[1] = $xs[1]; // No warn, since it's not inside root level
+
+  return $xs;
+}
+
+$v = 100;
+$v = $v; // Gives a warning
+
+$_ = $v == 100 ? 'a' : 'a'; // Warning
+$_ = $v == 100 ? 'a' : 'b'; // No warning
+
+require("some_file.php");      // Warning
+require_once("some_file.php"); // No warning
+
+$name = "noverify"; // Warning
+$name = "NoVerify"; // No warning
+`)
+
+	test.Expect = []string{
+		`self-assignment`,
+		`duplicated then/else parts in ternary expression`,
+		`use require_once instead of require`,
+		`the linter is spelled NoVerify`,
+	}
+	runRulesTest(t, test, rfile)
+}
+
+func runRulesTest(t *testing.T, test *linttest.Suite, rfile string) {
+	rparser := rules.NewParser()
+	rset, err := rparser.Parse("<test>", strings.NewReader(rfile))
+	if err != nil {
+		t.Fatalf("parse rules: %v", err)
+	}
+	oldRules := linter.Rules
+	linter.Rules = rset
+	test.RunAndMatch()
+	linter.Rules = oldRules
+}

--- a/src/linttest/rules_test.go
+++ b/src/linttest/rules_test.go
@@ -22,12 +22,30 @@ $x && $x;
  * @scope any
  */
 explode("", ${"*"});
+
+/**
+ * @warning 3rd argument of in_array must be true when comparing strings
+ * @type string $needle
+ */
+in_array($needle, $_);
+
+/**
+ * @warning strings must be compared using '===' operator
+ * @type string $x
+ * @or
+ * @type string $y
+ */
+$x == $y;
 `
 
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 function stripos($haystack, $needle, $offset = 0) { return 0; }
 function explode($delimeter, $s, $limit = 0) { return []; }
+function in_array($needle, $haystack, $strict = false) { return true; }
+function define($name, $value) {}
+
+define('true', 1 == 1);
 
 function f($x, $y) {
   $_ = stripos("needle", $x); // Bad
@@ -37,6 +55,18 @@ function f($x, $y) {
   $_ = $x && $x; // Bad
   $_ = 1 && $x;  // Good
   $_ = $x && $y; // Good
+
+  $str = 'x';
+  $int = 1;
+  $_ = in_array('x', $x);    // Bad
+  $_ = in_array($str, $x);   // Bad
+  $_ = in_array('x', $x, 1); // Good
+  $_ = in_array($int, $x);   // Good
+
+  $_ = $str == '1';  // Bad
+  $_ = '1' == $str;  // Bad
+  $_ = $str == $x;   // Bad
+  $_ = $str === '1'; // Good
 }
 
 $s = "123";
@@ -47,6 +77,11 @@ $_ = explode("", $s);
 		`duplicated sub-expressions inside boolean expression`,
 		`suspicious order of stripos function arguments`,
 		`don't call explode with empty delimiter`,
+		`3rd argument of in_array must be true when comparing strings`,
+		`3rd argument of in_array must be true when comparing strings`,
+		`strings must be compared using '===' operator`,
+		`strings must be compared using '===' operator`,
+		`strings must be compared using '===' operator`,
 	}
 	runRulesTest(t, test, rfile)
 }

--- a/src/phpgrep/LICENSE
+++ b/src/phpgrep/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Iskander (Alex) Sharipov / Quasilyte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/phpgrep/README.md
+++ b/src/phpgrep/README.md
@@ -1,0 +1,136 @@
+# phpgrep
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/quasilyte/phpgrep)](https://goreportcard.com/report/github.com/quasilyte/phpgrep)
+[![GoDoc](https://godoc.org/github.com/quasilyte/phpgrep?status.svg)](https://godoc.org/github.com/quasilyte/phpgrep)
+[![Build Status](https://travis-ci.org/quasilyte/phpgrep.svg?branch=master)](https://travis-ci.org/quasilyte/phpgrep)
+
+> TODO: clarify that this is a customized for integration fork of the [phpgrep](https://github.com/quasilyte/phpgrep).
+
+Syntax-aware grep for PHP code.
+
+This repository is used for the library and command-line tool development.
+A good source for additional utilities and ready-to-run recipes is [phpgrep-contrib](https://github.com/quasilyte/phpgrep-contrib) repository.
+
+## Overview
+
+`phpgrep` is both a library and a command-line tool.
+
+Library can be used to perform syntax-aware PHP code matching inside Go programs
+while binary utility can be used from your favorite text editor or terminal emulator.
+
+It's very close to [structural search and replace](https://www.jetbrains.com/help/phpstorm/structural-search-and-replace.html)
+in PhpStorm, but better suited for standalone usage.
+
+In many ways, inspired by [github.com/mvdan/gogrep/](https://github.com/mvdan/gogrep/).
+
+See also: ["phpgrep: syntax aware code search"](https://speakerdeck.com/quasilyte/phpgrep-syntax-aware-code-search).
+
+## Quick start
+
+To install `phpgrep` binary under your `$(go env GOPATH)/bin`:
+
+```bash
+go get -v github.com/quasilyte/phpgrep/cmd/phpgrep
+```
+
+If `$GOPATH/bin` is under your system `$PATH`, `phpgrep` command should be available after that.<br>
+This should print the help message:
+
+```bash
+$ phpgrep -help
+Usage: phpgrep [flags...] target pattern [filters...]
+Where:
+  flags are command-line flags that are listed in -help (see below)
+  target is a file or directory name where search is performed
+  pattern is a string that describes what is being matched
+  filters are optional arguments bound to the pattern
+
+Examples:
+  # Find f calls with a single variable argument.
+  phpgrep file.php 'f(${"var"})'
+  # Like previous example, but searches inside entire
+  # directory recursively and variable names are restricted
+  # to $id, $uid and $gid.
+  # Also uses -v flag that makes phpgrep output more info.
+  phpgrep -v ~/code/php 'f(${"x:var"})' 'x=id,uid,gid'
+
+Exit status:
+  0 if something is matched
+  1 if nothing is matched
+  2 if error occured
+
+# ... rest of output
+```
+
+Create a test file `hello.php`:
+
+```php
+<?php
+function f(...$xs) {}
+f(10);
+f(20);
+f(30);
+f($x);
+f();
+```
+
+Run `phpgrep` over that file:
+
+```bash
+# phpgrep hello.php 'f(${"x:int"})' 'x!=20'
+hello.php:3: f(10)
+hello.php:5: f(30)
+```
+
+We found all `f` calls with a **single** argument `x` that is `int` literal **not equal** to 20.
+
+Next thing to learn is `${"*"}` matcher.
+
+Suppose you need to match all `foo` function calls that have `null` argument.<br>
+`foo` is variadic, so it's unknown where that argument can be located.
+
+This pattern will match `null` arguments at any position: `foo(${"*"}, null, ${"*"})`.
+
+Read [pattern language docs](/pattern_language.md) to learn more about how to write search patterns.
+
+## Recipes
+
+This section contains ready-to-use `phpgrep` patterns.
+
+`srcdir` is a target source directory (can also be a single filename).
+
+### Useful recipes
+
+```bash
+# Find arrays with at least 1 duplicated key.
+$ phpgrep srcdir '[${"*"}, $k => $_, ${"*"}, $k => $_, ${"*"}]'
+
+# Find where ?: can be applied.
+$ phpgrep srcdir '$x ? $x : $y' # Use `$x ?: $y` instead
+
+# Find potential operator precedence issues.
+$ phpgrep srcdir '$x & $mask == $y' # Should be ($x & $mask) == $y
+$ phpgrep srcdir '$x & $mask != $y' # Should be ($x & $mask) != $y
+
+# Find calls where func args are misplaced.
+$ phpgrep srcdir 'stripos(${"str"}, $_)'
+$ phpgrep srcdir 'explode($_, ${"str"}, ${"*"})
+
+# Find new calls without parentheses.
+$ phpgrep srcdir 'new $t'
+
+# Find all if statements with a body without {}.
+$ phpgrep srcdir 'if ($cond) $x' 'x!~^\{'
+# Or without regexp.
+$ phpgrep srcdir 'if ($code) ${"expr"}'
+
+# Find all error-supress operator usages.
+$ phpgrep srcdir '@$_'
+```
+
+### Miscellaneous recipes
+
+```bash
+# Find all function calls that have at least one var-argument that has _id suffix.
+$ phpgrep srcdir '$f(${"*"}, ${"x:var"}, ${"*"})' 'x~.*_id$'
+```

--- a/src/phpgrep/compile.go
+++ b/src/phpgrep/compile.go
@@ -1,0 +1,81 @@
+package phpgrep
+
+import (
+	"strings"
+
+	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/node/scalar"
+	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
+	"github.com/VKCOM/noverify/src/php/parser/walker"
+)
+
+type compiler struct {
+	src []byte
+}
+
+func compile(opts *Compiler, pattern []byte) (*Matcher, error) {
+	root, src, err := parsePHP7(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	if st, ok := root.(*stmt.Expression); ok {
+		root = st.Expr
+	}
+
+	c := compiler{src: src}
+	root.Walk(&c)
+
+	m := &Matcher{m: matcher{root: root}}
+
+	return m, nil
+}
+
+func (c *compiler) EnterNode(w walker.Walkable) bool {
+	v, ok := w.(*node.Var)
+	if !ok {
+		return true
+	}
+	s, ok := v.Expr.(*scalar.String)
+	if !ok {
+		return true
+	}
+	value := unquoted(s.Value)
+
+	var name string
+	var class string
+
+	colon := strings.Index(value, ":")
+	if colon == -1 {
+		// Anonymous matcher.
+		name = "_"
+		class = value
+	} else {
+		// Named matcher.
+		name = value[:colon]
+		class = value[colon+len(":"):]
+	}
+
+	switch class {
+	case "var":
+		v.Expr = anyVar{metaNode{name: name}}
+	case "int":
+		v.Expr = anyInt{metaNode{name: name}}
+	case "float":
+		v.Expr = anyFloat{metaNode{name: name}}
+	case "str":
+		v.Expr = anyStr{metaNode{name: name}}
+	case "num":
+		v.Expr = anyNum{metaNode{name: name}}
+	case "expr":
+		v.Expr = anyExpr{metaNode{name: name}}
+	case "const":
+		v.Expr = anyConst{metaNode{name: name}}
+	case "func":
+		v.Expr = anyFunc{metaNode{name: name}}
+	}
+
+	return true
+}
+
+func (c *compiler) LeaveNode(w walker.Walkable) {}

--- a/src/phpgrep/doc.go
+++ b/src/phpgrep/doc.go
@@ -1,0 +1,44 @@
+// Package phpgrep is a library for searching PHP code
+// using syntax trees.
+//
+// Inspired by mvdan/gogrep.
+//
+// TODO(quasilyte): add the actual overview.
+package phpgrep
+
+// TODO(quasilyte): limitations of the currently used PHP parser imply some
+// unwanted side-effects. Enumerating them here.
+//
+// - We're missing parenthesis. We can't match with respect to them.
+//
+// - Can't match ";" (the empty statement).
+
+// TODO(quasilyte): unimplemented features.
+//
+// - Replace functionality.
+//
+// - Handle case sensitivity carefully (provide an option?).
+//
+// - stmt.Expression vs normal expressions named captures (should they match?).
+//
+// - Multi-statements matching.
+//   To match something like `while ($_); {${"*"};}` we need to
+//   continue matching rest of the pattern parts instead of stopping
+//   when `while ($_);` part is matched.
+
+// List of things that are hard (or impossible) to represent via patterns.
+//
+// - `$lhs <op> $rhs`; we can't express <op>.
+//
+// - Find a switch inside which "continue" is used.
+//   The problem is that there is no way to properly recurse.
+//
+// - Negative assertions, like "switch that doesn't have a default case".
+//
+// - Find duplicated switch case conditions.
+//   Can't use ${'*'} for "any case", since syntax expects only
+//   T_CASE and T_DEFAULT there, resulting in a syntax error.
+//   See issue #1.
+//
+// - $c::$constant doesn't match class const fetch,
+//   since it's static property fetch.

--- a/src/phpgrep/matcher.go
+++ b/src/phpgrep/matcher.go
@@ -1,0 +1,794 @@
+package phpgrep
+
+import (
+	"fmt"
+
+	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/assign"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/binary"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/cast"
+	"github.com/VKCOM/noverify/src/php/parser/node/name"
+	"github.com/VKCOM/noverify/src/php/parser/node/scalar"
+	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
+	"github.com/VKCOM/noverify/src/php/parser/walker"
+)
+
+type matcher struct {
+	root node.Node
+
+	handler func(*MatchData) bool
+	named   map[string]node.Node
+
+	literalMatch bool
+
+	data MatchData
+}
+
+func (m *matcher) matchAST(root node.Node) bool {
+	matched := false
+	m.findAST(root, func(*MatchData) bool {
+		matched = true
+		return false // Stop at the first match
+	})
+	return matched
+}
+
+func (m *matcher) findAST(root node.Node, callback func(*MatchData) bool) {
+	m.handler = callback
+
+	root.Walk(m)
+}
+
+func (m *matcher) eqNameParts(xs, ys []node.Node) bool {
+	if len(xs) != len(ys) {
+		return false
+	}
+	for i, p1 := range xs {
+		p1 := p1.(*name.NamePart).Value
+		p2 := ys[i].(*name.NamePart).Value
+		if p1 != p2 {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *matcher) eqNodeSliceNoMeta(xs, ys []node.Node) bool {
+	if len(xs) != len(ys) {
+		return false
+	}
+
+	for i, x := range xs {
+		if !m.eqNode(x, ys[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (m *matcher) eqArrayItemSlice(xs, ys []*expr.ArrayItem) bool {
+	// FIXME.
+
+	if len(xs) == 0 && len(ys) != 0 {
+		return false
+	}
+
+	matchAny := false
+
+	i := 0
+	for i < len(xs) {
+		x := xs[i]
+
+		if matchMetaVar(x, "*") {
+			matchAny = true
+		}
+
+		if matchAny {
+			switch {
+			// "Nothing left to match" stop condition.
+			case len(ys) == 0:
+				matchAny = false
+				i++
+			// Lookahead for non-greedy matching.
+			case i+1 < len(xs) && m.eqNode(xs[i+1], ys[0]):
+				matchAny = false
+				i += 2
+				ys = ys[1:]
+			default:
+				ys = ys[1:]
+			}
+			continue
+		}
+
+		if len(ys) == 0 || !m.eqNode(x, ys[0]) {
+			return false
+		}
+		i++
+		ys = ys[1:]
+	}
+
+	return len(ys) == 0
+}
+
+func (m *matcher) eqNodeSlice(xs, ys []node.Node) bool {
+	if len(xs) == 0 && len(ys) != 0 {
+		return false
+	}
+
+	matchAny := false
+
+	i := 0
+	for i < len(xs) {
+		x := xs[i]
+
+		if matchMetaVar(x, "*") {
+			matchAny = true
+		}
+
+		if matchAny {
+			switch {
+			// "Nothing left to match" stop condition.
+			case len(ys) == 0:
+				matchAny = false
+				i++
+			// Lookahead for non-greedy matching.
+			case i+1 < len(xs) && m.eqNode(xs[i+1], ys[0]):
+				matchAny = false
+				i += 2
+				ys = ys[1:]
+			default:
+				ys = ys[1:]
+			}
+			continue
+		}
+
+		if len(ys) == 0 || !m.eqNode(x, ys[0]) {
+			return false
+		}
+		i++
+		ys = ys[1:]
+	}
+
+	return len(ys) == 0
+}
+
+func (m *matcher) eqEncapsedStringPartSlice(xs, ys []node.Node) bool {
+	if len(xs) != len(ys) {
+		return false
+	}
+	for i, x := range xs {
+		if !m.eqEncapsedStringPart(x, ys[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *matcher) eqEncapsedStringPart(x, y node.Node) bool {
+	switch x := x.(type) {
+	case *scalar.EncapsedStringPart:
+		y, ok := y.(*scalar.EncapsedStringPart)
+		return ok && x.Value == y.Value
+	case *node.SimpleVar:
+		// Match variables literally.
+		y, ok := y.(*node.SimpleVar)
+		return ok && x.Name == y.Name
+	default:
+		return m.eqNode(x, y)
+	}
+}
+
+func (m *matcher) eqNode(x, y node.Node) bool {
+	if x == y {
+		return true
+	}
+
+	switch x := x.(type) {
+	case nil:
+		return y == nil
+
+	case *stmt.Expression:
+		// To make it possible to match statements with $-expressions,
+		// check whether expression inside x.Expr is a variable.
+		if x, ok := x.Expr.(*node.SimpleVar); ok {
+			return m.eqSimpleVar(x, y)
+		}
+		y, ok := y.(*stmt.Expression)
+		return ok && m.eqNode(x.Expr, y.Expr)
+
+	case *stmt.StmtList:
+		y, ok := y.(*stmt.StmtList)
+		return ok && m.eqNodeSlice(x.Stmts, y.Stmts)
+
+	case *stmt.Function:
+		return false // FIXME #23
+	case *stmt.Interface:
+		return false // FIXME #23
+	case *stmt.Class:
+		return false // FIXME #23
+	case *stmt.Trait:
+		return false // FIXME #23
+
+	case *stmt.InlineHtml:
+		y, ok := y.(*stmt.InlineHtml)
+		return ok && x.Value == y.Value
+	case *stmt.StaticVar:
+		y, ok := y.(*stmt.StaticVar)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expr, y.Expr)
+	case *stmt.Static:
+		y, ok := y.(*stmt.Static)
+		return ok && m.eqNodeSlice(x.Vars, y.Vars)
+	case *stmt.Global:
+		y, ok := y.(*stmt.Global)
+		return ok && m.eqNodeSlice(x.Vars, y.Vars)
+	case *stmt.Break:
+		y, ok := y.(*stmt.Break)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *stmt.Continue:
+		y, ok := y.(*stmt.Continue)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *stmt.Unset:
+		y, ok := y.(*stmt.Unset)
+		return ok && m.eqNodeSlice(x.Vars, y.Vars)
+	case *expr.Print:
+		y, ok := y.(*expr.Print)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *stmt.Echo:
+		y, ok := y.(*stmt.Echo)
+		return ok && m.eqNodeSlice(x.Exprs, y.Exprs)
+	case *stmt.Nop:
+		_, ok := y.(*stmt.Nop)
+		return ok
+	case *stmt.Do:
+		y, ok := y.(*stmt.Do)
+		return ok && m.eqNode(x.Cond, y.Cond) && m.eqNode(x.Stmt, y.Stmt)
+	case *stmt.While:
+		y, ok := y.(*stmt.While)
+		return ok && x.AltSyntax == y.AltSyntax &&
+			m.eqNode(x.Cond, y.Cond) && m.eqNode(x.Stmt, y.Stmt)
+	case *stmt.For:
+		y, ok := y.(*stmt.For)
+		return ok && x.AltSyntax == y.AltSyntax &&
+			m.eqNodeSlice(x.Init, y.Init) &&
+			m.eqNodeSlice(x.Cond, y.Cond) &&
+			m.eqNodeSlice(x.Loop, y.Loop) &&
+			m.eqNode(x.Stmt, y.Stmt)
+	case *stmt.Foreach:
+		y, ok := y.(*stmt.Foreach)
+		return ok && x.AltSyntax == y.AltSyntax &&
+			m.eqNode(x.Expr, y.Expr) &&
+			m.eqNode(x.Key, y.Key) &&
+			m.eqNode(x.Variable, y.Variable) &&
+			m.eqNode(x.Stmt, y.Stmt)
+
+	case *stmt.Else:
+		y, ok := y.(*stmt.Else)
+		return ok && x.AltSyntax == y.AltSyntax && m.eqNode(x.Stmt, y.Stmt)
+	case *stmt.ElseIf:
+		y, ok := y.(*stmt.ElseIf)
+		return ok && x.AltSyntax == y.AltSyntax &&
+			m.eqNode(x.Cond, y.Cond) && m.eqNode(x.Stmt, y.Stmt)
+	case *stmt.If:
+		y, ok := y.(*stmt.If)
+		return ok && x.AltSyntax == y.AltSyntax &&
+			m.eqNodeSliceNoMeta(x.ElseIf, y.ElseIf) &&
+			m.eqNode(x.Cond, y.Cond) &&
+			m.eqNode(x.Stmt, y.Stmt) &&
+			m.eqNode(x.Else, y.Else)
+
+	case *stmt.Throw:
+		y, ok := y.(*stmt.Throw)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *stmt.Try:
+		y, ok := y.(*stmt.Try)
+		return ok && m.eqNodeSlice(x.Stmts, y.Stmts) &&
+			m.eqNodeSlice(x.Catches, y.Catches) &&
+			m.eqNode(x.Finally, y.Finally)
+
+	case *expr.Yield:
+		y, ok := y.(*expr.Yield)
+		return ok && m.eqNode(x.Key, y.Key) && m.eqNode(x.Value, y.Value)
+	case *expr.YieldFrom:
+		y, ok := y.(*expr.YieldFrom)
+		return ok && m.eqNode(x.Expr, y.Expr)
+
+	case *expr.InstanceOf:
+		y, ok := y.(*expr.InstanceOf)
+		return ok && m.eqNode(x.Expr, y.Expr) && m.eqNode(x.Class, y.Class)
+
+	case *expr.List:
+		y, ok := y.(*expr.List)
+		return ok && x.ShortSyntax == y.ShortSyntax && m.eqArrayItemSlice(x.Items, y.Items)
+
+	case *expr.New:
+		y, ok := y.(*expr.New)
+		if !ok || !m.eqNode(x.Class, y.Class) {
+			return false
+		}
+		if x.ArgumentList == nil || y.ArgumentList == nil {
+			return x.ArgumentList == y.ArgumentList
+		}
+		return m.eqNodeSlice(x.ArgumentList.Arguments, y.ArgumentList.Arguments)
+
+	case *stmt.Case:
+		y, ok := y.(*stmt.Case)
+		return ok && m.eqNode(x.Cond, y.Cond) && m.eqNodeSlice(x.Stmts, y.Stmts)
+	case *stmt.Default:
+		y, ok := y.(*stmt.Default)
+		return ok && m.eqNodeSlice(x.Stmts, y.Stmts)
+	case *stmt.Switch:
+		y, ok := y.(*stmt.Switch)
+		return ok && x.AltSyntax == y.AltSyntax &&
+			m.eqNode(x.Cond, y.Cond) &&
+			m.eqNodeSlice(x.CaseList.Cases, y.CaseList.Cases)
+
+	case *stmt.Return:
+		y, ok := y.(*stmt.Return)
+		return ok && m.eqNode(x.Expr, y.Expr)
+
+	case *assign.Assign:
+		y, ok := y.(*assign.Assign)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.Plus:
+		y, ok := y.(*assign.Plus)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.Reference:
+		y, ok := y.(*assign.Reference)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.BitwiseAnd:
+		y, ok := y.(*assign.BitwiseAnd)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.BitwiseOr:
+		y, ok := y.(*assign.BitwiseOr)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.BitwiseXor:
+		y, ok := y.(*assign.BitwiseXor)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.Concat:
+		y, ok := y.(*assign.Concat)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.Div:
+		y, ok := y.(*assign.Div)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.Minus:
+		y, ok := y.(*assign.Minus)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.Mod:
+		y, ok := y.(*assign.Mod)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.Mul:
+		y, ok := y.(*assign.Mul)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.Pow:
+		y, ok := y.(*assign.Pow)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.ShiftLeft:
+		y, ok := y.(*assign.ShiftLeft)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+	case *assign.ShiftRight:
+		y, ok := y.(*assign.ShiftRight)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+
+	case *expr.ArrayDimFetch:
+		y, ok := y.(*expr.ArrayDimFetch)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Dim, y.Dim)
+	case *expr.ArrayItem:
+		y, ok := y.(*expr.ArrayItem)
+		if !ok {
+			return false
+		}
+		if x.Key == nil || y.Key == nil {
+			return x.Key == y.Key && m.eqNode(x.Val, y.Val)
+		}
+		return m.eqNode(x.Key, y.Key) && m.eqNode(x.Val, y.Val)
+	case *expr.Array:
+		y, ok := y.(*expr.Array)
+		return ok && x.ShortSyntax == y.ShortSyntax &&
+			m.eqArrayItemSlice(x.Items, y.Items)
+
+	case *node.Argument:
+		y, ok := y.(*node.Argument)
+		return ok && x.IsReference == y.IsReference &&
+			x.Variadic == y.Variadic &&
+			m.eqNode(x.Expr, y.Expr)
+	case *expr.FunctionCall:
+		y, ok := y.(*expr.FunctionCall)
+		if !ok || !m.eqNode(x.Function, y.Function) {
+			return false
+		}
+		return m.eqNodeSlice(x.ArgumentList.Arguments, y.ArgumentList.Arguments)
+
+	case *expr.PostInc:
+		y, ok := y.(*expr.PostInc)
+		return ok && m.eqNode(x.Variable, y.Variable)
+	case *expr.PostDec:
+		y, ok := y.(*expr.PostDec)
+		return ok && m.eqNode(x.Variable, y.Variable)
+	case *expr.PreInc:
+		y, ok := y.(*expr.PreInc)
+		return ok && m.eqNode(x.Variable, y.Variable)
+	case *expr.PreDec:
+		y, ok := y.(*expr.PreDec)
+		return ok && m.eqNode(x.Variable, y.Variable)
+
+	case *expr.Exit:
+		y, ok := y.(*expr.Exit)
+		return ok && x.Die == y.Die && m.eqNode(x.Expr, y.Expr)
+
+	case *expr.Include:
+		y, ok := y.(*expr.Include)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.IncludeOnce:
+		y, ok := y.(*expr.IncludeOnce)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.Require:
+		y, ok := y.(*expr.Require)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.RequireOnce:
+		y, ok := y.(*expr.RequireOnce)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.Empty:
+		y, ok := y.(*expr.Empty)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.Eval:
+		y, ok := y.(*expr.Eval)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.ErrorSuppress:
+		y, ok := y.(*expr.ErrorSuppress)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.Clone:
+		y, ok := y.(*expr.Clone)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.BitwiseNot:
+		y, ok := y.(*expr.BitwiseNot)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.BooleanNot:
+		y, ok := y.(*expr.BooleanNot)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.UnaryMinus:
+		y, ok := y.(*expr.UnaryMinus)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *expr.UnaryPlus:
+		y, ok := y.(*expr.UnaryPlus)
+		return ok && m.eqNode(x.Expr, y.Expr)
+
+	case *expr.StaticPropertyFetch:
+		switch y := y.(type) {
+		case *expr.StaticPropertyFetch:
+			return m.eqNode(x.Class, y.Class) &&
+				m.eqNode(x.Property, y.Property)
+		case *expr.ClassConstFetch:
+			return nodeIsVar(x.Property) &&
+				m.eqNode(x.Class, y.Class) &&
+				m.eqNode(x.Property, y.ConstantName)
+		default:
+			return false
+		}
+
+	case *expr.ClassConstFetch:
+		y, ok := y.(*expr.ClassConstFetch)
+		return ok && m.eqNode(x.Class, y.Class) && m.eqNode(x.ConstantName, y.ConstantName)
+	case *expr.StaticCall:
+		y, ok := y.(*expr.StaticCall)
+		return ok &&
+			m.eqNode(x.Class, y.Class) &&
+			m.eqNode(x.Call, y.Call) &&
+			m.eqNodeSlice(x.ArgumentList.Arguments, y.ArgumentList.Arguments)
+
+	case *expr.ShellExec:
+		y, ok := y.(*expr.ShellExec)
+		return ok && m.eqEncapsedStringPartSlice(x.Parts, y.Parts)
+	case *scalar.Encapsed:
+		y, ok := y.(*scalar.Encapsed)
+		return ok && m.eqEncapsedStringPartSlice(x.Parts, y.Parts)
+
+	case *scalar.Heredoc:
+		y, ok := y.(*scalar.Heredoc)
+		return ok && x.Label == y.Label && m.eqEncapsedStringPartSlice(x.Parts, y.Parts)
+	case *scalar.MagicConstant:
+		y, ok := y.(*scalar.MagicConstant)
+		return ok && y.Value == x.Value
+	case *scalar.Lnumber:
+		y, ok := y.(*scalar.Lnumber)
+		return ok && y.Value == x.Value
+	case *scalar.Dnumber:
+		y, ok := y.(*scalar.Dnumber)
+		return ok && y.Value == x.Value
+	case *scalar.String:
+		y, ok := y.(*scalar.String)
+		return ok && y.Value == x.Value
+
+	case *binary.Coalesce:
+		y, ok := y.(*binary.Coalesce)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Concat:
+		y, ok := y.(*binary.Concat)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Div:
+		y, ok := y.(*binary.Div)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Mod:
+		y, ok := y.(*binary.Mod)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Mul:
+		y, ok := y.(*binary.Mul)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Pow:
+		y, ok := y.(*binary.Pow)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.BitwiseAnd:
+		y, ok := y.(*binary.BitwiseAnd)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.BitwiseOr:
+		y, ok := y.(*binary.BitwiseOr)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.BitwiseXor:
+		y, ok := y.(*binary.BitwiseXor)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.ShiftLeft:
+		y, ok := y.(*binary.ShiftLeft)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.ShiftRight:
+		y, ok := y.(*binary.ShiftRight)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.LogicalAnd:
+		y, ok := y.(*binary.LogicalAnd)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.LogicalOr:
+		y, ok := y.(*binary.LogicalOr)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.LogicalXor:
+		y, ok := y.(*binary.LogicalXor)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.BooleanAnd:
+		y, ok := y.(*binary.BooleanAnd)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.BooleanOr:
+		y, ok := y.(*binary.BooleanOr)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.NotEqual:
+		y, ok := y.(*binary.NotEqual)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.NotIdentical:
+		y, ok := y.(*binary.NotIdentical)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Equal:
+		y, ok := y.(*binary.Equal)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Identical:
+		y, ok := y.(*binary.Identical)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Greater:
+		y, ok := y.(*binary.Greater)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.GreaterOrEqual:
+		y, ok := y.(*binary.GreaterOrEqual)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Smaller:
+		y, ok := y.(*binary.Smaller)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.SmallerOrEqual:
+		y, ok := y.(*binary.SmallerOrEqual)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Spaceship:
+		y, ok := y.(*binary.Spaceship)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Plus:
+		y, ok := y.(*binary.Plus)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+	case *binary.Minus:
+		y, ok := y.(*binary.Minus)
+		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+
+	case *expr.ConstFetch:
+		y, ok := y.(*expr.ConstFetch)
+		return ok && m.eqNode(x.Constant, y.Constant)
+	case *name.Name:
+		y, ok := y.(*name.Name)
+		return ok && m.eqNameParts(x.Parts, y.Parts)
+	case *name.FullyQualified:
+		y, ok := y.(*name.FullyQualified)
+		return ok && m.eqNameParts(x.Parts, y.Parts)
+	case *node.Identifier:
+		y, ok := y.(*node.Identifier)
+		return ok && x.Value == y.Value
+	case *node.SimpleVar:
+		return m.eqSimpleVar(x, y)
+	case *node.Var:
+		return m.eqVar(x, y)
+
+	case *expr.Reference:
+		y, ok := y.(*expr.Reference)
+		return ok && m.eqNode(x.Variable, y.Variable)
+
+	case *node.Parameter:
+		y, ok := y.(*node.Parameter)
+		return ok && x.ByRef == y.ByRef &&
+			x.Variadic == y.Variadic &&
+			m.eqNode(x.VariableType, y.VariableType) &&
+			m.eqNode(x.Variable, y.Variable) &&
+			m.eqNode(x.DefaultValue, y.DefaultValue)
+	case *expr.Closure:
+		return m.eqClosure(x, y)
+
+	case *expr.Ternary:
+		return m.eqTernary(x, y)
+
+	case *expr.Isset:
+		y, ok := y.(*expr.Isset)
+		return ok && m.eqNodeSlice(x.Variables, y.Variables)
+
+	case *expr.PropertyFetch:
+		y, ok := y.(*expr.PropertyFetch)
+		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Property, y.Property)
+	case *expr.MethodCall:
+		y, ok := y.(*expr.MethodCall)
+		return ok && m.eqNode(x.Variable, y.Variable) &&
+			m.eqNode(x.Method, y.Method) &&
+			m.eqNodeSlice(x.ArgumentList.Arguments, y.ArgumentList.Arguments)
+
+	case *cast.Double:
+		y, ok := y.(*cast.Double)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *cast.Array:
+		y, ok := y.(*cast.Array)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *cast.Bool:
+		y, ok := y.(*cast.Bool)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *cast.Int:
+		y, ok := y.(*cast.Int)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *cast.Object:
+		y, ok := y.(*cast.Object)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	case *cast.String:
+		y, ok := y.(*cast.String)
+		return ok && m.eqNode(x.Expr, y.Expr)
+
+	case *node.Root:
+		return false
+
+	default:
+		panic(fmt.Sprintf("unhandled node: x=%T y=%T (please, fill an issue on GitHub)\n", x, y))
+	}
+}
+
+func (m *matcher) matchNamed(name string, y node.Node) bool {
+	// Special case.
+	// "_" name matches anything, always.
+	// Anonymous names replaced with "_" during the compilation.
+	if name == "_" {
+		return true
+	}
+
+	z, ok := m.named[name]
+	if !ok {
+		m.named[name] = y
+		return true
+	}
+	if z == nil {
+		return y == nil
+	}
+
+	m.literalMatch = true
+	result := m.eqNode(z, y)
+	m.literalMatch = false
+	return result
+}
+
+func (m *matcher) eqTernary(x *expr.Ternary, y node.Node) bool {
+	if y, ok := y.(*expr.Ternary); ok {
+		// To avoid matching `$x ?: $y` with `$x ? $y : $z` pattern.
+		if x.IfTrue == nil || y.IfTrue == nil {
+			return y.IfTrue == x.IfTrue &&
+				m.eqNode(x.Condition, y.Condition) &&
+				m.eqNode(x.IfFalse, y.IfFalse)
+		}
+		return m.eqNode(x.Condition, y.Condition) &&
+			m.eqNode(x.IfTrue, y.IfTrue) &&
+			m.eqNode(x.IfFalse, y.IfFalse)
+	}
+
+	return false
+}
+
+func (m *matcher) eqClosure(x *expr.Closure, y node.Node) bool {
+	if y, ok := y.(*expr.Closure); ok {
+		var xUses, yUses []node.Node
+		if x.ClosureUse != nil {
+			xUses = x.ClosureUse.Uses
+		}
+		if y.ClosureUse != nil {
+			yUses = y.ClosureUse.Uses
+		}
+		return ok && x.ReturnsRef == y.ReturnsRef &&
+			x.Static == y.Static &&
+			m.eqNodeSlice(x.Params, y.Params) &&
+			m.eqNode(x.ReturnType, y.ReturnType) &&
+			m.eqNodeSlice(x.Stmts, y.Stmts) &&
+			m.eqNodeSlice(xUses, yUses)
+	}
+
+	return false
+}
+
+func (m *matcher) eqSimpleVar(x *node.SimpleVar, y node.Node) bool {
+	if m.literalMatch {
+		y, ok := y.(*node.SimpleVar)
+		return ok && x.Name == y.Name
+	}
+	return m.matchNamed(x.Name, y)
+}
+
+func (m *matcher) eqVar(x *node.Var, y node.Node) bool {
+	if m.literalMatch {
+		y, ok := y.(*node.Var)
+		return ok && m.eqNode(x.Expr, y.Expr)
+	}
+
+	switch vn := x.Expr.(type) {
+	case anyFunc:
+		_, ok := y.(*expr.Closure)
+		return ok && m.matchNamed(vn.name, y)
+	case anyConst:
+		switch y.(type) {
+		case *expr.ConstFetch, *expr.ClassConstFetch:
+			return m.matchNamed(vn.name, y)
+		default:
+			return false
+		}
+	case anyVar:
+		_, ok := y.(*node.SimpleVar)
+		return ok && m.matchNamed(vn.name, y)
+	case anyInt:
+		_, ok := y.(*scalar.Lnumber)
+		return ok && m.matchNamed(vn.name, y)
+	case anyFloat:
+		_, ok := y.(*scalar.Dnumber)
+		return ok && m.matchNamed(vn.name, y)
+	case anyStr:
+		_, ok := y.(*scalar.String)
+		return ok && m.matchNamed(vn.name, y)
+	case anyNum:
+		switch y.(type) {
+		case *scalar.Lnumber, *scalar.Dnumber:
+			return m.matchNamed(vn.name, y)
+		default:
+			return false
+		}
+	case anyExpr:
+		return nodeIsExpr(y) && m.matchNamed(vn.name, y)
+	}
+
+	if y, ok := y.(*node.Var); ok {
+		return m.eqNode(x.Expr, y.Expr)
+	}
+	return false
+}
+
+func (m *matcher) EnterNode(w walker.Walkable) bool {
+	n, ok := w.(node.Node)
+	if !ok {
+		return true
+	}
+
+	m.named = map[string]node.Node{}
+
+	if ok && m.eqNode(m.root, n) {
+		pos := getNodePos(n)
+		if pos == nil {
+			return true
+		}
+		m.data.Node = n
+		m.data.Named = m.named
+
+		return m.handler(&m.data)
+	}
+
+	return true
+}
+
+func (m *matcher) LeaveNode(w walker.Walkable) {}

--- a/src/phpgrep/matcher_test.go
+++ b/src/phpgrep/matcher_test.go
@@ -1,0 +1,680 @@
+package phpgrep
+
+import (
+	"testing"
+)
+
+func matchInText(m *matcher, code []byte) bool {
+	root, code, err := parsePHP7(code)
+	if err != nil {
+		return false
+	}
+	return m.matchAST(root)
+}
+
+func findInText(m *matcher, code []byte, callback func(*MatchData) bool) {
+	root, _, err := parsePHP7(code)
+	if err != nil {
+		return
+	}
+	m.findAST(root, callback)
+}
+
+type matcherTest struct {
+	pattern string
+	input   string
+}
+
+func mustCompile(t testing.TB, c *Compiler, code string) *Matcher {
+	matcher, err := c.Compile([]byte(code))
+	if err != nil {
+		t.Fatalf("pattern compilation error:\ntext: %q\nerr: %v", code, err)
+	}
+	return matcher
+}
+
+func TestFind(t *testing.T) {
+	runFindTest := func(t *testing.T, pattern, code string, wantMatches []string) {
+		var c Compiler
+		matcher := mustCompile(t, &c, pattern)
+		var haveMatches []string
+		findInText(&matcher.m, []byte(code), func(m *MatchData) bool {
+			pos := m.Node.GetPosition()
+			posFrom := pos.StartPos - 1
+			posTo := pos.EndPos
+			haveMatches = append(haveMatches, string(code[posFrom:posTo]))
+			return true
+		})
+		if len(haveMatches) != len(wantMatches) {
+			t.Errorf("matches count mismatch:\nhave: %d\nwant: %d",
+				len(haveMatches), len(wantMatches))
+			t.Log("have:")
+			for _, have := range haveMatches {
+				t.Log(have)
+			}
+			t.Log("want:")
+			for _, want := range wantMatches {
+				t.Log(want)
+			}
+			return
+		}
+		for i, have := range haveMatches {
+			want := wantMatches[i]
+			if have != want {
+				t.Errorf("match mismatch:\nhave: %q\nwant: %q", have, want)
+			}
+		}
+	}
+
+	runFindTest(t, `$x+1`, `<?php $x+1;`, []string{`$x+1`})
+
+	runFindTest(t, `$x = $x`, `<?php
+            $x = $x; $z1 = 10; $y = $y; $z2 = 20; $x = $y;
+        `, []string{
+		`$x = $x`,
+		`$y = $y`,
+	})
+
+	// TODO: uncomment when parentheses are handled correctly.
+	// runFindTest(t, `($x)`, `<?php
+	//     $x + $y; ($x1 + $y1); (($x2 + $y2));
+	// `, []string{
+	// 	`($x1 + $y1)`,
+	// 	`(($x2 + $y2))`,
+	// 	`($x2 + $y2)`,
+	// })
+}
+
+func runMatchTest(t *testing.T, want bool, tests []*matcherTest) {
+	var c Compiler
+	for _, test := range tests {
+		matcher := mustCompile(t, &c, test.pattern)
+
+		have := matchInText(&matcher.m, []byte(test.input))
+		if have != want {
+			t.Errorf("match results mismatch:\npattern: %q\ninput: %q\nhave: %v\nwant: %v",
+				test.pattern, test.input, have, want)
+		}
+	}
+}
+
+func TestMatchDebug(t *testing.T) {
+	runMatchTest(t, true, []*matcherTest{
+		{`if ($c) $_; else if ($c) {1;};`, `if ($c1) {1; 2;} else if ($c1) {1;}`},
+	})
+}
+
+func TestMatch(t *testing.T) {
+	runMatchTest(t, true, []*matcherTest{
+		{"``", "``"},
+		{"`ls`", "`ls`"},
+		{"`rm -rf /`", "`rm -rf /`"},
+
+		{`${"const"}`, `null`},
+		{`${"const"}`, `true`},
+		{`${"const"}`, `false`},
+		{`${"const"}`, `MY_CONST`},
+		{`$_ = ${"const"}`, `$x = MyClass::CONST`},
+
+		{`static $x = 10`, `static $vvv = 10`},
+		{`global $x, $y`, `global $a, $b`},
+		{`break $x`, `break 20`},
+		{`continue $x`, `continue 20`},
+		{`unset($x)`, `unset($v)`},
+		{`print(1)`, `print(1)`},
+		{`echo 1, 2`, `echo 1, 2`},
+		{`throw new $E()`, `throw new Exception()`},
+
+		{`!($x instanceof $y)`, `!($v instanceof MyClass)`},
+		{`$x`, `$v instanceof MyClass`},
+		{`$x`, `!($v instanceof MyClass)`},
+
+		{`$x=$x`, `$x=$x`},
+
+		{`1`, `1`},
+		{`"1"`, `"1"`},
+		{`'1'`, `'1'`},
+		{`1.4`, `1.4`},
+
+		{`$x & mask != 0`, `$v & mask != 0`},
+		{`($x & mask) != 0`, `($v & mask) != 0`},
+
+		{`$x`, `10`},
+		{`$x`, `"abc"`},
+		{`false`, `false`},
+		{`NULL`, `NULL`},
+
+		{`$x++`, `$y++`},
+		{`$x--`, `$y--`},
+		{`++$x`, `++$y`},
+		{`--$x`, `--$y`},
+
+		{`$x+1`, `10+1`},
+		{`$x+1`, `$x+1`},
+		{`$x-1`, `10-1`},
+		{`$x-1`, `$x-1`},
+
+		{`+$x`, `+1`},
+		{`-$x`, `-2`},
+		{`~$x`, `~$v`},
+		{`!$x`, `!$v`},
+
+		{`$f()`, `f()`},
+		{`$f()`, `g()`},
+		{`$f($a1, $a2)`, `f(1, 2)`},
+		{`$f($a1, $a2)`, `f("sa", $t)`},
+
+		{`$x + $x`, `1 + 1`},
+		{`$x + $y`, `1 + 1`},
+		{`$x | $y`, `$v1 | $v2`},
+		{`$x >> $y`, `$v1 >> $v2`},
+		{`$x << $y`, `$v1 << $v2`},
+		{`$x and $y`, `$v1 and $v2`},
+		{`$x or $y`, `$v1 or $v2`},
+		{`$x xor $y`, `$v1 xor $v2`},
+		{`$x != $y`, `$v1 != $v2`},
+		{`$x == $y`, `$v1 == $v2`},
+		{`$x === $y`, `$v1 === $v2`},
+		{`$x !== $y`, `$v1 !== $v2`},
+		{`$x > $y`, `$v1 > $v2`},
+		{`$x >= $y`, `$v1 >= $v2`},
+		{`$x < $y`, `$v1 < $v2`},
+		{`$x <= $y`, `$v1 <= $v2`},
+		{`$x <=> $y`, `$v1 <=> $v2`},
+		{`$x && $y`, `$v1 && $v2`},
+		{`$x || $y`, `$v1 || $v2`},
+		{`$x ?? $y`, `$v1 ?? $v2`},
+		{`$x . $y`, `$v1 . $v2`},
+		{`$x / $y`, `$v1 / $v2`},
+		{`$x % $y`, `$v1 % $v2`},
+		{`$x * $y`, `$v1 * $v2`},
+		{`$x ** $y`, `$v1 ** $v2`},
+
+		{`$x = $x`, `$x->b = $x->b`},
+		{`$x = $x`, `$x->b[0] = $x->b[0]`},
+		{`$x = $x`, `$a->$x[0] = $a->$x[0]`},
+		{`$x = $x`, `$x[0] = $x[0]`},
+		{`$x = $x`, `T::$x = T::$x`},
+
+		{`int($x)`, `int($v)`},
+		{`array($x)`, `array($v)`},
+		{`string($x)`, `string($v)`},
+		{`bool($x)`, `bool($v)`},
+		{`double($x)`, `double($v)`},
+		{`object($x)`, `object($v)`},
+
+		{`$$$x`, `$$$x`},
+		{`$$$x`, `$$$y`},
+		{`$$$x`, `$$$$x`},
+		{`$$x = $$x`, `$$$x = $$$x`},
+		{`$$x = $$x`, `$$x = $$x`},
+
+		{`$x = 0`, `$v = 0`},
+		{`$x += 1`, `$v += 1`},
+		{`$x -= 1`, `$v -= 1`},
+		{`$x =& $y`, `$x =& $y`},
+		{`$x &= $y`, `$x &= $y`},
+		{`$x |= $y`, `$x |= $y`},
+		{`$x ^= $y`, `$x ^= $y`},
+		{`$x /= $y`, `$x /= $y`},
+		{`$x %= $y`, `$x %= $y`},
+		{`$x *= $y`, `$x *= $y`},
+		{`$x **= $y`, `$x **= $y`},
+		{`$x <<= $y`, `$x <<= $y`},
+		{`$x >>= $y`, `$x >>= $y`},
+
+		{`\A\B`, `\A\B`},
+
+		{`[]`, `[]`},
+		{`array()`, `array()`},
+		{`[$x, $x]`, `[1, 1]`},
+		{`array($x, $x)`, `array(1, 1)`},
+		{`[$k1 => 2, $k2 => 4]`, `[1 => 2, 3 => 4]`},
+		{`[$k1 => 2, $k1 => 4]`, `[1 => 2, 1 => 4]`},
+
+		{`[${'*'}, $k => $_, ${'*'}, $k => $_, ${'*'}]`, `[1 => $x, 1 => $y]`},
+		{`[${'*'}, $k => $_, ${'*'}, $k => $_, ${'*'}]`, `[$v, 1 => $x, $v, 1 => $x, $v]`},
+		{`[${'*'}, $k => $_, ${'*'}, $k => $_, ${'*'}]`, `[1 => $x, 1 => $x, $v]`},
+		{`[${'*'}, $k => $_, ${'*'}, $k => $_, ${'*'}]`, `[$v, 1 => $x, 1 => $x]`},
+
+		{`{1; 2;}`, `{1; 2;}`},
+		{`{$x;}`, `{1;}`},
+		{`{$x;}`, `{2;}`},
+
+		{`{${'*'};}`, `{}`},
+		{`{${'*'};}`, `{1;}`},
+		{`{${'*'};}`, `{1; 2;}`},
+		{`{${'*'};}`, `{1; 2; 3;}`},
+
+		{`{${'*'}; 3;}`, `{1; 2; 3;}`},
+		{`{1; ${'*'};}`, `{1; 2; 3;}`},
+		{`{1; ${'*'}; 3;}`, `{1; 2; 3;}`},
+		{`{1; 2; ${'*'}; 3;}`, `{1; 2; 3;}`},
+		{`{${'*'}; 2; ${'*'};}`, `{1; 2; 3;}`},
+		{`{1; 2; 3; ${'*'};}`, `{1; 2; 3;}`},
+
+		{`f(${'*'})`, `f()`},
+		{`f(${'*'})`, `f(1)`},
+		{`f(${'*'})`, `f(1, 2)`},
+		{`f(${'*'})`, `f(1, 2, 3)`},
+		{`f(${'*'}, 3)`, `f(1, 2, 3)`},
+		{`f(${'*'}, $x, $y, $z)`, `f(1, 2, 3)`},
+		{`f($x, $y, $z, ${'*'})`, `f(1, 2, 3)`},
+		{`f(${'*'}, $x, ${'*'}, $y, ${'*'}, $z, ${'*'})`, `f(1, 2, 3)`},
+
+		{`if ($cond) $_;`, `if (1 == 1) return 1;`},
+		{`if ($cond) $_;`, `if (1 == 1) f();`},
+		{`if ($cond) return 1;`, `if (1 == 1) return 1;`},
+		{`if ($cond) { return 1; }`, `if (1 == 1) { return 1; }`},
+		{`if ($_ = $_) $_`, `if ($x = f()) {}`},
+		{`if ($_ = $_) $_`, `if ($x = f()) g();`},
+		{`if ($cond1) $_; else if ($cond2) $_;`, `if ($c1) {} else if ($c2) {}`},
+		{`if ($cond1) $_; elseif ($cond2) $_;`, `if ($c1) {} elseif ($c2) {}`},
+
+		{`switch ($e) {}`, `switch ($x) {}`},
+		{`switch ($_) {case 1: f();}`, `switch ($x) {case 1: f();}`},
+		{`switch ($_) {case $_: ${'*'};}`, `switch ($x) {case 1: f1(); f2();}`},
+		{`switch ($e) {default: $_;}`, `switch ($x) {default: 1;}`},
+
+		{`strcmp($s1, $s2) > 0`, `strcmp($s1, "foo") > 0`},
+
+		{`new $t`, `new T`},
+		{`new $t()`, `new T()`},
+		{`new $t($x)`, `new T(1)`},
+		{`new $t($x, $y)`, `new T(1, 2)`},
+		{`new $t(${'*'})`, `new T(1, 2)`},
+
+		{`list($x, $_, $x) = f()`, `list($v, $_, $v) = f()`},
+		{`list($x, $_, $x) = f()`, `list($v, , $v) = f()`},
+		{`list($x) = $a`, `list($v) = [1]`},
+
+		{`${'var'}`, `$x`},
+		{`${'var'}`, `$$x`},
+		{`${'x:var'} + $x`, `$x + $x`},
+		{`$x + ${'x:var'}`, `$x + $x`},
+		{`${'_:var'} + $_`, `$x + 1`},
+		{`${'var'} + $_`, `$x + 1`},
+
+		{`${"int"}`, `13`},
+		{`${"float"}`, `3.4`},
+		{`${"str"}`, `"123"`},
+		{`${"num"}`, `13`},
+		{`${"num"}`, `3.4`},
+
+		{`${"expr"}`, `1`},
+		{`${"expr"}`, `"124d"`},
+		{`${"expr"}`, `$x`},
+		{`${"expr"}`, `f(1, 5)`},
+		{`${"expr"}`, `$x = [1]`},
+
+		{`$cond ? $true : $false`, `1 ? 2 : 3`},
+		{`$cond ? a : b`, `1 ? a : b`},
+		{`$c1 ? $_ : $_ ? $_ : $_`, `true ? 1 : false ? 2 : 3`},
+		{`$c1 ? $_ : ($_ ? $_ : $_)`, `true ? 1 : (false ? 2 : 3)`},
+		{`$x ? $x : $y`, `$v ? $v : $other`},
+		{`$_ == $_ ? $_ : $_ == $_ ? $_ : $_`, `$a == 1 ? 'one' : $a == 2 ? 'two' : 'other'`},
+
+		{`$_ ?: $_`, `1 ?: 2`},
+
+		{`isset($x)`, `isset($v)`},
+		{`isset($x, $y)`, `isset($k, $v[$k])`},
+		{`empty($x)`, `empty($v)`},
+
+		{`$x->$_ = $x`, `$this->self = $this`},
+		{`$x->$_ = $x`, `$this->$indirect = $this`},
+		{`$x->$m()`, `$this->m()`},
+		{`$x->$m(1, 2)`, `$this->m(1, 2)`},
+		{`$x->ff(1, 2)`, `$this->ff(1, 2)`},
+
+		{`$_[0]`, `$v[0]`},
+
+		{`$c::$prop`, `C::$foo`},
+		{`$c::$prop`, `C::constant`},
+		{`$c::$f()`, `C::foo()`},
+		{`$c::$f()`, `C::$foo()`},
+		{`C::f()`, `C::f()`},
+		{`C::constant`, `C::constant`},
+
+		{`clone $v`, `clone new T()`},
+
+		{`@$_`, `@f()`},
+		{`@$_`, `@$o->method(1, 2)`},
+
+		{`eval($_)`, `eval('1')`},
+
+		{`exit(0)`, `exit(0)`},
+		{`die(0)`, `die(0)`},
+
+		{`include $_`, `include "foo.php"`},
+		{`include_once $_`, `include_once "foo.php"`},
+		{`require $_`, `require "foo.php"`},
+		{`require_once $_`, `require_once "foo.php"`},
+
+		{`__FILE__`, `__FILE__`},
+		{`[$x, $x]`, `[__FILE__, __FILE__]`},
+
+		{`"$x$y"`, `"$x$y"`},
+		{`"$x 1" . $x`, `"$x 1" . "2"`},
+		{`"${x}"`, `"${x}"`},
+
+		{`function() { return $x; }`, `function() { return 10; }`},
+		{`function($x) {}`, `function($arg1) {}`},
+		{`function($x) use($v) {}`, `function($arg1) use($y) {}`},
+		{`function() { ${"*"}; return 1; }`, `function() { return 1; }`},
+		{`function() { ${"*"}; return 1; }`, `function() { f(); return 1; }`},
+		{`function() { ${"*"}; return 1; }`, `function() { f(); f(); return 1; }`},
+
+		{`${"func"}`, `function() {}`},
+		{`${"func"}`, `function($x) {}`},
+		{`${"func"}`, `function() { return 1; }`},
+
+		{`1`, `(1)`},
+		{`(1)`, `(1)`},
+		{`((1))`, `((1))`},
+		{`f(1)`, `f(1)`},
+		{`f((1))`, `f((1))`},
+	})
+}
+
+func TestMatchNegative(t *testing.T) {
+	runMatchTest(t, false, []*matcherTest{
+		{`1`, `2`},
+		{`"1"`, `"2ed"`},
+		{`'1'`, `'x'`},
+		{`1.4`, `1.6`},
+		{`false`, `true`},
+
+		{`$x+1`, `10+2`},
+		{`$x+1`, `$x+$x`},
+
+		{`$x = $x`, `$x = $y`},
+		{`$x = $x`, `$x[0] = $y[0]`},
+		{`$x = $x`, `$x->a[0] = $y->a[0]`},
+		{`$x = $x`, `$x->a[0] = $x->b[0]`},
+		{`$x = $x`, `$x->a[0] = $x->a[1]`},
+
+		{`+$x`, `-1`},
+		{`-$x`, `+2`},
+
+		{`$f()`, `f(1)`},
+		{`$f()`, `g(2)`},
+		{`$f($a1, $a2)`, `f()`},
+		{`$f($a1, $a2)`, `f()`},
+
+		{`$x+$x`, `1+2`},
+		{`$x+$x`, `2+1`},
+		{`$x+$x`, `""+1`},
+		{`$x+$x`, `1+""`},
+
+		{`$$$x`, `$x`},
+		{`$$$x`, `10`},
+		{`$$x = $$x`, `$$$x = $$$y`},
+		{`$$x = $$x`, `$$x = $$y`},
+		{`$$x = $$x`, `$$x = $x`},
+		{`$$x = $$x`, `$x = $x`},
+
+		{`[$x, $x]`, `[1, 2]`},
+		{`array($x, $x)`, `array(1, 2)`},
+
+		{`{}`, `{1;}`},
+		{`{1;}`, `{}`},
+		{`{1;}`, `{1; 2;}`},
+		{`{1; 2;}`, `{1; 2; 3;}`},
+		{`{1; 2; 3;}`, `{1; 2;}`},
+
+		{`f(${'*'}, 4)`, `f(1, 2, 3)`},
+
+		{`new $t`, `new T()`},
+		{`new $t()`, `new T`},
+
+		{`while ($_); {${'*'};}`, `while ($cond) {$blah;}`},
+		{`for ($_; $_; $_) {${"*"};}`, `for (;;) {}`},
+		{`for ($_; $_; $_) {${"*"};}`, `for ($i = 0; $i < 10; $i++) { echo $; }`},
+
+		{`if ($c) $_; else if ($c) $_;`, `if ($c1) {} else if ($c2) {}`},
+		{`if ($c) $_; elseif ($c) $_;`, `if ($c1) {} elseif ($c2) {}`},
+
+		{`list($x, $_, $x) = f()`, `list(,1,2) = f()`},
+		{`list($x, $_, $x) = f()`, `list(2,1,) = f()`},
+
+		{`${'x:var'}`, `1`},
+		{`${'var'}`, `[10]`},
+		{`${'var'}`, `THE_CONST`},
+		{`${'x:var'} + $x`, `$x + 1`},
+		{`$x + ${'x:var'}`, `1 + $x`},
+
+		{`${"int"}`, `13.5`},
+		{`${"float"}`, `3`},
+		{`${"str"}`, `5`},
+		{`${"num"}`, `$x`},
+		{`${"num"}`, `"1"`},
+
+		{`${"expr"}`, `{}`},
+		{`${"expr"}`, `{{}}`},
+
+		{`$_ == $_ ? $_ : $_ == $_ ? $_ : $_`, `$a == 1 ? ('one' : $a == 2 ? ('two' : 'other'))`},
+		{`$x ? $x : $y`, `1 ?: 2`},
+		{`$x ? $y : $z`, `1 ?: 2`},
+
+		{`$x->$_ = $x`, `$this->self = $y`},
+
+		{`$_[0]`, `$v[1]`},
+
+		{`@$_`, `f()`},
+
+		{`die(0)`, `exit(0)`},
+		{`exit(0)`, `die(0)`},
+
+		{`$x->$m()`, `$this->m(1)`},
+		{`$x->$m(1, 2)`, `$this->m(2, 1)`},
+		{`$x->ff(1, 2)`, `$this->f2(1, 2)`},
+
+		{`C::f()`, `C2::f()`},
+		{`C::f()`, `C::f2()`},
+		{`C::constant`, `C::constant2`},
+		{`C::constant`, `C::$prop`},
+
+		{`__FILE__`, `__DIR__`},
+		{`[$x, $x]`, `[__FILE__, __DIR__]`},
+		{`[$x, $x]`, `[__DIR__, __FILE__]`},
+
+		{`"$x$x"`, `"11"`},
+		{`"$x$x"`, `'$x$x'`},
+
+		{`int($x)`, `$v`},
+		{`array($x)`, `$v`},
+		{`string($x)`, `$v`},
+		{`bool($x)`, `$v`},
+		{`double($x)`, `$v`},
+		{`object($x)`, `$v`},
+
+		{`\A\B`, `\A\A`},
+		{`\A\B`, `\B\B`},
+
+		{`function() { return $x; }`, `function() {}`},
+		{`function($x) {}`, `function() {}`},
+		{`function($x) use($v) {}`, `function($arg1) use() {}`},
+		{`function() { ${"*"}; return 1; }`, `function() {}`},
+		{`function() { ${"*"}; return 1; }`, `function($x) { return 1; }`},
+		{`function() { ${"*"}; return 1; }`, `static function() { f(); f(); return 1; }`},
+
+		{`!($x instanceof $y)`, `1`},
+		{`$x instanceof T1`, `$v instanceof T2`},
+		{`$x instanceof T`, `$x instance of $y`},
+
+		{`static $x = 10`, `static $vvv = 11`},
+		{`global $x, $y`, `global $a`},
+		{`break ${"expr"}`, `break`},
+		{`continue ${"expr"}`, `continue`},
+		{`unset($x)`, `unset($v, $y)`},
+		{`print(1)`, `print(2)`},
+		{`echo 1, 2`, `echo 1`},
+		{`throw new $E()`, `throw new Exception(1)`},
+
+		{`${"const"}`, `$v`},
+		{`${"const"}`, `1`},
+		{`${"const"}`, `"1"`},
+		{`${"const"}`, `$x->y`},
+		{`$_ = ${"const"}`, `$x = MyClass::$var`},
+
+		{`${"func"}`, `1`},
+		{`${"func"}`, `$x`},
+		{`${"func"}`, `f()`},
+
+		// TODO: uncomment when parentheses are handled correctly.
+		// {`(1)`, `1`},
+		// {`((1))`, `(1)`},
+		// {`f((1))`, `f(1)`},
+	})
+}
+
+func BenchmarkFind(b *testing.B) {
+	input := []byte(`<?php
+
+use N\{ClassName,
+  AnotherClassName,
+  OneMoreClassName};
+
+namespace A {
+  function foo() {
+    return 0;
+  }
+
+  function bar($x,
+    $y, int $z = 1) {
+    $x = 0;
+// $x = 1
+    do {
+      $y += 1;
+    } while ($y < 10);
+    if (true)
+      $x = 10;
+    elseif ($y < 10)
+      $x = 5;
+    elseif (true)
+      $x = 5;
+    for ($i = 0; $i < 10; $i++)
+      $yy = $x > 2 ? 1 : 2;
+    while (true)
+      $x = 0;
+    do {
+      $x += 1;
+    } while (true);
+    foreach (["a" => 0, "b" => 1,
+              "c" => 2] as $e1) {
+      echo $e1;
+    }
+    $count = 10;
+    $x     = ["x", "y",
+      [1 => "abc",
+       2 => "def", 3 => "ghi"]];
+    $zz    = [0.1, 0.2,
+      0.3, 0.4];
+    $x     = [
+      0   => "zero",
+      123 => "one two three",
+      25  => "two five",
+    ];
+    bar(0, bar(1,
+      "b"));
+  }
+
+  abstract class Foo extends FooBaseClass implements Bar1, Bar2, Bar3 {
+
+    var $numbers = ["one", "two", "three", "four", "five", "six"];
+    var $v = 0;
+    public $path = "root";
+
+    const FIRST  = 'first';
+    const SECOND = 0;
+    const Z      = -1;
+
+    function bar($v,
+      $w = "a") {
+      $y      = $w;
+      $result = foo("arg1",
+        "arg2",
+        10);
+      switch ($v) {
+        case 0:
+          return 1;
+        case 1:
+          echo '1';
+          break;
+        case 2:
+          break;
+        default:
+          $result = 10;
+      }
+      return $result;
+    }
+
+    public static function fOne($argA, $argB, $argC, $argD, $argE, $argF, $argG, $argH) {
+      $x = $argA + $argB + $argC + $argD + $argE + $argF + $argG + $argH;
+      list($field1, $field2, $field3, $filed4, $field5, $field6) = explode(",", $x);
+      fTwo($argA, $argB, $argC, fThree($argD, $argE, $argF, $argG, $argH));
+      $z      = $argA == "Some string" ? "yes" : "no";
+      $colors = ["red", "green", "blue", "black", "white", "gray"];
+      $count  = count($colors);
+      for ($i = 0; $i < $count; $i++) {
+        $colorString = $colors[$i];
+      }
+    }
+
+    function fTwo($strA, $strB, $strC, $strD) {
+      if ($strA == "one" || $strB == "two" || $strC == "three") {
+        return $strA + $strB + $strC;
+      }
+      $x = $foo->one("a", "b")->two("c", "d", "e")->three("fg")->four();
+      $y = a()->b()->c();
+      return $strD;
+    }
+
+    function fThree($strA, $strB, $strC, $strD, $strE) {
+      try {
+      } catch (Exception $e) {
+        foo();
+      } finally {
+        // do something
+      }
+      return $strA + $strB + $strC + $strD + $strE;
+    }
+
+    protected abstract function fFour();
+
+  }
+}
+
+function f() {}
+
+$_ = f(1 + 2 + 3 + 4 + 5);
+$_ = f(f() + f() + f() + f() + f());
+`)
+
+	var c Compiler
+
+	b.Run("positive/with-1-named", func(b *testing.B) {
+		matcher := mustCompile(b, &c, `$x`)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			findInText(&matcher.m, input, func(m *MatchData) bool { return true })
+		}
+	})
+
+	b.Run("positive/with-5-named", func(b *testing.B) {
+		matcher := mustCompile(b, &c, `$x1 + $x2 + $x3 + $x4 + $x5`)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			findInText(&matcher.m, input, func(m *MatchData) bool { return true })
+		}
+	})
+
+	b.Run("negative/with-0-named", func(b *testing.B) {
+		matcher := mustCompile(b, &c, `1 + 7 - 103`)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			findInText(&matcher.m, input, func(m *MatchData) bool { return true })
+		}
+	})
+
+}

--- a/src/phpgrep/meta_nodes.go
+++ b/src/phpgrep/meta_nodes.go
@@ -1,0 +1,28 @@
+package phpgrep
+
+import (
+	"github.com/VKCOM/noverify/src/php/parser/freefloating"
+	"github.com/VKCOM/noverify/src/php/parser/position"
+	"github.com/VKCOM/noverify/src/php/parser/walker"
+)
+
+type metaNode struct {
+	name string
+}
+
+func (metaNode) Walk(v walker.Visitor)                     {}
+func (metaNode) Attributes() map[string]interface{}        { return nil }
+func (metaNode) SetPosition(p *position.Position)          {}
+func (metaNode) GetPosition() *position.Position           { return nil }
+func (metaNode) GetFreeFloating() *freefloating.Collection { return nil }
+
+type (
+	anyConst struct{ metaNode }
+	anyVar   struct{ metaNode }
+	anyInt   struct{ metaNode }
+	anyFloat struct{ metaNode }
+	anyStr   struct{ metaNode }
+	anyNum   struct{ metaNode }
+	anyExpr  struct{ metaNode }
+	anyFunc  struct{ metaNode }
+)

--- a/src/phpgrep/pattern_language.md
+++ b/src/phpgrep/pattern_language.md
@@ -1,0 +1,137 @@
+# phpgrep pattern language
+
+This file serves as a main documentation source for the pattern language used inside phpgrep.
+
+We'll refer to it as PPL (phpgrep pattern language) for brevity.
+
+## Overview
+
+Syntax-wise, PPL is 100% compatible with PHP.
+
+In fact, it only changes the semantics of some syntax constructions without adding any
+new syntax forms to the PHP language. It means that phpgrep patterns can be parsed by
+any parser that can handle PHP.
+
+The patterns describe the program parts (syntax trees) that they need to match.
+In places where whitespace doesn't mattern in PHP, it has no special meaning in PPL as well.
+
+### PHP variables
+
+PHP variables syntax, `$<id>` match any kind of node (expression or a statement) exactly once.
+
+If same `<id>` is used multiple times, both "variables" should match the same AST.
+
+```php
+$x = $y; // Matches any assignment
+$x = $x; // Matches only self-assignments
+```
+
+The special variable `$_` can be used to avoid having to give names to less important parts of the pattern
+without additional restrictions that apply when variable names are identical.
+
+```php
+$_ = $_ // Matches any assignment (because $_ is special)
+```
+
+### Matcher expressions
+
+Expressions in form of `${"<matcher>"}` or `${'<matcher>'}` are called **matcher expressions**.
+The `<matcher>` determines what will be matched.
+
+It does not matter whether you use `'` or `"`, both behave identically.
+
+```
+matcher_expr = "$" "{" quote matcher quote "}"
+quote = "\"" | "'"
+matcher = named_matcher | matcher_class
+named_matcher = <name> ":" matcher_class
+matcher_class = <see the table of supported classes below>
+```
+
+| Class | Description |
+|---|---|
+| `*` | Any node, 0-N times |
+| `+` | Any node, 1-N times |
+| `int` | Integer literal |
+| `float` | Float literal |
+| `num` | Integer or float literal |
+| `str` | String literal |
+| `const` | Constant, like true or a class constant like T::FOO |
+| `var` | Variable |
+| `func` | Anonymous function/closure expression |
+| `expr` | Any expression |
+
+Some examples of complete matcher expressions:
+* `${'*'}` - matches any number of nodes
+* `${"+"}` - matches one or more nodes
+* `${'str'}` - matches any kind of string literal
+* `${"x:int"}` - `x`-named matcher that matches any integer
+* `$${"var"}` - matches any "variable variable", like `$$x` and `$$php`
+
+Interesting details:
+* Anonymous matchers get "_" name, so `${"var"}` is actually `${"_:var"}`
+* Semantically, `$x` is `${"x:node"}` (but PPL doesn't define `node`)
+
+### Filters
+
+After pattern is matched, additional filters can be applied to either accept or reject the match.
+
+Filters can only be applied to a **named** matchers.
+
+```
+filter = <name> operator argument
+operator = <see list of supported ops below>
+argument = <depends on the operator>
+```
+
+Filters are connected like a pipeline.
+If the first filter failed, a second filter will not be executed and the match will be rejected.
+
+This is an impossible filter list:
+
+```
+'x=1' 'x=2'
+```
+
+`x` is required to be equal to `1` and then it compared to `2`.
+
+**or**-like behavior can be encoded in several operator arguments using `,`:
+
+```
+'x=1,2'
+```
+
+### Filtering operators
+
+#### `~` filter
+
+The `~` filter matches matched node source text against regular expression.
+
+> Note: it uses **original** source text, not the printed AST node representation.
+> It means that you need to take code formatting into account.
+
+#### `!~` filter
+
+Opposite of `~`. Matches only when given regexp is not matched.
+
+#### `=` filter
+
+| Class | Effect | Example |
+|---|---|---|
+| `*` | Sub-pattern | `x=[$_]` |
+| `+` |  Sub-pattern | `x=${"var"}` |
+| `int` | Value matching | `x=1,20,300` |
+| `float` | Value matching | `x=5.6` |
+| `num` | Value matching | `x=1,1.5` |
+| `str` | Value matching | `x="foo","bar"` |
+| `var` | Name matching | `x=length,len` |
+| `expr` | Value matching | `x=1` |
+
+Sub-pattern can include any valid PPL text.
+
+Value and name matching accept a comma-separated lists of permitted values.
+For strings you need to use quotes, so there is no problem with having `,` inside them.
+
+#### `!=` filter
+
+Opposite of `=`. Matches only when `=` would not match.

--- a/src/phpgrep/phpgrep.go
+++ b/src/phpgrep/phpgrep.go
@@ -1,0 +1,40 @@
+package phpgrep
+
+import (
+	"github.com/VKCOM/noverify/src/php/parser/node"
+)
+
+// Compiler creates matcher objects out of the string patterns.
+type Compiler struct {
+}
+
+// Compile compiler a given pattern into a matcher.
+func (c *Compiler) Compile(pattern []byte) (*Matcher, error) {
+	return compile(c, pattern)
+}
+
+// Matcher is a compiled pattern that can be used for PHP code search.
+type Matcher struct {
+	m matcher
+}
+
+type MatchData struct {
+	Node  node.Node
+	Named map[string]node.Node
+}
+
+// Clone returns a deep copy of m.
+func (m *Matcher) Clone() *Matcher {
+	return &Matcher{m: m.m}
+}
+
+// Match reports whether given PHP code matches the bound pattern.
+//
+// For malformed inputs (like code with syntax errors), returns false.
+func (m *Matcher) Match(root node.Node) bool {
+	return m.m.matchAST(root)
+}
+
+func (m *Matcher) Find(root node.Node, callback func(*MatchData) bool) {
+	m.m.findAST(root, callback)
+}

--- a/src/phpgrep/utils.go
+++ b/src/phpgrep/utils.go
@@ -1,0 +1,189 @@
+package phpgrep
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/assign"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/binary"
+	"github.com/VKCOM/noverify/src/php/parser/node/scalar"
+	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
+	"github.com/VKCOM/noverify/src/php/parser/php7"
+	"github.com/VKCOM/noverify/src/php/parser/position"
+)
+
+func getNodePos(n node.Node) *position.Position {
+	pos := n.GetPosition()
+	if pos == nil {
+		// FIXME: investigate how and why we're getting nil position for some nodes.
+		// See #24.
+		return nil
+	}
+	if pos.EndPos < 0 || pos.StartPos-1 < 0 {
+		// FIXME: investigate why we sometimes get out-of-range pos ranges.
+		// We also get negative EndPos for some nodes, which is awkward.
+		// See #24.
+		return nil
+	}
+	return pos
+}
+
+func unquoted(s string) string {
+	return s[1 : len(s)-1]
+}
+
+func nodeIsVar(n node.Node) bool {
+	switch n.(type) {
+	case *node.SimpleVar, *node.Var:
+		return true
+	default:
+		return false
+	}
+}
+
+func nodeIsExpr(n node.Node) bool {
+	switch n.(type) {
+	case *assign.Assign,
+		*assign.BitwiseAnd,
+		*assign.BitwiseOr,
+		*assign.BitwiseXor,
+		*assign.Concat,
+		*assign.Div,
+		*assign.Minus,
+		*assign.Mod,
+		*assign.Mul,
+		*assign.Plus,
+		*assign.Pow,
+		*assign.Reference,
+		*assign.ShiftLeft,
+		*assign.ShiftRight,
+		*node.Var,
+		*node.SimpleVar,
+		*binary.BitwiseAnd,
+		*binary.BitwiseOr,
+		*binary.BitwiseXor,
+		*binary.BooleanAnd,
+		*binary.BooleanOr,
+		*binary.Coalesce,
+		*binary.Concat,
+		*binary.Div,
+		*binary.Equal,
+		*binary.Greater,
+		*binary.GreaterOrEqual,
+		*binary.Identical,
+		*binary.LogicalAnd,
+		*binary.LogicalOr,
+		*binary.LogicalXor,
+		*binary.Minus,
+		*binary.Mod,
+		*binary.Mul,
+		*binary.NotEqual,
+		*binary.NotIdentical,
+		*binary.Plus,
+		*binary.Pow,
+		*binary.ShiftLeft,
+		*binary.ShiftRight,
+		*binary.Smaller,
+		*binary.SmallerOrEqual,
+		*binary.Spaceship,
+		*expr.Array,
+		*expr.ArrayDimFetch,
+		*expr.ArrayItem,
+		*expr.BitwiseNot,
+		*expr.BooleanNot,
+		*expr.ClassConstFetch,
+		*expr.Clone,
+		*expr.Closure,
+		*expr.ClosureUse,
+		*expr.ConstFetch,
+		*expr.Empty,
+		*expr.ErrorSuppress,
+		*expr.Eval,
+		*expr.Exit,
+		*expr.FunctionCall,
+		*expr.Include,
+		*expr.IncludeOnce,
+		*expr.InstanceOf,
+		*expr.Isset,
+		*expr.MethodCall,
+		*expr.New,
+		*expr.PostDec,
+		*expr.PreInc,
+		*expr.Print,
+		*expr.PropertyFetch,
+		*expr.Reference,
+		*expr.Require,
+		*expr.RequireOnce,
+		*expr.ShellExec,
+		*expr.StaticCall,
+		*expr.StaticPropertyFetch,
+		*expr.Ternary,
+		*expr.UnaryMinus,
+		*expr.UnaryPlus,
+		*expr.Yield,
+		*expr.YieldFrom,
+		*scalar.Dnumber,
+		*scalar.Encapsed,
+		*scalar.EncapsedStringPart,
+		*scalar.Heredoc,
+		*scalar.Lnumber,
+		*scalar.MagicConstant,
+		*scalar.String,
+		*stmt.Expression:
+		return true
+
+	default:
+		return false
+	}
+}
+
+func matchMetaVar(n node.Node, s string) bool {
+	switch n := n.(type) {
+	case *expr.ArrayItem:
+		return n.Key == nil && matchMetaVar(n.Val, s)
+	case *stmt.Expression:
+		return matchMetaVar(n.Expr, s)
+	case *node.Argument:
+		return matchMetaVar(n.Expr, s)
+
+	case *node.Var:
+		nm, ok := n.Expr.(*scalar.String)
+		return ok && unquoted(nm.Value) == s
+
+	default:
+		return false
+	}
+}
+
+func parsePHP7(code []byte) (node.Node, []byte, error) {
+	if bytes.HasPrefix(code, []byte("<?")) || bytes.HasPrefix(code, []byte("<?php")) {
+		n, err := parsePHP7root(code)
+		return n, code, err
+	}
+	return parsePHP7expr(code)
+}
+
+func parsePHP7expr(code []byte) (node.Node, []byte, error) {
+	code = append([]byte("<?php "), code...)
+	code = append(code, ';')
+	root, err := parsePHP7root(code)
+	if err != nil {
+		return nil, code, err
+	}
+	stmts := root.(*node.Root).Stmts
+	if len(stmts) == 0 {
+		return &stmt.Nop{}, code, nil
+	}
+	return root.(*node.Root).Stmts[0], code, nil
+}
+
+func parsePHP7root(code []byte) (node.Node, error) {
+	p := php7.NewParser(bytes.NewReader(code), "string-input.php")
+	p.Parse()
+	if len(p.GetErrors()) != 0 {
+		return nil, errors.New(p.GetErrors()[0].String())
+	}
+	return p.GetRootNode(), nil
+}

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -1,0 +1,215 @@
+package rules
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/VKCOM/noverify/src/linter/lintapi"
+	"github.com/VKCOM/noverify/src/php/parser/freefloating"
+	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
+	"github.com/VKCOM/noverify/src/php/parser/php7"
+	"github.com/VKCOM/noverify/src/phpdoc"
+	"github.com/VKCOM/noverify/src/phpgrep"
+)
+
+var magicComment = regexp.MustCompile(`\* @(?:warning|error|info|maybe) `)
+
+type parseError struct {
+	filename string
+	lineNum  int
+	msg      string
+}
+
+func (e *parseError) Error() string {
+	return fmt.Sprintf("%s:%d: %s", e.filename, e.lineNum, e.msg)
+}
+
+// parser parses rules file into a RuleSet.
+type parser struct {
+	filename string
+	sources  []byte
+	res      *Set
+	compiler phpgrep.Compiler
+}
+
+// Parse reads PHP code that represents a rule file from r and creates a RuleSet based on it.
+func (p *parser) parse(filename string, r io.Reader) (*Set, error) {
+	res := NewSet()
+
+	// Parse PHP file.
+	//
+	// TODO: make phpgrep.compile accepting AST and stop
+	// slurping sources here + don't parse it twice.
+	sources, err := ioutil.ReadAll(r)
+	if err != nil {
+		return res, err
+	}
+	q := php7.NewParser(bytes.NewReader(sources), filename)
+	q.WithFreeFloating()
+	q.Parse()
+	if errs := q.GetErrors(); len(errs) != 0 {
+		return res, errors.New(errs[0].String())
+	}
+	root := q.GetRootNode()
+
+	// Convert PHP file into the rule set.
+	p.filename = filename
+	p.sources = sources
+	p.res = res
+	for _, st := range root.Stmts {
+		if err := p.parseRule(st); err != nil {
+			return p.res, err
+		}
+	}
+
+	return p.res, nil
+}
+
+func (p *parser) parseRule(st node.Node) error {
+	comment := ""
+	for _, ff := range (*st.GetFreeFloating())[freefloating.Start] {
+		if ff.StringType != freefloating.CommentType {
+			continue
+		}
+		if strings.HasPrefix(ff.Value, "/**") && magicComment.MatchString(ff.Value) {
+			comment = ff.Value
+			break
+		}
+	}
+	if comment == "" {
+		return nil
+	}
+
+	var rule Rule
+	rule.Name = fmt.Sprintf("%s:%d", filepath.Base(p.filename), st.GetPosition().StartLine)
+	critical := false
+	unnamed := true
+
+	var filterSet map[string]Filter
+	dst := p.res.Any // Use "any" set by default
+
+	for _, part := range phpdoc.Parse(comment) {
+		switch part.Name {
+		case "name":
+			if len(part.Params) != 1 {
+				return p.errorf(st, "@name expects exactly 1 param, got %d", len(part.Params))
+			}
+			unnamed = false
+			rule.Name = part.Params[0]
+
+		case "location":
+			if len(part.Params) != 1 {
+				return p.errorf(st, "@type expects exactly 1 params, got %d", len(part.Params))
+			}
+			name := part.Params[0]
+			if !strings.HasPrefix(name, "$") {
+				return p.errorf(st, "@type 2nd param must be a phpgrep variable")
+			}
+			rule.Location = strings.TrimPrefix(name, "$")
+
+		case "scope":
+			if len(part.Params) != 1 {
+				return p.errorf(st, "@scope expects exactly 1 params, got %d", len(part.Params))
+			}
+			switch part.Params[0] {
+			case "any":
+				dst = p.res.Any
+				rule.scope = "any"
+			case "root":
+				dst = p.res.Root
+				rule.scope = "root"
+			case "local":
+				dst = p.res.Local
+				rule.scope = "block"
+			default:
+				return p.errorf(st, "unknown @scope: %s", part.Params[0])
+			}
+
+		case "error":
+			rule.Level = lintapi.LevelError
+			rule.Message = part.ParamsText
+			critical = true
+		case "warning":
+			rule.Level = lintapi.LevelWarning
+			rule.Message = part.ParamsText
+			critical = true
+		case "info":
+			rule.Level = lintapi.LevelInformation
+			rule.Message = part.ParamsText
+		case "maybe":
+			rule.Level = lintapi.LevelMaybe
+			rule.Message = part.ParamsText
+
+		case "or":
+			rule.Filters = append(rule.Filters, filterSet)
+			filterSet = nil
+		case "type":
+			if len(part.Params) != 2 {
+				return p.errorf(st, "@type expects exactly 2 params, got %d", len(part.Params))
+			}
+			typ := part.Params[0]
+			name := part.Params[1]
+			if !strings.HasPrefix(name, "$") {
+				return p.errorf(st, "@type 2nd param must be a phpgrep variable")
+			}
+			name = strings.TrimPrefix(name, "$")
+			if filterSet == nil {
+				filterSet = map[string]Filter{}
+			}
+			filter := filterSet[name]
+			if filter.Types != nil {
+				return p.errorf(st, "$%s: duplicate type constraint", name)
+			}
+			filter.Types = strings.Split(typ, "|")
+			filterSet[name] = filter
+
+		default:
+			return p.errorf(st, "unknown attribute @%s on line %d", part.Name, part.Line)
+		}
+	}
+
+	if unnamed {
+		p.res.AlwaysAllowed = append(p.res.AlwaysAllowed, rule.Name)
+	}
+	if critical && unnamed {
+		p.res.AlwaysCritical = append(p.res.AlwaysCritical, rule.Name)
+	}
+
+	if filterSet != nil {
+		rule.Filters = append(rule.Filters, filterSet)
+	}
+
+	pos := st.GetPosition()
+	m, err := p.compiler.Compile(p.sources[pos.StartPos-1 : pos.EndPos])
+	if err != nil {
+		return p.errorf(st, "pattern compilation error: %v", err)
+	}
+	rule.Matcher = m
+
+	if st2, ok := st.(*stmt.Expression); ok {
+		st = st2.Expr
+	}
+	kind := CategorizeNode(st)
+	if kind == KindNone {
+		return p.errorf(st, "can't categorize pattern node: %T", st)
+	}
+	dst.RulesByKind[kind] = append(dst.RulesByKind[kind], rule)
+
+	return nil
+}
+
+func (p *parser) errorf(n node.Node, format string, args ...interface{}) *parseError {
+	pos := n.GetPosition()
+	return &parseError{
+		filename: p.filename,
+		lineNum:  pos.StartLine,
+		msg:      fmt.Sprintf(format, args...),
+	}
+}

--- a/src/rules/rule_kind.go
+++ b/src/rules/rule_kind.go
@@ -1,0 +1,189 @@
+package rules
+
+import (
+	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/assign"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/binary"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/cast"
+	"github.com/VKCOM/noverify/src/php/parser/node/scalar"
+	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
+)
+
+type RuleKind int
+
+// All kinds of node categories.
+//
+// See CategorizeNode to see how they are connected
+// with particular node types.
+const (
+	KindNone RuleKind = iota
+
+	KindMethodCall
+	KindFunctionCall
+	KindStaticCall
+	KindArray
+
+	KindValueFetch
+	KindCmp     // All binary comparison ops
+	KindBinOp   // All binary ops except comparison ops
+	KindUnaryOp // All unary-ish ops
+	KindAssign  // All assignments
+	KindCondOp  // All conditional expressions
+	KindBranch  // All conditional statements
+	KindScalar  // All scalar-like nodes
+	KindConst   // All const fetching ops
+	KindRequire
+	KindLoop
+	KindCast
+	KindOther         // All remaining kinds that are not None
+	KindOtherUnlikely // Second Other category, even less priority
+
+	_KindCount // Should be always the last one
+)
+
+// CategorizeNode tries to associate a node with one of the known categories.
+// If node can't be (yet?) categorized, returns KindNone.
+//
+// Note that for some nodes we *want* to return KindNone, since matching
+// engine can have a hard time trying to match them.
+//
+// We try to categorize nodes in a way that predict which rules have
+// higher chances to be used by the users. For examples, it's likely
+// that function calls could be the most important pattern out there.
+// With some other groups it's more or less shot in the dark.
+// A better algorithm can be found later. Maybe we'll assign categories
+// dynamically or map them 1-to-1 with nodes kind in future.
+func CategorizeNode(n node.Node) RuleKind {
+	switch n.(type) {
+	case *expr.FunctionCall:
+		return KindFunctionCall
+
+	case *expr.MethodCall:
+		return KindMethodCall
+
+	case *expr.StaticCall:
+		return KindStaticCall
+
+	case *expr.Array:
+		return KindArray
+
+	case *expr.PropertyFetch,
+		*expr.StaticPropertyFetch,
+		*expr.ArrayDimFetch:
+		return KindValueFetch
+
+	case *expr.Isset,
+		*expr.Empty,
+		*stmt.Return,
+		*expr.New:
+		return KindOther
+
+	case *expr.Exit,
+		*expr.Yield,
+		*expr.Eval,
+		*expr.Print,
+		*expr.Clone:
+		return KindOtherUnlikely
+
+	case *assign.Assign,
+		*assign.Reference,
+		*assign.BitwiseAnd,
+		*assign.BitwiseOr,
+		*assign.BitwiseXor,
+		*assign.Concat,
+		*assign.Div,
+		*assign.Minus,
+		*assign.Mod,
+		*assign.Mul,
+		*assign.Plus,
+		*assign.Pow,
+		*assign.ShiftLeft,
+		*assign.ShiftRight:
+		return KindAssign
+
+	case *binary.Equal,
+		*binary.NotEqual,
+		*binary.Identical,
+		*binary.NotIdentical,
+		*binary.Smaller,
+		*binary.Greater,
+		*binary.SmallerOrEqual,
+		*binary.GreaterOrEqual,
+		*binary.Spaceship:
+		return KindCmp
+
+	case *binary.BitwiseAnd,
+		*binary.BitwiseOr,
+		*binary.BitwiseXor,
+		*binary.Coalesce,
+		*binary.Concat,
+		*binary.Div,
+		*binary.Minus,
+		*binary.Mod,
+		*binary.Mul,
+		*binary.Plus,
+		*binary.Pow,
+		*binary.ShiftLeft,
+		*binary.ShiftRight:
+		return KindBinOp
+
+	case *expr.BitwiseNot,
+		*expr.BooleanNot,
+		*expr.ErrorSuppress,
+		*expr.PostDec,
+		*expr.PostInc,
+		*expr.PreDec,
+		*expr.PreInc,
+		*expr.Reference,
+		*expr.UnaryMinus:
+		return KindUnaryOp
+
+	case *binary.LogicalOr,
+		*binary.LogicalAnd,
+		*binary.BooleanOr,
+		*binary.BooleanAnd,
+		*expr.Ternary:
+		return KindCondOp
+
+	case *stmt.Do,
+		*stmt.For,
+		*stmt.Foreach,
+		*stmt.While:
+		return KindLoop
+
+	case *cast.Array,
+		*cast.Bool,
+		*cast.Double,
+		*cast.Int,
+		*cast.Object,
+		*cast.String,
+		*cast.Unset:
+		return KindCast
+
+	case *expr.Require,
+		*expr.RequireOnce,
+		*expr.Include,
+		*expr.IncludeOnce:
+		return KindRequire
+
+	case *stmt.If,
+		*stmt.Throw:
+		return KindBranch
+
+	case *expr.ShellExec,
+		*scalar.String,
+		*scalar.Lnumber,
+		*scalar.Dnumber,
+		*scalar.Heredoc,
+		*scalar.Encapsed:
+		return KindScalar
+
+	case *expr.ClassConstFetch,
+		*expr.ConstFetch:
+		return KindConst
+
+	default:
+		return KindNone
+	}
+}

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -1,0 +1,95 @@
+package rules
+
+import (
+	"io"
+
+	"github.com/VKCOM/noverify/src/phpgrep"
+)
+
+type Parser struct{}
+
+func NewParser() *Parser {
+	return &Parser{}
+}
+
+func (*Parser) Parse(filename string, r io.Reader) (*Set, error) {
+	var p parser
+	return p.parse(filename, r)
+}
+
+// NewSet returns a new empty rules set.
+func NewSet() *Set {
+	return &Set{
+		Any:   &ScopedSet{},
+		Root:  &ScopedSet{},
+		Local: &ScopedSet{},
+	}
+}
+
+// Set is a result of rule file parsing.
+type Set struct {
+	Any   *ScopedSet // Anywhere
+	Root  *ScopedSet // Only outside of functions
+	Local *ScopedSet // Only inside functions
+
+	AlwaysAllowed  []string // All unnamed rules
+	AlwaysCritical []string // Unnamed rules of warning or error level
+}
+
+// ScopedSet is a categorized rules collection.
+// Categories help to assign a better execution strategy for a rule.
+type ScopedSet struct {
+	RulesByKind [_KindCount][]Rule
+}
+
+// Clone returns a deep copy of a scoped set.
+func (set *ScopedSet) Clone() *ScopedSet {
+	if set == nil {
+		return nil
+	}
+	var clone ScopedSet
+	for i, list := range &set.RulesByKind {
+		clone.RulesByKind[i] = cloneRuleList(list)
+	}
+	return &clone
+}
+
+// Rule is a dynamically-loaded linter rule.
+//
+// A rule is called unnamed if no @name attribute is given.
+// Unnamed rules receive auto-generated name that includes
+// a rule file name and a line that defines that rule.
+type Rule struct {
+	// Name tells whether this rule causes critical report.
+	Name string
+
+	// Matcher is an object that is used to check whether a given AST node
+	// should trigger a warning that is associated with rule.
+	Matcher *phpgrep.Matcher
+
+	// Level is a severity level that is used during report generation.
+	Level int
+
+	// Message is a report text that is printed when this rule matches.
+	Message string
+
+	// Location is a phpgrep variable name that should be used as a warning location.
+	// Empty string selects the root node.
+	Location string
+
+	// Filters is a list of OR-connected filter sets.
+	// Every filter set is a mapping of phpgrep variable to a filter.
+	Filters []map[string]Filter
+
+	scope string
+}
+
+// String returns a rule printer representation.
+func (r *Rule) String() string {
+	return formatRule(r)
+}
+
+// Filter describes constraints that should be applied to a given phpgrep variable.
+type Filter struct {
+	Types []string
+}

--- a/src/rules/util.go
+++ b/src/rules/util.go
@@ -1,0 +1,58 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/VKCOM/noverify/src/linter/lintapi"
+)
+
+func cloneRuleList(rules []Rule) []Rule {
+	res := make([]Rule, len(rules))
+	for i, rule := range rules {
+		res[i] = rule
+		res[i].Matcher = rule.Matcher.Clone()
+	}
+	return res
+}
+
+func formatRule(r *Rule) string {
+	var buf strings.Builder
+
+	buf.WriteString("/**\n")
+
+	switch r.Level {
+	case lintapi.LevelError:
+		buf.WriteString(" * @error " + r.Message + "\n")
+	case lintapi.LevelWarning:
+		buf.WriteString(" * @warning " + r.Message + "\n")
+	case lintapi.LevelInformation:
+		buf.WriteString(" * @info " + r.Message + "\n")
+	case lintapi.LevelMaybe:
+		buf.WriteString(" * @maybe " + r.Message + "\n")
+	}
+
+	if r.Location != "" {
+		buf.WriteString(" * @location $" + r.Location + "\n")
+	}
+
+	if r.scope != "" {
+		buf.WriteString(" * @scope " + r.scope + "\n")
+	}
+
+	for i, filters := range r.Filters {
+		for name, filter := range filters {
+			if len(filter.Types) != 0 {
+				fmt.Fprintf(&buf, " * @type %s $%s\n", strings.Join(filter.Types, "|"), name)
+			}
+		}
+		if i != len(r.Filters)-1 {
+			buf.WriteString(" * @or\n")
+		}
+	}
+
+	buf.WriteString(" */")
+
+	return buf.String()
+
+}


### PR DESCRIPTION
Added a new command-line argument, -rules=<files-list>.
When this argument is set, NoVerify parses these files
and makes dynamic rules out of it. Dynamic rules are a way
to add diagnostics to NoVerify without a need to write any Go
code or even re-compile the linter.

The rules syntax and matching engine is borrowed from
	https://github.com/quasilyte/phpgrep

No measurable performance impact when rules are not used.
When rules are used, we use rule clusterization to
reduce the amount of excessive work performed.
Some more optimizations can be applied later if we find
any bottlenecks or if there is a demand to make this mechanism faster.
Right now it can execute hundreds of rules without significant
penalties (unless all rules belong to the same category,
which can be the case with function call patterns, but that
specific case can be easily optimized in separation).

TODO: add more documentation, tests, and examples.

Right now this feature is not mentioned in docs since
it needs to be better tested prior to that.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>