### PR TITLE
linter: handle /* @var */ in addition to /** @var */

### DIFF
--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -6,6 +6,18 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestIssue289(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Foo { public $value = 11; }
+
+$xs = [0, new Foo()];
+
+/* @var Foo $foo */
+$foo = $xs[1];
+$_ = $foo->value;
+`)
+}
+
 func TestIssue1(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 	interface TestInterface


### PR DESCRIPTION
Even though phpdoc documentation does not explicitly permit
/* @var */ to be used instead of /** @var */, there are
occasions where former form is used. PhpStorm does understand
it, so we can do the same at least by default.

It solves false positives that appear when we miss @var
info due to malformed syntax.

Fixes #289
Fixes #284

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>