### PR TITLE
all: Pure() function flag

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -24,7 +24,8 @@ import (
 //     29 - updated type inference for ClassConstFetch
 //     30 - resolve ClassConstFetch to a wrapped type string
 //     31 - fixed plus operator type inference for arrays
-const cacheVersion = 31
+//     32 - replaced Static:bool with Flags:uint8 in meta.FuncInfo
+const cacheVersion = 32
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -99,7 +99,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 2799
+		wantLen := 2804
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -108,7 +108,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "81f1a7850db7d602d4d968cfdd1280b3c9afe9069e2a96bcb021a8f4f3801d550d2a7c9d18f9644078a976534c1c3bd4722ba91637a32527fb289250ec5f6823"
+		wantStrings := "ded0f69ce9bbe287f3bc00199198587cf00efc031f5d38d1ef456dd3af19fde16d52682644d293a752e35697acbabcfc191218fd271eff34a0f76911cd255221"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/linter/side_effects_finder.go
+++ b/src/linter/side_effects_finder.go
@@ -1,0 +1,190 @@
+package linter
+
+import (
+	"github.com/VKCOM/noverify/src/meta"
+	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/assign"
+	"github.com/VKCOM/noverify/src/php/parser/node/name"
+	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
+	"github.com/VKCOM/noverify/src/php/parser/walker"
+	"github.com/VKCOM/noverify/src/solver"
+)
+
+func sideEffectFreeFunc(sc *meta.Scope, st *meta.ClassParseState, customTypes []solver.CustomType, stmts []node.Node) bool {
+	// TODO: functions that call pure functions are also pure.
+	// TODO: allow local var assignments those RHS is pure.
+	f := sideEffectsFinder{sc: sc, st: st, customTypes: customTypes}
+	n := &stmt.StmtList{Stmts: stmts}
+	n.Walk(&f)
+	return !f.sideEffects
+}
+
+func sideEffectFree(sc *meta.Scope, st *meta.ClassParseState, customTypes []solver.CustomType, n node.Node) bool {
+	f := sideEffectsFinder{sc: sc, st: st, customTypes: customTypes}
+	n.Walk(&f)
+	return !f.sideEffects
+}
+
+type sideEffectsFinder struct {
+	sc          *meta.Scope
+	st          *meta.ClassParseState
+	customTypes []solver.CustomType
+
+	sideEffects bool
+}
+
+var pureBuiltins = func() map[string]struct{} {
+	list := []string{
+		`\count`,
+		`\strlen`,
+		`\implode`,
+		`\explode`,
+	}
+
+	set := make(map[string]struct{}, len(list))
+	for _, nm := range list {
+		set[nm] = struct{}{}
+	}
+	return set
+}()
+
+func (f *sideEffectsFinder) functionCallIsPure(n *expr.FunctionCall) bool {
+	// Allow referencing builtin funcs even before indexing is completed.
+	nm, ok := n.Function.(*name.Name)
+	var funcName string
+	if ok && len(nm.Parts) == 1 {
+		// Might be a builtin.
+		funcName = `\` + meta.NameToString(nm)
+		if _, ok := pureBuiltins[funcName]; ok {
+			return true
+		}
+	}
+
+	if !meta.IsIndexingComplete() {
+		return false
+	}
+	if funcName != "" {
+		// We can't properly annotate builtin funcs
+		// as pure during the indexing, since we don't have
+		// their PHP sources.
+		_, ok := meta.GetInternalFunctionInfo(funcName)
+		if ok {
+			return false
+		}
+	}
+
+	call := resolveFunctionCall(f.sc, f.st, f.customTypes, n)
+	if !call.defined || !call.canAnalyze || call.fqName == "" {
+		return false
+	}
+	return call.info.IsPure() && call.info.ExitFlags == 0
+}
+
+func (f *sideEffectsFinder) staticCallIsPure(n *expr.StaticCall) bool {
+	if !meta.IsIndexingComplete() {
+		return false
+	}
+	methodName, ok := n.Call.(*node.Identifier)
+	if !ok {
+		return false
+	}
+	className, ok := solver.GetClassName(f.st, n.Class)
+	if !ok {
+		return false
+	}
+	info, _, ok := solver.FindMethod(className, methodName.Value)
+	return ok && info.IsPure() && info.ExitFlags == 0
+}
+
+func (f *sideEffectsFinder) methodCallIsPure(n *expr.MethodCall) bool {
+	if !meta.IsIndexingComplete() {
+		return false
+	}
+	methodName, ok := n.Method.(*node.Identifier)
+	if !ok {
+		return false
+	}
+	typ := solver.ExprTypeCustom(f.sc, f.st, n.Variable, f.customTypes)
+	if typ.Len() != 1 || typ.Is("mixed") {
+		return false
+	}
+	return typ.Find(func(typ string) bool {
+		info, impl, ok := solver.FindMethod(typ, methodName.Value)
+		if meta.IsInternalClass(impl) {
+			return false
+		}
+		return ok && info.IsPure() && info.ExitFlags == 0
+	})
+}
+
+func (f *sideEffectsFinder) EnterNode(w walker.Walkable) bool {
+	if f.sideEffects {
+		return false
+	}
+
+	// We can get false positives for overloaded operations.
+	// For example, array index can be an offsetGet() call,
+	// which might not be pure.
+
+	switch n := w.(type) {
+	case *expr.FunctionCall:
+		// fmt.Printf("node=%T %s\n", w, FmtNode(w.(node.Node)))
+		if f.functionCallIsPure(n) {
+			return true
+		}
+		f.sideEffects = true
+		return false
+
+	case *expr.MethodCall:
+		if f.methodCallIsPure(n) {
+			return true
+		}
+		f.sideEffects = true
+		return false
+
+	case *expr.StaticCall:
+		if f.staticCallIsPure(n) {
+			return true
+		}
+		f.sideEffects = true
+		return false
+
+	case *expr.Print,
+		*stmt.Echo,
+		*stmt.Unset,
+		*stmt.Throw,
+		*expr.Exit,
+		*assign.Assign,
+		*assign.Reference,
+		*assign.BitwiseAnd,
+		*assign.BitwiseOr,
+		*assign.BitwiseXor,
+		*assign.Concat,
+		*assign.Div,
+		*assign.Minus,
+		*assign.Mod,
+		*assign.Mul,
+		*assign.Plus,
+		*assign.Pow,
+		*assign.ShiftLeft,
+		*assign.ShiftRight,
+		*expr.Yield,
+		*expr.YieldFrom,
+		*expr.Eval,
+		*expr.PreInc,
+		*expr.PostInc,
+		*expr.PreDec,
+		*expr.PostDec,
+		*expr.Require,
+		*expr.RequireOnce,
+		*expr.Include,
+		*expr.IncludeOnce:
+		f.sideEffects = true
+		return false
+	}
+
+	return true
+}
+
+func (f *sideEffectsFinder) LeaveNode(w walker.Walkable) {}

--- a/src/linttest/discard_expr_test.go
+++ b/src/linttest/discard_expr_test.go
@@ -1,0 +1,204 @@
+package linttest_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestDiscardExprInternalClassCall(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{
+		`stubs/phpstorm-stubs/dom/dom_c.php`,
+	}
+	test.AddFile(`<?php
+class MyDoc extends DOMDocument {
+  /**/
+  public function loadContent($content) {
+    $this->loadHTML('<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">' . $content);
+  }
+}
+
+$content = '';
+$dom = new DOMDocument();
+$dom->loadHTML('<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">' . $content);
+`)
+	runFilterMatch(test, "discardExpr")
+}
+
+func TestDiscardExprVariableCall(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+function local1($xs) {
+  // It does discard the result, but we're not tracking
+  // variable function calls yet.
+  $process = function($x) { return $x; };
+  foreach ($xs as $x) {
+    $process($x);
+  }
+}
+
+function local2($xs) {
+  $process = function($x) { exit(0); };
+  foreach ($xs as $x) {
+    echo 123;
+    $process($x);
+  }
+}
+
+function local3($xs) {
+  $process = function($x) { echo $x; };
+  $process($xs);
+}
+
+function local4($xs) {
+  $process = function($x) { return $x; };
+  $process($xs);
+}
+`)
+}
+
+func TestDiscardExprAbstractCall(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+abstract class TheAbstractClass {
+  /** @return bool */
+  abstract public function doIt();
+}
+
+class TheClass extends TheAbstractClass {
+  /** @return bool */
+  public function doIt() { return (bool)1; }
+}
+
+function useAbstract(TheAbstractClass $ac) {
+  $ac->doIt();
+}
+
+$c = new TheClass();
+
+useAbstract($c);
+`)
+}
+
+func TestDiscardExprInterfaceCall(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+interface TheInterface {
+  /** @return bool */
+  public function load($x);
+}
+
+class TheClass implements TheInterface {
+  /** @return bool */
+  public function load($x) { return (bool)0; }
+}
+
+function useInterface(TheInterface $i) {
+  $i->load(10);
+}
+
+$c = new TheClass();
+
+useInterface($c);
+`)
+}
+
+func TestDiscardExprCall(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+define('null', 0);
+
+function count($xs) { return 0; }
+
+class C {
+  public function pure1() {
+    return 10;
+  }
+
+  public function pure2($xs) {
+    return count($xs) + 1;
+  }
+
+  public static function create() {
+    return new static();
+  }
+
+  public function notPure1() {
+    throw new Exception("123");
+  }
+  public function notPure2() {
+    exit(0);
+  }
+  public function notPure3() {
+    $this->notPure2();
+  }
+}
+
+function pure_fn1($x, $y) {
+  if ($x && $y) {
+    return null;
+  }
+  return [$x, $y];
+}
+
+$fn = function() { return 10; };
+$fn();
+
+$c = new C();
+$c->notPure1();
+$c->notPure2();
+$c->notPure3();
+$c->pure1(); // warn 1
+$c->pure2(); // warn 2
+C::create(); // warn 3
+pure_fn1(1, 2); // warn 4
+`)
+	test.Expect = []string{
+		`expression evaluated but not used`,
+		`expression evaluated but not used`,
+		`expression evaluated but not used`,
+		`expression evaluated but not used`,
+	}
+	runFilterMatch(test, "discardExpr")
+}
+
+func TestDiscardExpr(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+class C {}
+
+function count($xs) { return 0; }
+
+$xs = [];
+
+count($xs); // Unused count()
+
+function f() {
+  1; // Unused literal
+}
+
+[1, 2]; // Unused array literal
+new C(); // Unused new expression
+
+1 + 4; // Unused binary expr
+count($xs) * 2; // Unused binary expr
+
+$xs /*::array<int>*/;
+
+class Foo {
+  private static $x;
+
+  private function f() {
+    self::$x /*::int*/;
+    return self::$x;
+  }
+}
+`)
+	test.Expect = []string{
+		`expression evaluated but not used`,
+		`expression evaluated but not used`,
+		`expression evaluated but not used`,
+		`expression evaluated but not used`,
+		`expression evaluated but not used`,
+		`expression evaluated but not used`,
+	}
+	test.RunAndMatch()
+}

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -458,6 +458,8 @@ func TestExprTypeSimple(t *testing.T) {
 		{`$int`, "int"},
 		{`$float`, "float"},
 		{`$string`, "string"},
+
+		{`define('foo', 0 == 0)`, `void`},
 	}
 
 	global := `<?php

--- a/src/linttest/rules_test.go
+++ b/src/linttest/rules_test.go
@@ -169,14 +169,14 @@ $f--; // Good
 $s--; // Bad
 $a--; // Bad
 
-implode("", []); // GOOD
-implode($s, $a); // GOOD
-implode($s, []); // GOOD
-implode("", $a); // GOOD
-implode($a, $s); // BAD:x array, string
-implode($a, $a); // BAD: array, array
-implode($s, $s); // BAD: string, string
-implode($s, $i); // BAD: string, int
+$_ = implode("", []); // GOOD
+$_ = implode($s, $a); // GOOD
+$_ = implode($s, []); // GOOD
+$_ = implode("", $a); // GOOD
+$_ = implode($a, $s); // BAD:x array, string
+$_ = implode($a, $a); // BAD: array, array
+$_ = implode($s, $s); // BAD: string, string
+$_ = implode($s, $i); // BAD: string, int
 `)
 
 	test.Expect = []string{

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -276,16 +276,26 @@ type PhpDocInfo struct {
 	DeprecationNote string
 }
 
+type FuncFlags uint8
+
+const (
+	FuncStatic FuncFlags = 1 << iota
+	FuncPure
+)
+
 type FuncInfo struct {
 	Pos          ElementPosition
 	Params       []FuncParam
 	MinParamsCnt int
 	Typ          TypesMap
 	AccessLevel  AccessLevel
-	Static       bool
+	Flags        FuncFlags
 	ExitFlags    int // if function has exit/die/throw, then ExitFlags will be <> 0
 	Doc          PhpDocInfo
 }
+
+func (info *FuncInfo) IsStatic() bool { return info.Flags&FuncStatic != 0 }
+func (info *FuncInfo) IsPure() bool   { return info.Flags&FuncPure != 0 }
 
 type OverrideType int
 
@@ -371,6 +381,11 @@ type ElementPosition struct {
 	EndLine   int32
 	Character int32
 	Length    int32 // body length
+}
+
+func IsInternalClass(className string) bool {
+	_, ok := internalClasses[className]
+	return ok
 }
 
 func GetInternalFunctionInfo(fn string) (info FuncInfo, ok bool) {

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -98,11 +98,6 @@ func (m TypesMap) IsString() bool {
 	return m.Is("string")
 }
 
-// IsVoid checks if map only contains void type
-func (m TypesMap) IsVoid() bool {
-	return m.Is("void")
-}
-
 // IsArray checks if map contains only array of any type
 func (m TypesMap) IsArray() bool {
 	if len(m.m) != 1 {


### PR DESCRIPTION
- Add FuncPure flag for functions that are pure-like.
  The "pure" definition will be adjusted later,
  we need to mark functions that call pure functions
  with pure flag as well, but for simplicity,
  we don't do deep analysis for now.

- Use FuncPure flag in discardExpr check.
  If function/method is pure, its result should
  not be ignored (discarded).

- Made several minor changes along the way,
  like moved side effects finder to a separate file
  and made function call resolving method a
  freestanding function to re-use it in
  side effects finder.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>