### PR TITLE
linter: check for non-existing var refs in @param

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -980,6 +980,12 @@ func (d *RootWalker) parsePHPDoc(doc string, actualParams []node.Node) phpDocPar
 		return result
 	}
 
+	actualParamNames := make(map[string]struct{}, len(actualParams))
+	for _, p := range actualParams {
+		p := p.(*node.Parameter)
+		actualParamNames[p.Variable.Name] = struct{}{}
+	}
+
 	result.types = make(phpDocParamsMap, len(actualParams))
 
 	var curParam int
@@ -1035,6 +1041,11 @@ func (d *RootWalker) parsePHPDoc(doc string, actualParams []node.Node) phpDocPar
 				result.errs.pushLint("too many @param tags on line %d", part.Line)
 				continue
 			}
+		}
+
+		if _, ok := actualParamNames[strings.TrimPrefix(variable, "$")]; !ok {
+			result.errs.pushLint("@param for non-existing argument %s", variable)
+			continue
 		}
 
 		curParam++

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -818,7 +818,7 @@ func TestForeachByRefUnused(t *testing.T) {
 	/**
 	 * @param SomeClass[] $some_arr
 	 */
-	function doSometing() {
+	function doSometing($some_arr) {
 		$some_arr = [];
 
 		foreach ($some_arr as $var) {

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -6,6 +6,28 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestBadParamName(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+/**
+ * @param B1 $v2
+ * @param B2 $v3
+ */
+function f($v1, $v2) {
+}
+
+class Bear {
+  /** @param int $y */
+  private function migrate($x) {}
+}
+`)
+	test.Expect = []string{
+		`@param for non-existing argument $v3`,
+		`@param for non-existing argument $y`,
+	}
+	test.RunAndMatch()
+}
+
 func TestDeprecatedMethod(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
Warning message borrowed from the PhpStorm inspection.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>