### PR TITLE
linter: improve if-related implicit vars handling

### DIFF
--- a/src/linter/assign_walker.go
+++ b/src/linter/assign_walker.go
@@ -1,0 +1,28 @@
+package linter
+
+import (
+	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/assign"
+	"github.com/VKCOM/noverify/src/php/parser/walker"
+	"github.com/VKCOM/noverify/src/solver"
+)
+
+// assignWalker handles assignments by pushing all defined variables
+// to the associated block scope.
+type assignWalker struct {
+	b *BlockWalker
+}
+
+func (a *assignWalker) EnterNode(w walker.Walkable) (res bool) {
+	b := a.b
+	switch n := w.(type) {
+	case *assign.Assign:
+		switch v := n.Variable.(type) {
+		case *node.Var, *node.SimpleVar:
+			b.ctx.sc.ReplaceVar(v, solver.ExprTypeLocal(b.ctx.sc, b.r.st, n.Expression), "assign", true)
+		}
+	}
+	return true
+}
+
+func (a *assignWalker) LeaveNode(w walker.Walkable) {}

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -10,6 +10,69 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestIfCondAssign(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+function f1($v) {
+  if ($x = $v) {}
+  echo $x;
+}
+function f2($v) {
+  if ($x = $v) {
+    exit(0);
+  }
+  echo $x;
+}
+`)
+}
+
+func TestElseIf1CondAssign(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function f1($v) {
+  if ($v) {
+  } elseif ($x = 10) {}
+  echo $x;
+}
+function f2($v) {
+  if ($v) {
+  } elseif ($x = 10) {
+    exit(0);
+  }
+  echo $x;
+}
+`)
+	// It could be more precise to report 2 "might have not been defined",
+	// but at least we report both usages. Can be improved in future.
+	test.Expect = []string{
+		`Undefined variable: x`,
+		`Variable might have not been defined: x`,
+	}
+	test.RunAndMatch()
+}
+
+func TestElseIf2CondAssign(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function f1($v) {
+  if ($v) {
+  } else if ($x = 10) {}
+  echo $x;
+}
+function f2($v) {
+  if ($v) {
+  } else if ($x = 10) {
+    exit(0);
+  }
+  echo $x;
+}
+`)
+	test.Expect = []string{
+		`Variable might have not been defined: x`,
+		`Variable might have not been defined: x`,
+	}
+	test.RunAndMatch()
+}
+
 func TestForeachEmpty(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -562,9 +562,9 @@ function fn4($f4) {
 }`)
 	test.Expect = []string{
 		`Call to undefined method {\File}->name()`,
-		`Call to undefined method {\File|\Video}->filename()`,
+		`Call to undefined method {\Video}->filename()`,
 		`Call to undefined method {\File}->name()`,
-		`Call to undefined method {\File|\Video}->filename()`,
+		`Call to undefined method {\Video}->filename()`,
 	}
 	test.RunAndMatch()
 }
@@ -654,7 +654,6 @@ func TestInstanceOf(t *testing.T) {
 	}
 	runFilterMatch(test, "undefined")
 }
-
 
 func TestNullableTypes(t *testing.T) {
 	test := linttest.NewSuite(t)


### PR DESCRIPTION
This change attempts to improve handleIf behavior.

We introduce implicit kind of vars to express automatically
defined vars that can be handled in a special way.

andWalker.varsToDelete are removed because we're running
all branches in a separate block contexts. No extra
cleanup is required.

Changed code requires to evaluate if statement condition
separately, so we can get variables defined inside it
into the parent block context.
assignWalker type does that.

Fixes #369
Fixes #363
Fixes #370

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>