### PR TITLE
linter: fix normalizeType for nullable types

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1844,6 +1844,7 @@ func (b *BlockWalker) handleAssignReference(a *assign.Reference) bool {
 		b.addVar(v, solver.ExprTypeLocal(b.ctx.sc, b.r.st, a.Expression), "assign", true)
 		b.addNonLocalVar(v)
 	case *expr.List:
+		// TODO: figure out whether this case is reachable.
 		for _, item := range v.Items {
 			b.handleVariableNode(item.Val, meta.NewTypesMap("unknown_from_list"), "assign")
 		}

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -873,6 +873,10 @@ func (d *RootWalker) normalizeType(typStr string) string {
 
 		switch className {
 		case "bool", "boolean", "true", "false", "double", "float", "string", "int", "array", "resource", "mixed", "null", "callable", "void", "object":
+			// Can't assign className here because it also erases [] for arrays.
+			if classNames[idx][0] == '?' {
+				classNames[idx] = classNames[idx][1:]
+			}
 			continue
 		case "$this":
 			// Handle `$this` as `static` alias in phpdoc context.

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -1432,6 +1432,15 @@ func TestAssignByRef(t *testing.T) {
 	echo a();`)
 }
 
+func TestUndefinedConst(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+echo UNDEFINED_CONST;
+`)
+	test.Expect = []string{`Undefined constant UNDEFINED_CONST`}
+	test.RunAndMatch()
+}
+
 func addNamedFile(test *linttest.Suite, name, code string) {
 	test.Files = append(test.Files, linttest.TestFile{
 		Name: name,

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -318,6 +318,65 @@ $chain = new Chain();`
 	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
 }
 
+func TestExprTypeNullable(t *testing.T) {
+	tests := []exprTypeTest{
+		{`$int`, `int|null`},
+		{`$foo`, `int|string|null`},
+		{`$a->b`, `\B|null`},
+		{`nullable_int(1)`, `int|null`},
+		{`nullable_string(0)`, `string|null`},
+		{`nullable_array(0)`, `int[]|null`},
+	}
+
+	global := `<?php
+class A {
+	/** @var ?B */
+	public $b;
+}
+class B {
+	public $c;
+}
+
+/**
+ * @return ?int
+ */
+function nullable_int($cond) {
+  if ($cond) {
+    return 4;
+  }
+  return null;
+}
+
+
+/**
+ * @return ?int[]
+ */
+function nullable_array($cond) {
+  if ($cond) {
+    return [1];
+  }
+  return null;
+}
+
+function nullable_string($cond) : ?string {
+  if ($cond) {
+    return '123';
+  }
+  return null;
+}
+`
+	local := `
+/** @var ?int $int */
+$int = null;
+
+/** @var ?int|?string $foo */
+$foo = null;
+
+$a = new A();
+`
+	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
+}
+
 func TestExprTypeLateStaticBinding(t *testing.T) {
 	tests := []exprTypeTest{
 		{`getBase()`, `\Base`},

--- a/src/linttest/oop_test.go
+++ b/src/linttest/oop_test.go
@@ -655,7 +655,6 @@ func TestInstanceOf(t *testing.T) {
 	runFilterMatch(test, "undefined")
 }
 
-
 func TestNullableTypes(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
Before this fix, ?int was resolved as `?int|null` because
for builtin types we did no classNames[idx] replacement.

Found this while adding more tests to extend test coverage.
It turned out that nullable-related if statement inside
normalizeType() method was not covered by tests.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>