### PR TITLE
linter: improve method_exists handling

### DIFF
--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -880,6 +880,77 @@ func TestIssue183(t *testing.T) {
 	test.RunAndMatch()
 }
 
+func TestIssue362_1(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+function method_exists($object, $method_name) { return 1 == 1; }
+
+class Foo {
+  public $value;
+}
+
+$x = new Foo();
+if (method_exists($x, 'm1')) {
+  $x->m1();
+  $x->m1(1, 2);
+}
+
+if (method_exists(new Foo(), 'm2')) {
+  if (method_exists(new Foo(), 'm3')) {
+    (new Foo())->m2((new Foo())->m3());
+  }
+  (new Foo())->m2();
+}
+
+$y = new Foo();
+if (method_exists($x, 'x1')) {
+  $x->x1();
+} elseif (method_exists($y, 'y1')) {
+  $foo = $y->y1();
+  if ($foo instanceof Foo) {
+    echo $foo->value;
+  }
+}
+`)
+}
+
+func TestIssue362_2(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function method_exists($object, $method_name) { return 1 == 1; }
+
+class Foo {}
+
+$x = new Foo();
+if (method_exists($x, 'm1')) {
+}
+$x->m1(); // Bad: called outside of if
+
+if (method_exists(new Foo(), 'm2')) {
+  if (method_exists(new Foo(), 'm3')) {
+    $x->m2(); // Bad: called a method on a different object expression
+  }
+}
+(new Foo())->m3(); // Bad: called outside of if
+
+$y = new Foo();
+if (method_exists($x, 'x1')) {
+  $x->y1();
+} elseif (method_exists($y, 'y1')) {
+  $v = $y->x1();
+  $v->foo();
+}
+`)
+	test.Expect = []string{
+		`Call to undefined method {\Foo}->m1()`,
+		`Call to undefined method {\Foo}->m2()`,
+		`Call to undefined method {\Foo}->m3()`,
+		`Call to undefined method {\Foo}->y1()`,
+		`Call to undefined method {\Foo}->x1()`,
+		`Call to undefined method {mixed}->foo()`,
+	}
+	test.RunAndMatch()
+}
+
 func TestIssue252(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 class Foo {

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -179,7 +179,7 @@ func exprTypeLocalCustom(sc *meta.Scope, cs *meta.ClassParseState, n node.Node, 
 	}
 
 	for _, c := range custom {
-		if nodeAwareDeepEqual(c.Node, n) {
+		if NodeAwareDeepEqual(c.Node, n) {
 			return c.Typ
 		}
 	}

--- a/src/solver/node_equal.go
+++ b/src/solver/node_equal.go
@@ -8,9 +8,9 @@ import (
 	"github.com/VKCOM/noverify/src/php/parser/position"
 )
 
-// Like reflect.DeepEqual but knows how to compare node.Node by ignoring
+// NodeAwareDeepEqual is a reflect.DeepEqual but knows how to compare node.Node by ignoring
 // freefloating text and positions
-func nodeAwareDeepEqual(a, b interface{}) bool {
+func NodeAwareDeepEqual(a, b interface{}) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
@@ -57,7 +57,7 @@ func nodeDeepEqual(a, b node.Node) bool {
 			continue
 		}
 
-		if !nodeAwareDeepEqual(f1.Interface(), f2.Interface()) {
+		if !NodeAwareDeepEqual(f1.Interface(), f2.Interface()) {
 			return false
 		}
 	}
@@ -72,7 +72,7 @@ func nodeSliceDeepEqual(a, b []node.Node) bool {
 	}
 
 	for i, n := range a {
-		if !nodeAwareDeepEqual(n, b[i]) {
+		if !NodeAwareDeepEqual(n, b[i]) {
 			return false
 		}
 	}


### PR DESCRIPTION
We collect a slice of `<object, methodName>` pairs
inside a block context.

New pair entries are added via `method_exists(object, methodName)`
upon the if statement entry. These entries are removed
upon that if statement exit.

This new addition does not affect the type inference.
We only permit calling method_exists-defined methods,
but their types will be `(...mixed)->mixed`.

Fixes #362

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>

Should be merged after #363 is resolved.