### PR TITLE
rules: make it possible to have several patterns for 1 phpdoc comment

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -332,7 +332,7 @@ func initRules() error {
 		appendRules(linter.Rules.Root, rset.Root)
 		appendRules(linter.Rules.Local, rset.Local)
 
-		for _, name := range rset.AlwaysAllowed {
+		for _, name := range rset.ToAllow {
 			reportsIncludeChecksSet[name] = true
 		}
 		for _, name := range rset.AlwaysCritical {

--- a/src/linttest/rules_test.go
+++ b/src/linttest/rules_test.go
@@ -11,6 +11,20 @@ import (
 
 func TestAnyRules(t *testing.T) {
 	rfile := `<?php
+/**
+ * @warning don't compare arrays with numeric types
+ * @type array $x
+ * @type int|float $y
+ * @or
+ * @type int|float $x
+ * @type array $y
+ */
+$x > $y;
+$x < $y;
+$x >= $y;
+$x <= $y;
+$x == $y;
+
 /** @warning suspicious order of stripos function arguments */
 stripos(${"str"}, ${"*"});
 
@@ -47,6 +61,19 @@ function define($name, $value) {}
 
 define('true', 1 == 1);
 
+function combinedPatterns(array $arr) {
+  $_ = $arr > 10;
+  $_ = 10 > $arr;
+  $_ = $arr < 10;
+  $_ = 10 < $arr;
+  $_ = $arr >= 10;
+  $_ = 10 >= $arr;
+  $_ = $arr <= 10;
+  $_ = 10 <= $arr;
+  $_ = $arr == 10;
+  $_ = 10 == $arr;
+}
+
 function f($x, $y) {
   $_ = stripos("needle", $x); // Bad
   $_ = stripos($x, "needle"); // Good
@@ -82,6 +109,16 @@ $_ = explode("", $s);
 		`strings must be compared using '===' operator`,
 		`strings must be compared using '===' operator`,
 		`strings must be compared using '===' operator`,
+		`don't compare arrays with numeric types`,
+		`don't compare arrays with numeric types`,
+		`don't compare arrays with numeric types`,
+		`don't compare arrays with numeric types`,
+		`don't compare arrays with numeric types`,
+		`don't compare arrays with numeric types`,
+		`don't compare arrays with numeric types`,
+		`don't compare arrays with numeric types`,
+		`don't compare arrays with numeric types`,
+		`don't compare arrays with numeric types`,
 	}
 	runRulesTest(t, test, rfile)
 }

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -32,7 +32,7 @@ type Set struct {
 	Root  *ScopedSet // Only outside of functions
 	Local *ScopedSet // Only inside functions
 
-	AlwaysAllowed  []string // All unnamed rules
+	ToAllow        []string // All rule names
 	AlwaysCritical []string // Unnamed rules of warning or error level
 }
 


### PR DESCRIPTION
When several patterns have exactly the same phpdoc comment, we want
to refactor that or to re-use constraints in some way.

Proposed way for that is phpdoc combining.

If a pattern doesn't have its own phpdoc comment, it borrows
all attributes from the last pattern with explicit phpdoc comment.

A good usage example of this feature is demonstrated in tests.

Made named rules enabled ("allowed") by default as well.
Whey can be disabled with -exclude-checks option if desired.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>