### PR TITLE
Parse array<K,V>, list<V>, etc as V[]. Currently the key type is ignored

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -535,7 +535,7 @@ func (b *BlockWalker) parseComment(c freefloating.String) {
 			continue
 		}
 
-		m := meta.NewTypesMap(b.r.maybeAddNamespace(typ))
+		m := meta.NewTypesMap(b.r.normalizeType(typ))
 		b.ctx.sc.AddVarFromPHPDoc(strings.TrimPrefix(varName, "$"), m, "@var")
 	}
 }

--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -25,7 +25,8 @@ import (
 //     30 - resolve ClassConstFetch to a wrapped type string
 //     31 - fixed plus operator type inference for arrays
 //     32 - replaced Static:bool with Flags:uint8 in meta.FuncInfo
-const cacheVersion = 32
+//     33 - support parsing of array<k,v> and list<type>
+const cacheVersion = 33
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -63,6 +63,10 @@ func TestExprTypeFixes(t *testing.T) {
 		{`dash()`, `mixed`},
 		{`array1()`, `int[]`},
 		{`array2()`, `int[][]`},
+		{`array_int()`, `int[]`},
+		{`array_int_string()`, `string[]`}, // key type is currently ignored
+		{`array_int_stdclass()`, `\stdclass[]`}, // key type is currently ignored
+		{`array_return_string()`, `string`},
 	}
 
 	global := `<?php
@@ -92,6 +96,18 @@ function array1() {}
 
 /** @return [][]int */
 function array2() {}
+
+/** @return array<int> */
+function array_int() {}
+
+/** @return array<int, string> */
+function array_int_string() {}
+
+/** @return array<int, stdclass> */
+function array_int_stdclass() {}
+
+/** @param array<int,string> $a */
+function array_return_string($a) { return $a[0]; }
 `
 
 	runExprTypeTest(t, &exprTypeTestContext{global: global}, tests)

--- a/src/meta/typestring.go
+++ b/src/meta/typestring.go
@@ -224,6 +224,11 @@ func UnwrapArrayOf(s string) (typ string) {
 	return unwrap1(s)
 }
 
+func WrapArray2(ktyp, vtyp string) string {
+	// TODO: actually support types of keys
+	return WrapArrayOf(vtyp)
+}
+
 func WrapElemOf(typ string) string {
 	// ElemOf(ArrayOf(typ)) == typ
 	if len(typ) >= 1+stringLenBytes && typ[0] == WArrayOf {

--- a/src/phpdoc/parser.go
+++ b/src/phpdoc/parser.go
@@ -63,6 +63,8 @@ func Parse(doc string) (res []CommentPart) {
 			text = strings.TrimSpace(ln[nameEndPos:])
 		}
 
+		ln = shrinkAngleBracketsTypes(ln)
+
 		fields := strings.Fields(ln)
 		if len(fields) == 0 {
 			continue
@@ -77,4 +79,31 @@ func Parse(doc string) (res []CommentPart) {
 	}
 
 	return res
+}
+
+// shrinkAngleBracketsTypes removes spaces in types like "array<int, string>" to simplify parsing.
+func shrinkAngleBracketsTypes(t string) string {
+	depth := 0
+	res := make([]byte, 0, len(t))
+
+	for _, b := range []byte(t) {
+		switch b {
+		case '<':
+			depth++
+			res = append(res, b)
+		case '>':
+			if depth > 0 {
+				depth--
+			}
+			res = append(res, b)
+		case ' ', '\t':
+			if depth == 0 {
+				res = append(res, b)
+			}
+		default:
+			res = append(res, b)
+		}
+	}
+
+	return string(res)
 }

--- a/src/phpdoc/parser_test.go
+++ b/src/phpdoc/parser_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParseSimple(t *testing.T) {
-	expected := []CommentPart{
+	want := []CommentPart{
 		{
 			Line:       4,
 			Name:       "param",
@@ -15,20 +15,84 @@ func TestParseSimple(t *testing.T) {
 		},
 		{
 			Line:       5,
+			Name:       "param",
+			Params:     []string{"array<int,string>", "$arr", "Array", "of", "int", "to", "string"},
+			ParamsText: "array<int, string> $arr  Array of int to string",
+		},
+		{
+			Line:       6,
+			Name:       "param",
+			Params:     []string{"array<int,array<string,stdclass>>", "$arr_nested", "Array", "of", "nested", "arrays"},
+			ParamsText: "array<int, array<string, stdclass> > $arr_nested  Array of nested arrays",
+		},
+		{
+			Line:       7,
+			Name:       "param",
+			Params:     []string{"$arr_nested", "array<int,array<string,stdclass>>", "Array", "of", "nested", "arrays"},
+			ParamsText: "$arr_nested array<int, array<string, stdclass> >  Array of nested arrays",
+		},
+		{
+			Line:       8,
+			Name:       "var",
+			Params:     []string{"int"},
+			ParamsText: "int",
+		},
+		{
+			Line:       9,
+			Name:       "var",
+			Params:     []string{"array<int>"},
+			ParamsText: "array<int>",
+		},
+		{
+			Line:       10,
+			Name:       "var",
+			Params:     []string{"array<int,string>"},
+			ParamsText: "array<int,string>",
+		},
+		{
+			Line:       11,
+			Name:       "var",
+			Params:     []string{"array<int,string>"},
+			ParamsText: "array< int, string >",
+		},
+		{
+			Line:   12,
+			Name:   "var",
+			Params: []string{"array<int,array<string,stdclass>>"},
+			ParamsText: "array<int, array<string, stdclass>	>",
+		},
+		{
+			Line:       13,
 			Name:       "return",
 			Params:     []string{"int", "some", "result"},
 			ParamsText: "int   some    result",
 		},
 	}
 
-	actual := Parse(`/**
+	got := Parse(`/**
 	 * Some description
 	 *
 	 * @param   $param int  Here goes the description
+	 * @param  array<int, string> $arr  Array of int to string
+	 * @param  array<int, array<string, stdclass> > $arr_nested  Array of nested arrays
+	 * @param  $arr_nested array<int, array<string, stdclass> >  Array of nested arrays
+	 * @var int
+	 * @var array<int>
+	 * @var array<int,string>
+	 * @var array< int, string >
+	 * @var array<int, array<string, stdclass>	>
 	 * @return int   some    result
 	*/`)
 
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("Actual parsed structure is different from what we expected: %+v", actual)
+	if len(got) != len(want) {
+		t.Fatalf("len(got) != len(want): %d != %d", len(got), len(want))
+	}
+
+	for i, g := range got {
+		w := want[i]
+
+		if !reflect.DeepEqual(g, w) {
+			t.Errorf("%d: got %#v, want %#v", i, g, w)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #290