### PR TITLE
linter: fix arraySyntax false positive in func params

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1157,7 +1157,7 @@ func (d *RootWalker) checkFuncParam(p *node.Parameter) {
 	// TODO(quasilyte): DefaultValue can only contain constant expressions.
 	// Could run special check over them to detect the potential fatal errors.
 	walkNode(p.DefaultValue, func(w walker.Walkable) bool {
-		if n, ok := w.(*expr.Array); ok {
+		if n, ok := w.(*expr.Array); ok && !n.ShortSyntax {
 			d.Report(n, LevelDoNotReject, "arraySyntax", "Use of old array syntax (use short form instead)")
 		}
 		return true

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -91,7 +91,9 @@ function mt_rand($x = 0, $y = 0) {}`)
 func TestArgsArraysSyntax(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
-function f($a = array()) {}`)
+function bad($a = array()) {}
+function good($a = []) {}
+`)
 	test.Expect = []string{
 		`Use of old array syntax (use short form instead)`,
 	}


### PR DESCRIPTION
Appeared after php parser rewrite. Now Array node represents
both kinds of array literals.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>