### PR TITLE
solver: handle ClassConstFetch exprs

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -21,7 +21,8 @@ import (
 // Version log:
 //     27 - added Static field to meta.FuncInfo
 //     28 - array type parsed as mixed[]
-const cacheVersion = 28
+//     29 - updated type inference for ClassConstFetch
+const cacheVersion = 29
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -99,7 +99,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 2740
+		wantLen := 2799
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -108,7 +108,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "96c3b3c94f4c9830ab91ce432ad9fb22e1d719e054807f4854d87c6781157a7bb1e1b219aaa04f17d994ffa924163d1f1156f5d729d0fe9f681500549a3c6b7b"
+		wantStrings := "81f1a7850db7d602d4d968cfdd1280b3c9afe9069e2a96bcb021a8f4f3801d550d2a7c9d18f9644078a976534c1c3bd4722ba91637a32527fb289250ec5f6823"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)
@@ -122,9 +122,12 @@ main();
 		if err := readMetaCache(bytes.NewReader(buf.Bytes()), "", decodedMeta); err != nil {
 			t.Errorf("decoding failed: %v", err)
 		} else {
+			// TODO: due to lots of important unexported fields,
+			// we can't reliably check 2 meta files via assert.
 			assert.DeepEqual(t,
 				encodedMeta, decodedMeta,
-				cmp.AllowUnexported(meta.TypesMap{}))
+				cmp.AllowUnexported(meta.TypesMap{}),
+				cmp.AllowUnexported(meta.Scope{}))
 		}
 
 		if t.Failed() {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -249,7 +249,7 @@ func (d *RootWalker) EnterNode(w walker.Walkable) (res bool) {
 			break
 		}
 
-		d.scope().AddVar(v, solver.ExprTypeLocal(d.meta.Scope, d.st, n.Expression), "global variable", true)
+		d.scope().AddVar(v, solver.ExprTypeLocal(d.scope(), d.st, n.Expression), "global variable", true)
 	case *stmt.Function:
 		res = d.enterFunction(n)
 	case *stmt.PropertyList:
@@ -605,7 +605,7 @@ func (d *RootWalker) enterPropertyList(pl *stmt.PropertyList) bool {
 		}
 
 		if p.Expr != nil {
-			typ = typ.Append(solver.ExprTypeLocal(d.meta.Scope, d.st, p.Expr))
+			typ = typ.Append(solver.ExprTypeLocal(d.scope(), d.st, p.Expr))
 		}
 
 		if isStatic {
@@ -642,7 +642,7 @@ func (d *RootWalker) enterClassConstList(s *stmt.ClassConstList) bool {
 		c := cNode.(*stmt.Constant)
 
 		nm := c.ConstantName.Value
-		typ := solver.ExprTypeLocal(d.meta.Scope, d.st, c.Expr)
+		typ := solver.ExprTypeLocal(d.scope(), d.st, c.Expr)
 
 		// TODO: handle duplicate constant
 		cl.Constants[nm] = meta.ConstantInfo{
@@ -1200,7 +1200,7 @@ func (d *RootWalker) enterFunctionCall(s *expr.FunctionCall) bool {
 
 	d.meta.Constants[`\`+strings.TrimFunc(str.Value, isQuote)] = meta.ConstantInfo{
 		Pos: d.getElementPos(s),
-		Typ: solver.ExprTypeLocal(d.meta.Scope, d.st, valueArg.Expr),
+		Typ: solver.ExprTypeLocal(d.scope(), d.st, valueArg.Expr),
 	}
 	return true
 }
@@ -1298,7 +1298,7 @@ func (d *RootWalker) enterConstList(lst *stmt.ConstList) bool {
 
 		d.meta.Constants[nm] = meta.ConstantInfo{
 			Pos: d.getElementPos(s),
-			Typ: solver.ExprTypeLocal(d.meta.Scope, d.st, s.Expr),
+			Typ: solver.ExprTypeLocal(d.scope(), d.st, s.Expr),
 		}
 	}
 

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -541,19 +541,18 @@ func TestExprTypeProperty(t *testing.T) {
 		{`$point->x`, "float"},
 		{`$point->y`, "float"},
 
-		// TODO:
-		//
-		// {`Gopher::$name`, "string"},
-		// {`Gopher::POWER`, "int"},
-		// {`$magic->int`, ""},
+		{`Gopher::$name`, "string"},
+		{`Gopher::POWER`, "int"},
+		{`$magic->int`, "int"},
 	}
 
 	global := `<?php
+
 class Gopher {
   /** @var string */
   public static $name = "unnamed";
 
-  constant POWER = 9001; // It's over 9000
+  const POWER = 9001; // It's over 9000
 }
 
 /**

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -314,6 +314,15 @@ func exprTypeLocalCustom(sc *meta.Scope, cs *meta.ClassParseState, n node.Node, 
 		return meta.NewTypesMap("int")
 	case *cast.String:
 		return meta.NewTypesMap("string")
+	case *expr.ClassConstFetch:
+		className, ok := GetClassName(cs, n.Class)
+		if !ok {
+			return meta.TypesMap{}
+		}
+		res, _, ok := FindConstant(className, n.ConstantName.Value)
+		if ok {
+			return res.Typ
+		}
 	case *expr.ConstFetch:
 		nm, ok := n.Constant.(*name.Name)
 		if !ok {


### PR DESCRIPTION
Previously, class const fetch always resulted in "mixed" type.
Handle ClassConstFetch case in solver to get proper type info for it.

Also use RootWalker.scope() method instead of meta.scope field inside
the walker, since if scope is nil, ExprType would return empty type
resolving results.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>