### PR TITLE
phpgrep: add call* benchmark for completeness

### DIFF
--- a/src/phpgrep/matcher_test.go
+++ b/src/phpgrep/matcher_test.go
@@ -561,10 +561,11 @@ func BenchmarkFind(b *testing.B) {
 		input   []byte
 	}{
 		// Benchmarking list matching.
-		{"positive/call_", `$_($_)`, lotsOfCalls},
+		{"positive/call*", `$_(${"*"})`, lotsOfCalls},
 		{"positive/call_*", `$_($_, ${"*"})`, lotsOfCalls},
 		{"positive/call*_", `$_(${"*"}, $_)`, lotsOfCalls},
 		{"positive/call*_*", `$_(${"*"}, $_, ${"*"})`, lotsOfCalls},
+		{"negative/call_", `$_($_)`, lotsOfCalls},
 
 		// Benchmarking named variables.
 		{"positive/with-1-named", `$x`, benchmarkInput},

--- a/src/phpgrep/meta_nodes.go
+++ b/src/phpgrep/meta_nodes.go
@@ -11,7 +11,6 @@ type metaNode struct {
 }
 
 func (metaNode) Walk(v walker.Visitor)                     {}
-func (metaNode) Attributes() map[string]interface{}        { return nil }
 func (metaNode) SetPosition(p *position.Position)          {}
 func (metaNode) GetPosition() *position.Position           { return nil }
 func (metaNode) GetFreeFloating() *freefloating.Collection { return nil }


### PR DESCRIPTION
Also removed GetAttributes method from metaNode,
since it's not needed to implement node.Node anymore.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>