### PR TITLE
rules: add @path rule constraint

### DIFF
--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -1293,6 +1293,13 @@ func TestAssignByRef(t *testing.T) {
 	echo a();`)
 }
 
+func addNamedFile(test *linttest.Suite, name, code string) {
+	test.Files = append(test.Files, linttest.TestFile{
+		Name: name,
+		Data: []byte(code),
+	})
+}
+
 func runFilterMatch(test *linttest.Suite, name string) {
 	test.Match(filterReports(name, test.RunLinter()))
 }

--- a/src/linttest/rules_test.go
+++ b/src/linttest/rules_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/VKCOM/noverify/src/rules"
 )
 
+func TestRulePathFilter(t *testing.T) {
+	rfile := `<?php
+/**
+ * @warning don't eval from variable
+ * @path my/site/ads_
+ */
+eval(${"var"});
+`
+	test := linttest.NewSuite(t)
+	code := `<?php
+          $hello = 'echo 123;';
+          eval($hello);
+          eval('echo 456;');
+        `
+	addNamedFile(test, "/home/john/my/site/foo.php", code)
+	addNamedFile(test, "/home/john/my/site/ads_foo.php", code)
+	addNamedFile(test, "/home/jogh/my/site/ads_bar.php", code)
+	test.Expect = []string{
+		`don't eval from variable`,
+		`don't eval from variable`,
+	}
+	runRulesTest(t, test, rfile)
+}
+
 func TestAnyRules(t *testing.T) {
 	rfile := `<?php
 /**

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -151,6 +151,14 @@ func (p *parser) parseRule(st node.Node) error {
 		case "or":
 			rule.Filters = append(rule.Filters, filterSet)
 			filterSet = nil
+		case "path":
+			if len(part.Params) != 1 {
+				return p.errorf(st, "@path expects exactly 1 param, got %d", len(part.Params))
+			}
+			if rule.Path != "" {
+				return p.errorf(st, "duplicate @path constraint")
+			}
+			rule.Path = part.Params[0]
 		case "type":
 			if len(part.Params) != 2 {
 				return p.errorf(st, "@type expects exactly 2 params, got %d", len(part.Params))

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -43,18 +43,6 @@ type ScopedSet struct {
 	RulesByKind [_KindCount][]Rule
 }
 
-// Clone returns a deep copy of a scoped set.
-func (set *ScopedSet) Clone() *ScopedSet {
-	if set == nil {
-		return nil
-	}
-	var clone ScopedSet
-	for i, list := range &set.RulesByKind {
-		clone.RulesByKind[i] = cloneRuleList(list)
-	}
-	return &clone
-}
-
 // Rule is a dynamically-loaded linter rule.
 //
 // A rule is called unnamed if no @name attribute is given.
@@ -77,6 +65,10 @@ type Rule struct {
 	// Location is a phpgrep variable name that should be used as a warning location.
 	// Empty string selects the root node.
 	Location string
+
+	// Path is a filter-like rule switcher.
+	// A rule is only applied to a file that contains a Path as a substring in its name.
+	Path string
 
 	// Filters is a list of OR-connected filter sets.
 	// Every filter set is a mapping of phpgrep variable to a filter.

--- a/src/rules/util.go
+++ b/src/rules/util.go
@@ -6,15 +6,6 @@ import (
 	"github.com/VKCOM/noverify/src/linter/lintapi"
 )
 
-func cloneRuleList(rules []Rule) []Rule {
-	res := make([]Rule, len(rules))
-	for i, rule := range rules {
-		res[i] = rule
-		res[i].Matcher = rule.Matcher.Clone()
-	}
-	return res
-}
-
 func formatRule(r *Rule) string {
 	var buf strings.Builder
 


### PR DESCRIPTION
Allow a rule to be bound only to some files.
Achieved with `@path $p` filter-like option that requires
a file to contain $p, otherwise, a rule will be disabled for it.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>