### PR TITLE
rules: improve @type filter support

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1388,22 +1388,21 @@ func (d *RootWalker) matchRule(n node.Node, sc *meta.Scope, rule *rules.Rule) no
 	return location
 }
 
+func (d *RootWalker) checkTypeFilter(typeExpr phpdoc.TypeExpr, sc *meta.Scope, nn node.Node) bool {
+	if typeExpr == nil {
+		return true
+	}
+
+	typ := solver.ExprType(sc, d.st, nn)
+	return typeIsCompatible(typ, typeExpr)
+}
+
 func (d *RootWalker) checkFilterSet(m *phpgrep.MatchData, sc *meta.Scope, filterSet map[string]rules.Filter) bool {
 	for name, filter := range filterSet {
 		nn := m.Named[name]
 
-		if len(filter.Types) != 0 {
-			typ := solver.ExprType(sc, d.st, nn)
-			matched := false
-			for _, wantType := range filter.Types {
-				if typeIsCompatible(typ, wantType) {
-					matched = true
-					break
-				}
-			}
-			if !matched {
-				return false
-			}
+		if !d.checkTypeFilter(filter.Type, sc, nn) {
+			return false
 		}
 	}
 

--- a/src/linter/type_filter_test.go
+++ b/src/linter/type_filter_test.go
@@ -1,0 +1,108 @@
+package linter
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/phpdoc"
+)
+
+func TestTypeFilter(t *testing.T) {
+	type testCase struct {
+		dst string
+		val string
+	}
+
+	matchingTests := []testCase{
+		{`array`, `mixed[]`},
+		{`array`, `\Foo[]`},
+
+		{`object`, `object`},
+		{`object`, `\Foo`},
+		{`object`, `\Foo\Bar`},
+
+		{`!int`, `string`},
+		{`!int`, `mixed`},
+		{`!array`, `int`},
+		{`!array`, `string`},
+
+		{`int[]`, `int[]`},
+
+		{`int|float`, `int`},
+		{`int|float`, `float`},
+		{`float|int`, `int`},
+		{`int|float`, `float`},
+
+		{`!(int|float)`, `string`},
+		{`!(int|float)`, `int[]`},
+		{`!(object|array)`, `int`},
+		{`!(object|array)`, `string`},
+
+		{`a|b`, `a|b`},
+		{`object|array`, `\Foo|int[]`},
+		{`object|array`, `object|float[]`},
+
+		// TODO: make union comparison work in these cases.
+		// {`a|b|c`, `a|b|c`},
+		// {`a|c|b`, `a|b|c`},
+		// {`c|b|a`, `a|b|c`},
+	}
+
+	nonMatchingTests := []testCase{
+		{`array`, `int`},
+		{`array`, `mixed`},
+		{`array`, `\Foo`},
+
+		{`object`, `int`},
+		{`object`, `\Foo[]`},
+		{`object`, `mixed`},
+
+		{`!int`, `int`},
+		{`!array`, `mixed[]`},
+		{`!array`, `int[]`},
+
+		{`int[]`, `float[]`},
+		{`int[]`, `mixed[]`},
+
+		{`int|float`, `string`},
+		{`int|float`, `\Foo`},
+		{`float|int`, `int[]`},
+		{`int|float`, `float[]`},
+		{`int|float`, `mixed`},
+
+		{`!(int|float)`, `int`},
+		{`!(int|float)`, `float`},
+		{`!(object|array)`, `object`},
+		{`!(object|array)`, `int[]`},
+		{`!(object|array)`, `\Foo`},
+		{`!(object|array)`, `\Foo[]`},
+
+		{`object|array`, `int|int[]`},
+		{`object|array`, `object|float`},
+		{`object|array`, `string|float`},
+	}
+
+	runTests := func(want bool, tests []testCase) {
+		var p phpdoc.TypeParser
+		for _, test := range tests {
+			val, err := p.ParseType(test.val)
+			if err != nil {
+				t.Errorf("parse type `%s`: %v", test.val, err)
+				continue
+			}
+			dst, err := p.ParseType(test.dst)
+			if err != nil {
+				t.Errorf("parse type `%s`: %v", test.dst, err)
+				continue
+			}
+
+			have := typeExprIsCompatible(dst, val)
+			if have != want {
+				t.Errorf("incorrect result: compatible(%s, %s) => %v",
+					test.dst, test.val, have)
+			}
+		}
+	}
+
+	runTests(true, matchingTests)
+	runTests(false, nonMatchingTests)
+}

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -158,7 +158,13 @@ func (m TypesMap) Append(n TypesMap) TypesMap {
 
 // String returns string representation of a map
 func (m TypesMap) String() string {
-	var types []string
+	if len(m.m) == 1 {
+		for k := range m.m {
+			return k
+		}
+	}
+
+	types := make([]string, 0, len(m.m))
 	for k := range m.m {
 		types = append(types, formatType(k))
 	}

--- a/src/phpdoc/type_parser.go
+++ b/src/phpdoc/type_parser.go
@@ -1,0 +1,129 @@
+package phpdoc
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// TODO: use this parser inside linter as well after it's polished?
+//
+// TODO: consider using the grammar from https://github.com/phpstan/phpdoc-parser
+//       if we ever want to understand array literal types, generics, callable with params.
+
+// TypeParser handles phpdoc type expressions parsing.
+//
+// See https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#abnf
+type TypeParser struct {
+	s string
+}
+
+// ParseType parses a phpdoc type out of a sting s.
+func (p *TypeParser) ParseType(s string) (result TypeExpr, err error) {
+	defer func() {
+		r := recover()
+		if err2, ok := r.(error); ok {
+			err = err2
+			return
+		}
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	p.s = strings.TrimSpace(s)
+	return p.parseType(), nil
+}
+
+func (p *TypeParser) parseType() TypeExpr {
+	if len(p.s) == 0 {
+		panic(errors.New("unexpected end of input, expected type expr"))
+	}
+
+	left := p.parseOperand()
+	for p.tryConsume("[") {
+		if p.tryConsume("]") {
+			left = &ArrayType{Elem: left}
+		} else {
+			panic(errors.New("missing closing `]`"))
+		}
+	}
+	switch {
+	case p.tryConsume("&"):
+		return &InterType{X: left, Y: p.parseType()}
+	case p.tryConsume("|"):
+		return &UnionType{X: left, Y: p.parseType()}
+	}
+	return left
+}
+
+func (p *TypeParser) parseOperand() TypeExpr {
+	switch {
+	case isClassNameChar(p.s[0], true):
+		i := 1
+		for i < len(p.s) && isClassNameChar(p.s[i], false) {
+			i++
+		}
+		typ := &NamedType{Name: p.s[:i]}
+		p.consume(i)
+		return typ
+
+	case p.tryConsume("("):
+		typ := p.parseType()
+		if p.tryConsume(")") {
+			return typ
+		}
+		panic(errors.New("missing closing `)`"))
+
+	case p.tryConsume("!"):
+		return &NotType{Expr: p.parseOperand()}
+
+	case p.tryConsume("?"):
+		return &NullableType{Expr: p.parseOperand()}
+
+	case p.tryConsume("$this"): // The only permitted $-prefixed type
+		return &NamedType{Name: "$this"}
+
+	default:
+		if len(p.s) == 0 {
+			panic(errors.New("unexpected end of input, expected type operand"))
+		}
+		panic(fmt.Errorf("unexpected `%c` in type operand", p.s[0]))
+	}
+}
+
+func (p *TypeParser) skipSpace() {
+	p.s = strings.TrimLeftFunc(p.s, unicode.IsSpace)
+}
+
+func (p *TypeParser) tryConsume(s string) bool {
+	p.skipSpace()
+	if strings.HasPrefix(p.s, s) {
+		p.consume(len(s))
+		return true
+	}
+	return false
+}
+
+func (p *TypeParser) consume(n int) {
+	p.s = p.s[n:]
+}
+
+func isClassNameChar(ch byte, first bool) bool {
+	// ^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$
+	switch {
+	case ch == '\\':
+		return true
+	case ch == '_':
+		return true
+	case ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z':
+		return true
+	case ch >= '0' && ch <= '9':
+		return !first
+	case ch >= 0x80 && ch <= 0xff:
+		return true
+	default:
+		return false
+	}
+}

--- a/src/phpdoc/type_parser_test.go
+++ b/src/phpdoc/type_parser_test.go
@@ -1,0 +1,93 @@
+package phpdoc
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TODO: parsing error tests.
+
+func TestTypeParser(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{` int `, `int`},
+		{`int`, `int`},
+		{`(string)`, `string`},
+		{` ( (string))`, `string`},
+		{` ((string ) ) `, `string`},
+		{`$this`, `$this`},
+		{`\A`, `\A`},
+		{`\A\B`, `\A\B`},
+		{`Foo\Bar`, `Foo\Bar`},
+
+		{`!int`, `!int`},
+		{`!(string)`, `!string`},
+		{`!((string))`, `!string`},
+		{`!!int`, `!!int`},
+
+		{`?int`, `?int`},
+		{`?(string)`, `?string`},
+		{`?((string))`, `?string`},
+		{`??int`, `??int`},
+
+		{`int[]`, `int[]`},
+		{`int[][]`, `int[][]`},
+		{`(int)[]`, `int[]`},
+		{` int [ ] `, `int[]`},
+		{` x[] [ ][  ] `, `x[][][]`},
+
+		{`(int|float)[]`, `(int|float)[]`},
+		{`(float|int)[]`, `(float|int)[]`},
+		{`\A\B|C|int`, `(\A\B|(C|int))`},
+		{`int|float`, `(int|float)`},
+		{`float|int`, `(float|int)`},
+		{`a|b|c`, `(a|(b|c))`},
+		{`!a|!b|c`, `(!a|(!b|c))`},
+		{`!a|b|!c|d`, `(!a|(b|(!c|d)))`},
+		{`!(a|b)|!c|d`, `(!(a|b)|(!c|d))`},
+		{`(a|b)|(d|c)`, `((a|b)|(d|c))`},
+		{`(a|b)|(d|c|e)|x`, `((a|b)|((d|(c|e))|x))`},
+		{`int[]|string[]`, `(int[]|string[])`},
+		{`(int[])|string[]`, `(int[]|string[])`},
+		{`int[]|(string[])`, `(int[]|string[])`},
+
+		{`a|b&c`, `(a|(b&c))`},
+		{`(a|b)&c`, `((a|b)&c)`},
+		{`a|(b&c)`, `(a|(b&c))`},
+		{`a&b|c`, `(a&(b|c))`},
+		{`(a&b)|c`, `((a&b)|c)`},
+		{`a&(b|c)`, `(a&(b|c))`},
+	}
+
+	var p TypeParser
+	for _, test := range tests {
+		typ, err := p.ParseType(test.input)
+		if err != nil {
+			t.Errorf("unexpected error for parse(%q): %v", test.input, err)
+			continue
+		}
+		have := typ.String()
+		if have != test.want {
+			t.Errorf("result mismatch for parse(%q):\nhave: %s\nwant: %s", test.input, have, test.want)
+			t.Logf("%#v", typ)
+			continue
+		}
+
+		typ2, err := p.ParseType(have)
+		if err != nil {
+			t.Errorf("re-parse %q error: %v", have, err)
+			continue
+		}
+		have2 := typ2.String()
+		if have2 != have {
+			t.Errorf("re-parse result mismatch:\nhave: %s\nwant: %s", have2, have)
+			continue
+		}
+		if diff := cmp.Diff(typ, typ2); diff != "" {
+			t.Errorf("re-parse result mismatch: %s", diff)
+		}
+	}
+}

--- a/src/phpdoc/types.go
+++ b/src/phpdoc/types.go
@@ -1,0 +1,46 @@
+package phpdoc
+
+// TypeExpr is an arbitrary type expression.
+type TypeExpr interface {
+	typeExpr()
+
+	// String returns a textual representation of a type.
+	String() string
+}
+
+// Types that implement TypeExpr.
+type (
+	// NamedType is a type that is identified by its name.
+	NamedType struct{ Name string }
+
+	// NotType is `!expr` type.
+	NotType struct{ Expr TypeExpr }
+
+	// NullableType is `?expr` type.
+	NullableType struct{ Expr TypeExpr }
+
+	// ArrayType is `elem[]` type.
+	ArrayType struct{ Elem TypeExpr }
+
+	// UnionType is `x|y` type.
+	// Union type requires a type to "implement" either X or Y.
+	UnionType struct{ X, Y TypeExpr }
+
+	// InterType is `x&y` type.
+	// Intersection type requires a type to "implement" both X and Y.
+	InterType struct{ X, Y TypeExpr }
+)
+
+func (*NamedType) typeExpr()    {}
+func (*NotType) typeExpr()      {}
+func (*NullableType) typeExpr() {}
+func (*ArrayType) typeExpr()    {}
+func (*UnionType) typeExpr()    {}
+func (*InterType) typeExpr()    {}
+
+func (typ *NamedType) String() string    { return typ.Name }
+func (typ *NotType) String() string      { return "!" + typ.Expr.String() }
+func (typ *NullableType) String() string { return "?" + typ.Expr.String() }
+func (typ *ArrayType) String() string    { return typ.Elem.String() + "[]" }
+func (typ *UnionType) String() string    { return "(" + typ.X.String() + "|" + typ.Y.String() + ")" }
+func (typ *InterType) String() string    { return "(" + typ.X.String() + "&" + typ.Y.String() + ")" }

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -33,10 +33,11 @@ func (e *parseError) Error() string {
 
 // parser parses rules file into a RuleSet.
 type parser struct {
-	filename string
-	sources  []byte
-	res      *Set
-	compiler phpgrep.Compiler
+	filename   string
+	sources    []byte
+	res        *Set
+	compiler   phpgrep.Compiler
+	typeParser phpdoc.TypeParser
 }
 
 // Parse reads PHP code that represents a rule file from r and creates a RuleSet based on it.
@@ -106,11 +107,11 @@ func (p *parser) parseRule(st node.Node) error {
 
 		case "location":
 			if len(part.Params) != 1 {
-				return p.errorf(st, "@type expects exactly 1 params, got %d", len(part.Params))
+				return p.errorf(st, "@location expects exactly 1 params, got %d", len(part.Params))
 			}
 			name := part.Params[0]
 			if !strings.HasPrefix(name, "$") {
-				return p.errorf(st, "@type 2nd param must be a phpgrep variable")
+				return p.errorf(st, "@location 2nd param must be a phpgrep variable")
 			}
 			rule.Location = strings.TrimPrefix(name, "$")
 
@@ -164,10 +165,14 @@ func (p *parser) parseRule(st node.Node) error {
 				filterSet = map[string]Filter{}
 			}
 			filter := filterSet[name]
-			if filter.Types != nil {
+			if filter.Type != nil {
 				return p.errorf(st, "$%s: duplicate type constraint", name)
 			}
-			filter.Types = strings.Split(typ, "|")
+			typeExpr, err := p.typeParser.ParseType(typ)
+			if err != nil {
+				return p.errorf(st, "$%s: parseType(%s): %v", name, typ, err)
+			}
+			filter.Type = typeExpr
 			filterSet[name] = filter
 
 		default:

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"io"
 
+	"github.com/VKCOM/noverify/src/phpdoc"
 	"github.com/VKCOM/noverify/src/phpgrep"
 )
 
@@ -91,5 +92,5 @@ func (r *Rule) String() string {
 
 // Filter describes constraints that should be applied to a given phpgrep variable.
 type Filter struct {
-	Types []string
+	Type phpdoc.TypeExpr
 }

--- a/src/rules/util.go
+++ b/src/rules/util.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/VKCOM/noverify/src/linter/lintapi"
@@ -42,8 +41,10 @@ func formatRule(r *Rule) string {
 
 	for i, filters := range r.Filters {
 		for name, filter := range filters {
-			if len(filter.Types) != 0 {
-				fmt.Fprintf(&buf, " * @type %s $%s\n", strings.Join(filter.Types, "|"), name)
+			if filter.Type != nil {
+				buf.WriteString(" * @type ")
+				buf.WriteString(filter.Type.String())
+				buf.WriteString(" $" + name + "\n")
 			}
 		}
 		if i != len(r.Filters)-1 {


### PR DESCRIPTION
Changes to @type handling:

- Support for proper union types matching.

- Extend phpdoc package to support types
  parsing. Used new types to describe @type
  pattern expression from rule files.

- Support of `!<type>` for rules patterns.
  A `!<x>` type matches any type, except `<x>`.

Type parser supports intersection types as well
as nullable types, although it's not very useful
for NoVerify right now, we can use them later.