### PR TITLE
linter: add regexpVet checker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,11 +40,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:19117fa2f48301785d438b96eba9079ab6a9f19ccd9d633d9c97df9a0d32db74"
+  digest = "1:ffcc3e815eeb6beec4afaff6c66e5c13848671ec4da220353457aa24803e5517"
   name = "github.com/quasilyte/regex"
   packages = ["syntax"]
   pruneopts = "UT"
-  revision = "fc66bae20aa1902d57959d1a02bc6d9c5cda12dd"
+  revision = "497963207d1f63c29da8a8b4fb25e80c236e00be"
 
 [[projects]]
   digest = "1:a5cc901b8e54c4b73a62f97dc7c8f6c46e347c148a7a38e09b2e942c2587ba03"

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -842,14 +842,26 @@ func (b *BlockWalker) handleFunctionCall(e *expr.FunctionCall) bool {
 
 	switch call.fqName {
 	case `\preg_match`, `\preg_match_all`, `\preg_replace`, `\preg_split`:
-		s, ok := e.ArgumentList.Arguments[0].(*node.Argument).Expr.(*scalar.String)
+		argNode := e.ArgumentList.Arguments[0]
+		s, ok := argNode.(*node.Argument).Expr.(*scalar.String)
 		if !ok {
 			break
 		}
-		simplified := b.r.reSimplifier.simplifyRegexp(s)
+		pat, ok := newRegexpPattern(s)
+		if !ok {
+			break
+		}
+		simplified := b.r.reSimplifier.simplifyRegexp(pat)
 		if simplified != "" {
-			b.r.Report(e.ArgumentList.Arguments[0], LevelDoNotReject, "regexpSimplify", "May re-write %s as '%s'",
+			b.r.Report(argNode, LevelDoNotReject, "regexpSimplify", "May re-write %s as '%s'",
 				s.Value, simplified)
+		}
+		issues, err := b.r.reVet.CheckRegexp(pat)
+		if err != nil {
+			b.r.Report(argNode, LevelError, "regexpSyntax", "parse error: %v", err)
+		}
+		for _, issue := range issues {
+			b.r.Report(argNode, LevelWarning, "regexpVet", "%s", issue)
 		}
 	}
 

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -156,6 +156,11 @@ func analyzeFile(filename string, contents []byte, parser *php7.Parser, lineRang
 		rootRset:  cloneRulesForFile(filename, Rules.Root),
 		localRset: cloneRulesForFile(filename, Rules.Local),
 
+		reVet: &regexpVet{
+			parser: syntax.NewParser(&syntax.ParserOptions{
+				NoLiterals: false,
+			}),
+		},
 		reSimplifier: &regexpSimplifier{
 			parser: syntax.NewParser(&syntax.ParserOptions{
 				NoLiterals: true,

--- a/src/linter/regexp_utils.go
+++ b/src/linter/regexp_utils.go
@@ -1,0 +1,50 @@
+package linter
+
+import (
+	"strings"
+
+	"github.com/VKCOM/noverify/src/php/parser/node/scalar"
+)
+
+type regexpPattern struct {
+	value  string
+	quotes rune
+}
+
+func newRegexpPattern(lit *scalar.String) (regexpPattern, bool) {
+	// We need to interpret the string literal so we see it in a same
+	// was as regexp engine (PCRE) would.
+	//
+	// The '/\\\\/' pattern matches a single '\' literally:
+	// - First we interpret 2 \\ pairs as two '\' characters.
+	// - Then regexp engine sees two '\' and interprets them as a '\' escape.
+	//
+	// The '/\d/' works differently, since single quotes don't interptet
+	// that escape sequence, so what you see is what you get.
+	// The unfortunate consequence is that '/\\d/' is also correct.
+	//
+	// We probably want to suggest using `\d` instead of `\\d`.
+	// Right now it happens as a side effect of regexp re-write process.
+	// If pattern score is 0, no \d->\\d will be suggested.
+
+	var result regexpPattern
+
+	switch lit.Value[0] {
+	case '\'':
+		// Single quotes only interpret \' and \\ sequences.
+		pat := unquote(lit.Value)
+		pat = strings.ReplaceAll(pat, `\\`, `\`)
+		pat = strings.ReplaceAll(pat, `\'`, `'`)
+		result.value = pat
+		result.quotes = '\''
+	case '"':
+		// TODO: interpret the double-quoted literals?
+		// Note that it would also be harder to reconstruct
+		// the literal syntax for the simplified string.
+		result.quotes = '"'
+		return result, false
+	default:
+		return result, false
+	}
+	return result, true
+}

--- a/src/linter/regexpvet.go
+++ b/src/linter/regexpvet.go
@@ -1,0 +1,324 @@
+package linter
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/quasilyte/regex/syntax"
+)
+
+type regexpVet struct {
+	parser *syntax.Parser
+
+	issues    []string
+	exprFlags []string
+}
+
+func (c *regexpVet) CheckRegexp(pat regexpPattern) ([]string, error) {
+	c.issues = c.issues[:0]
+	c.exprFlags = c.exprFlags[:0]
+
+	re, err := c.parser.ParsePCRE(pat.value)
+	if err != nil {
+		if strings.Contains(err.Error(), "not supported") {
+			// Can't analyze, can't report an error.
+			return nil, nil
+		}
+		return nil, err
+	}
+	c.walk(re.Expr)
+
+	return c.issues, nil
+}
+
+func (c *regexpVet) walk(e syntax.Expr) {
+	switch e.Op {
+	case syntax.OpAlt:
+		c.checkAltAnchor(e)
+		c.checkAltDups(e)
+		for _, a := range e.Args {
+			c.walk(a)
+		}
+
+	case syntax.OpCharClass, syntax.OpNegCharClass:
+		if c.checkCharClassRanges(e) {
+			c.checkCharClassDups(e)
+		}
+
+	case syntax.OpStar, syntax.OpPlus:
+		c.checkNestedQuantifier(e)
+		c.walk(e.Args[0])
+
+	case syntax.OpFlagOnlyGroup:
+		c.checkFlags(e, e.Args[0].Value)
+		c.exprFlags = append(c.exprFlags, e.Args[0].Value)
+	case syntax.OpGroupWithFlags:
+		nflags := len(c.exprFlags)
+		c.checkFlags(e, e.Args[1].Value)
+		c.exprFlags = append(c.exprFlags, e.Args[1].Value)
+		c.walk(e.Args[0])
+		c.exprFlags = c.exprFlags[:nflags]
+	case syntax.OpGroup, syntax.OpCapture, syntax.OpNamedCapture:
+		nflags := len(c.exprFlags)
+		c.walk(e.Args[0])
+		c.exprFlags = c.exprFlags[:nflags]
+
+	default:
+		for _, a := range e.Args {
+			c.walk(a)
+		}
+	}
+}
+
+func (c *regexpVet) checkFlags(e syntax.Expr, flags string) {
+	for _, fset := range c.exprFlags {
+		if i := strings.IndexAny(flags, fset); i != -1 {
+			c.warn("redundant flag %c in %s", flags[i], e.Value)
+		}
+	}
+}
+
+func (c *regexpVet) checkNestedQuantifier(e syntax.Expr) {
+	x := e.Args[0]
+	switch x.Op {
+	case syntax.OpGroup, syntax.OpCapture, syntax.OpGroupWithFlags:
+		if len(e.Args) == 1 {
+			x = x.Args[0]
+		}
+	}
+
+	switch x.Op {
+	case syntax.OpPlus, syntax.OpStar:
+		c.warn("repeated greedy quantifier in %s", e.Value)
+	}
+}
+
+func (c *regexpVet) checkAltDups(alt syntax.Expr) {
+	// Seek duplicated alternation expressions.
+
+	set := make(map[string]struct{}, len(alt.Args))
+	for _, a := range alt.Args {
+		if _, ok := set[a.Value]; ok {
+			c.warn("'%s' is duplicated in %s", a.Value, alt.Value)
+		}
+		set[a.Value] = struct{}{}
+	}
+}
+
+func (c *regexpVet) checkAltAnchor(alt syntax.Expr) {
+	// Seek suspicious anchors.
+
+	// Case 1: an alternation of literals where 1st expr begins with ^ anchor.
+	first := alt.Args[0]
+	if first.Op == syntax.OpConcat && len(first.Args) > 0 && first.Args[0].Op == syntax.OpCaret {
+		matched := true
+		for _, a := range alt.Args[1:] {
+			if a.Op != syntax.OpLiteral && a.Op != syntax.OpChar {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			c.warn("^ applied only to '%s' in %s", first.Value[len(`^`):], alt.Value)
+		}
+	}
+
+	// Case 2: an alternation of literals where last expr ends with $ anchor.
+	last := alt.Args[len(alt.Args)-1]
+	if last.Op == syntax.OpConcat && len(last.Args) > 0 && last.LastArg().Op == syntax.OpDollar {
+		matched := true
+		for _, a := range alt.Args[:len(alt.Args)-1] {
+			if a.Op != syntax.OpLiteral && a.Op != syntax.OpChar {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			c.warn("$ applied only to '%s' in %s", last.Value[:len(last.Value)-len(`$`)], alt.Value)
+		}
+	}
+}
+
+func (c *regexpVet) checkCharClassRanges(cc syntax.Expr) bool {
+	// Seek for suspicious ranges like `!-_`.
+	//
+	// We permit numerical ranges (0-9, hex and octal literals)
+	// and simple ascii letter ranges.
+
+	for _, e := range cc.Args {
+		if e.Op != syntax.OpCharRange {
+			continue
+		}
+		if e.Args[0].Op == syntax.OpEscapeOctal || e.Args[0].Op == syntax.OpEscapeHex {
+			continue
+		}
+		ch := c.charClassBoundRune(e.Args[0])
+		if ch == 0 {
+			return false
+		}
+		isLetter := unicode.IsLetter(ch)
+		okay := isLetter || (ch >= '0' && ch <= '9')
+		if !okay {
+			c.warnSloppyCharRange(e.Value, cc.Value)
+		}
+	}
+
+	return true
+}
+
+func (c *regexpVet) checkCharClassDups(cc syntax.Expr) {
+	// Seek for excessive elements inside a character class.
+	// Report them as intersections.
+
+	if len(cc.Args) == 1 {
+		return // Can't had duplicates.
+	}
+
+	type charRange struct {
+		low    rune
+		high   rune
+		source string
+	}
+	ranges := make([]charRange, 0, 8)
+	addRange := func(source string, low, high rune) {
+		ranges = append(ranges, charRange{source: source, low: low, high: high})
+	}
+	addRange1 := func(source string, ch rune) {
+		addRange(source, ch, ch)
+	}
+
+	// 1. Collect ranges, O(n).
+	for _, e := range cc.Args {
+		switch e.Op {
+		case syntax.OpEscapeOctal:
+			addRange1(e.Value, c.octalToRune(e))
+		case syntax.OpEscapeHex:
+			addRange1(e.Value, c.hexToRune(e))
+		case syntax.OpChar:
+			addRange1(e.Value, c.stringToRune(e.Value))
+		case syntax.OpCharRange:
+			addRange(e.Value, c.charClassBoundRune(e.Args[0]), c.charClassBoundRune(e.Args[1]))
+		case syntax.OpEscapeMeta:
+			addRange1(e.Value, rune(e.Value[1]))
+		case syntax.OpEscapeChar:
+			ch := c.stringToRune(e.Value[len(`\`):])
+			if unicode.IsPunct(ch) {
+				addRange1(e.Value, ch)
+				break
+			}
+			switch e.Value {
+			case `\|`, `\<`, `\>`, `\+`, `\=`: // How to cover all symbols?
+				addRange1(e.Value, c.stringToRune(e.Value[len(`\`):]))
+			case `\t`:
+				addRange1(e.Value, '\t')
+			case `\n`:
+				addRange1(e.Value, '\n')
+			case `\r`:
+				addRange1(e.Value, '\r')
+			case `\v`:
+				addRange1(e.Value, '\v')
+			case `\d`:
+				addRange(e.Value, '0', '9')
+			case `\D`:
+				addRange(e.Value, 0, '0'-1)
+				addRange(e.Value, '9'+1, utf8.MaxRune)
+			case `\s`:
+				addRange(e.Value, '\t', '\n') // 9-10
+				addRange(e.Value, '\f', '\r') // 12-13
+				addRange1(e.Value, ' ')       // 32
+			case `\S`:
+				addRange(e.Value, 0, '\t'-1)
+				addRange(e.Value, '\n'+1, '\f'-1)
+				addRange(e.Value, '\r'+1, ' '-1)
+				addRange(e.Value, ' '+1, utf8.MaxRune)
+			case `\w`:
+				addRange(e.Value, '0', '9') // 48-57
+				addRange(e.Value, 'A', 'Z') // 65-90
+				addRange1(e.Value, '_')     // 95
+				addRange(e.Value, 'a', 'z') // 97-122
+			case `\W`:
+				addRange(e.Value, 0, '0'-1)
+				addRange(e.Value, '9'+1, 'A'-1)
+				addRange(e.Value, 'Z'+1, '_'-1)
+				addRange(e.Value, '_'+1, 'a'-1)
+				addRange(e.Value, 'z'+1, utf8.MaxRune)
+			default:
+				// Give up: unknown escape sequence.
+				return
+			}
+		default:
+			// Give up: unexpected operation inside char class.
+			return
+		}
+	}
+
+	// 2. Sort ranges, O(nlogn).
+	sort.Slice(ranges, func(i, j int) bool {
+		return ranges[i].low < ranges[j].low
+	})
+
+	// 3. Search for duplicates, O(n).
+	for i := 0; i < len(ranges)-1; i++ {
+		x := ranges[i+0]
+		y := ranges[i+1]
+		if x.high >= y.low {
+			c.warnCharClassDup(x.source, y.source, cc.Value)
+			break
+		}
+	}
+}
+
+func (c *regexpVet) charClassBoundRune(e syntax.Expr) rune {
+	switch e.Op {
+	case syntax.OpChar:
+		return c.stringToRune(e.Value)
+	case syntax.OpEscapeHex:
+		return c.hexToRune(e)
+	case syntax.OpEscapeOctal:
+		return c.octalToRune(e)
+	default:
+		return 0
+	}
+}
+
+func (c *regexpVet) octalToRune(e syntax.Expr) rune {
+	v, _ := strconv.ParseInt(e.Value[len(`\`):], 8, 32)
+	return rune(v)
+}
+
+func (c *regexpVet) hexToRune(e syntax.Expr) rune {
+	var s string
+	switch e.Form {
+	case syntax.FormEscapeHexFull:
+		s = e.Value[len(`\x{`) : len(e.Value)-len(`}`)]
+	default:
+		s = e.Value[len(`\x`):]
+	}
+	v, _ := strconv.ParseInt(s, 16, 32)
+	return rune(v)
+}
+
+func (c *regexpVet) stringToRune(s string) rune {
+	ch, _ := utf8.DecodeRuneInString(s)
+	return ch
+}
+
+func (c *regexpVet) warn(format string, args ...interface{}) {
+	c.issues = append(c.issues, fmt.Sprintf(format, args...))
+}
+
+func (c *regexpVet) warnSloppyCharRange(rng, charClass string) {
+	c.warn("suspicious char range '%s' in %s", rng, charClass)
+}
+
+func (c *regexpVet) warnCharClassDup(x, y, charClass string) {
+	if x == y {
+		c.warn("'%s' is duplicated in %s", x, charClass)
+	} else {
+		c.warn("'%s' intersects with '%s' in %s", x, y, charClass)
+	}
+}

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -157,6 +157,18 @@ func init() {
 		},
 
 		{
+			Name:    "regexpVet",
+			Default: true,
+			Comment: `Report suspicious regexp patterns.`,
+		},
+
+		{
+			Name:    "regexpSyntax",
+			Default: true,
+			Comment: `Report regexp syntax errors.`,
+		},
+
+		{
 			Name:    "caseContinue",
 			Default: true,
 			Comment: `Report suspicious 'continue' usages inside switch cases.`,

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -47,6 +47,7 @@ type RootWalker struct {
 	anyRset   *rules.ScopedSet
 
 	reSimplifier *regexpSimplifier
+	reVet        *regexpVet
 
 	// internal state
 	meta fileMeta

--- a/src/linttest/regexpsimplify_test.go
+++ b/src/linttest/regexpsimplify_test.go
@@ -145,7 +145,7 @@ function f($s) {
 	test.RunAndMatch()
 }
 
-func TestRESimplifyNone(t *testing.T) {
+func TestRENegativeTests(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.LoadStubs = []string{`stubs/phpstorm-stubs/pcre/pcre.php`}
 	test.AddFile(`<?php
@@ -156,6 +156,7 @@ function f($s) {
 }
 
 function _1($s) {
+  preg_match('~[а-яё]~', $s);
   preg_match('/\s*\{weight=(\d+)\}\s*/', $s);
   preg_match('/\{inherits=(\d+)\}/', $s);
   preg_match('/[<>]+/', $s);
@@ -207,7 +208,6 @@ function _2($s) {
 }
 
 function _3($s) {
-  preg_match('/(?m)^([\s\t]*)([\*\-\+]|\d\.)\s+/', $s);
   preg_match('/\n={2,}/', $s);
   preg_match('/~~/', $s);
   preg_match('/[aeiou][^aeiou]/', $s);
@@ -295,7 +295,6 @@ function _5($s) {
   preg_match('/@(?i:article){.*/', $s);
   preg_match('/\blimit \?(?:, ?\?| offset \?)?/', $s);
   preg_match('/^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,4}$/', $s);
-  preg_match('~^(www.|https://|http://)*[A-Za-z0-9._%+\-]+\.[com|org|edu|net]{3}$~', $s);
   preg_match('/^4\d{12}(\d{3})?$/', $s);
   preg_match('/^(5[1-5]\d{4}|677189)\d{10}$/', $s);
   preg_match('/^(6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14})$/', $s);
@@ -325,7 +324,6 @@ function _6($s) {
   preg_match('/(-\s+(\d+)(?:\d|$))/', $s);
   preg_match('~ edge/(\d+)\.(\d+)~', $s);
   preg_match('/^.+@.+\..+$/', $s);
-  preg_match('/^[\w\d]{3,30}$/', $s);
   preg_match('/^\$bgm\s+(\[.*\])$/', $s);
   preg_match('/^\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/', $s);
   preg_match('/;[^=;{}]+;/', $s);

--- a/src/linttest/regexpvet_test.go
+++ b/src/linttest/regexpvet_test.go
@@ -1,0 +1,193 @@
+package linttest_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestREVetParse(t *testing.T) {
+	// Don't add too much test cases here as we don't want to
+	// be dependent on the regexp parser library error messages
+	// too much. We prove that we react on parse errors and that's enough.
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{`stubs/phpstorm-stubs/pcre/pcre.php`}
+	test.AddFile(`<?php
+function parseErrors($s) {
+  preg_match('', $s);
+  preg_match('aba', $s);
+  preg_match('<foo([abc)+', $s);
+  preg_match('#foo([abc)+#', $s);
+}
+
+`)
+	test.Expect = []string{
+		`parse error: empty pattern: can't find delimiters`,
+		`parse error: 'a' is not a valid delimiter`,
+		`parse error: can't find '>' ending delimiter`,
+		`parse error: unterminated '['`,
+	}
+	test.RunAndMatch()
+}
+
+func TestREVet(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{`stubs/phpstorm-stubs/pcre/pcre.php`}
+	test.AddFile(`<?php
+function charRange($s) {
+	preg_match('~[$-%]~', $s);
+	preg_match('~[ -!]~', $s);
+	preg_match('~[❤-❥]~', $s);
+}
+
+function altDups($s) {
+	preg_match('~x|x~', $s);
+	preg_match('~([a-z]|[a-z]|[0-9])~', $s);
+	preg_match('~(foo)+|(bar)+|(foo)+~');
+	preg_match_all('/(?:\*[\dAGC]+)+|(?:\/[\dAGC]+)+|(?:\+[\d]+)+|(?:\-[\d]+)+/', $s, $matches);
+}
+
+function charClassDuplicates($s) {
+	preg_match('~x[aba]y~', $s);
+
+	preg_match('~[\141a]~', $s);
+	preg_match('~[a\x61]~', $s);
+	preg_match('~[^a\x{61}]~', $s);
+
+	preg_match('~[a-cb]~', $s);
+	preg_match('~[^a-ba-b]~', $s);
+
+	preg_match('~[\x{61}-\x{63}c]~', $s);
+	preg_match('~[\x61-\x63c]~', $s);
+	preg_match('~[\141-\143c]~', $s);
+
+	preg_match('~[\d5]~', $s);
+	preg_match('~[5-6\d]~', $s);
+	preg_match('~[\w_]~', $s);
+	preg_match('~[\w%a-d]~', $s);
+	preg_match('~[\Dg]~', $s);
+	preg_match('~[\D❤5]~', $s);
+	preg_match('~[\s\t]~', $s);
+	preg_match('~[\n\s]~', $s);
+
+	preg_match('~[1-52-34]~', $s);
+	preg_match('~[42-31-5]~', $s);
+
+	preg_match('~[\w\W❤]~', $s);
+}
+
+function repeatedQuantifier($s) {
+	preg_match('~(a+)+~', $s);
+	preg_match('~(?:[ab]*)+~', $s);
+	preg_match('~((ab)+)*~', $s);
+}
+
+function redundantFlags($s) {
+	preg_match('~(?m)(?m)~', $s);
+	preg_match('~(?ims:(?i:foo))(?im:bar)~', $s);
+	preg_match('~(?i)(?ims:flags1)(?m:flags2)~', $s);
+	preg_match('~((?m)(?m:a|b(?s:foo))(?i)x)~', $s);
+}
+
+function suspiciousAltAnchor($s) {
+	preg_match('~^foo|bar|baz~', $s);
+	preg_match('~(?:^a|bc)c~', $s);
+	preg_match('~foo|bar|baz$~', $s);
+	preg_match('~(?:a|bc$)c~', $s);
+}
+`)
+	test.Expect = []string{
+		`suspicious char range '$-%' in [$-%]`,
+		`suspicious char range ' -!' in [ -!]`,
+		`suspicious char range '❤-❥' in [❤-❥]`,
+
+		`'x' is duplicated in x|x`,
+		`'[a-z]' is duplicated in [a-z]|[a-z]|[0-9]`,
+		`'(foo)+' is duplicated in (foo)+|(bar)+|(foo)+`,
+
+		`'a' is duplicated in [aba]`,
+
+		`'\141' intersects with 'a' in [\141a]`,
+		`'a' intersects with '\x61' in [a\x61]`,
+		`'a' intersects with '\x{61}' in [^a\x{61}]`,
+		`'a-c' intersects with 'b' in [a-cb]`,
+		`'a-b' is duplicated in [^a-ba-b]`,
+		`'\x{61}-\x{63}' intersects with 'c' in [\x{61}-\x{63}c]`,
+		`'\x61-\x63' intersects with 'c' in [\x61-\x63c]`,
+		`'\141-\143' intersects with 'c' in [\141-\143c]`,
+		`'\d' intersects with '5' in [\d5]`,
+		`'\d' intersects with '5-6' in [5-6\d]`,
+		`'\w' intersects with '_' in [\w_]`,
+		`'\w' intersects with 'a-d' in [\w%a-d]`,
+		`'\D' intersects with 'g' in [\Dg]`,
+		`'\D' intersects with '❤' in [\D❤5]`,
+		`'\s' intersects with '\t' in [\s\t]`,
+		`'\s' intersects with '\n' in [\n\s]`,
+		`'1-5' intersects with '2-3' in [1-52-34]`,
+		`'1-5' intersects with '2-3' in [42-31-5]`,
+		`'\W' intersects with '❤' in [\w\W❤]`,
+
+		`repeated greedy quantifier in (a+)+`,
+		`repeated greedy quantifier in (?:[ab]*)+`,
+		`repeated greedy quantifier in ((ab)+)*`,
+
+		`redundant flag m in (?m)`,
+		`redundant flag i in (?i:foo)`,
+		`redundant flag i in (?ims:flags1)`,
+		`redundant flag m in (?m:a|b(?s:foo))`,
+
+		`^ applied only to 'foo' in ^foo|bar|baz`,
+		`^ applied only to 'a' in ^a|bc`,
+		`$ applied only to 'baz' in foo|bar|baz$`,
+		`$ applied only to 'bc' in a|bc$`,
+	}
+	runFilterMatch(test, `regexpVet`)
+}
+
+func TestREVet_2(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{`stubs/phpstorm-stubs/pcre/pcre.php`}
+	test.AddFile(`<?php
+function f($s) {
+  preg_match('/(?m)^([\s\t]*)([\*\-\+]|\d\.)\s+/', $s);
+  preg_match('~^(www.|https://|http://)*[A-Za-z0-9._%+\-]+\.[com|org|edu|net]{3}$~', $s);
+  preg_match('/^[\w\d]{3,30}$/', $s);
+}
+`)
+	test.Expect = []string{
+		`'\s' intersects with '\t' in [\s\t]`,
+		`'e' is duplicated in [com|org|edu|net]`,
+		`'\w' intersects with '\d' in [\w\d]`,
+	}
+	test.RunAndMatch()
+}
+
+func TestREVet_3(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{`stubs/phpstorm-stubs/pcre/pcre.php`}
+	test.AddFile(`<?php
+function f($s) {
+  preg_match('~^each\s+(\$[\w]*)(?:\s*,\s*(\$[\w0-9\-_]*))?\s+in\s+(.+)$~', $s);
+  preg_match('~(?i)(?:for=)([^(;|,| )]+)~', $s);
+  preg_match('~[^\w\d\-_ ]~', $s);
+  preg_match('~^[\w+-\.]+$~', $s);
+  preg_match('~^([\w\.\-_+]+)$~', $s);
+  preg_match('~Usage: docker \\\\[OPTIONS\\\\] COMMAND~', $s);
+  preg_match('~(ok|FAIL)\s+(.+)[\s]+(\d+\.\d+(s| seconds))([\s\t]+coverage:\s+(\d+\.\d+)\% of statements)?~', $s);
+  preg_match('~UPSTREAM: (revert: [a-f0-9]{7,}: )?(([\w\.-]+\/[\w-\.-]+)?: )?(\d+:|<carry>:|<drop>:)~', $s);
+  preg_match('~\A\w{1}:[/\/]~', $s);
+}
+`)
+	test.Expect = []string{
+		`'\w' intersects with '0-9' in [\w0-9\-_]`,
+		`'|' is duplicated in [^(;|,| )]`,
+		`'\w' intersects with '\d' in [^\w\d\-_ ]`,
+		`suspicious char range '+-\.' in [\w+-\.]`,
+		`'\w' intersects with '_' in [\w\.\-_+]`,
+		`'O' is duplicated in [OPTIONS\\]`,
+		`'\s' intersects with '\t' in [\s\t]`,
+		`'-' is duplicated in [\w-\.-]`,
+		`'/' intersects with '\/' in [/\/]`,
+	}
+	runFilterMatch(test, `regexpVet`)
+}

--- a/src/linttest/testdata/ctype/golden.txt
+++ b/src/linttest/testdata/ctype/golden.txt
@@ -1,7 +1,16 @@
 MAYBE   regexpSimplify: May re-write '/[^0-9]/' as '/\D/' at testdata/ctype/ctype.php:84
         return \is_string($text) && '' !== $text && !preg_match('/[^0-9]/', $text);
                                                                 ^^^^^^^^^^
+WARNING regexpVet: suspicious char range '!-~' in [^!-~] at testdata/ctype/ctype.php:100
+        return \is_string($text) && '' !== $text && !preg_match('/[^!-~]/', $text);
+                                                                ^^^^^^^^^^
+WARNING regexpVet: suspicious char range ' -~' in [^ -~] at testdata/ctype/ctype.php:132
+        return \is_string($text) && '' !== $text && !preg_match('/[^ -~]/', $text);
+                                                                ^^^^^^^^^^
 MAYBE   regexpSimplify: May re-write '/[^!-\/\:-@\[-`\{-~]/' as '/[^!-\/:-@\[-`\{-~]/' at testdata/ctype/ctype.php:148
+        return \is_string($text) && '' !== $text && !preg_match('/[^!-\/\:-@\[-`\{-~]/', $text);
+                                                                ^^^^^^^^^^^^^^^^^^^^^^^
+WARNING regexpVet: suspicious char range '!-\/' in [^!-\/\:-@\[-`\{-~] at testdata/ctype/ctype.php:148
         return \is_string($text) && '' !== $text && !preg_match('/[^!-\/\:-@\[-`\{-~]/', $text);
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   regexpSimplify: May re-write '/[^\s]/' as '/\S/' at testdata/ctype/ctype.php:164

--- a/vendor/github.com/quasilyte/regex/syntax/parser.go
+++ b/vendor/github.com/quasilyte/regex/syntax/parser.go
@@ -440,10 +440,12 @@ func (p *Parser) newPCRE(source string) (*RegexpPCRE, error) {
 		}
 	}
 
-	j := strings.LastIndexByte(source, endDelim)
+	const delimLen = 1
+	j := strings.LastIndexByte(source[delimLen:], endDelim)
 	if j == -1 {
 		return nil, fmt.Errorf("can't find '%c' ending delimiter", endDelim)
 	}
+	j += delimLen
 
 	pcre := &RegexpPCRE{
 		Pattern:   source[1:j],

--- a/vendor/github.com/quasilyte/regex/syntax/utils.go
+++ b/vendor/github.com/quasilyte/regex/syntax/utils.go
@@ -2,7 +2,7 @@ package syntax
 
 func isSpace(ch byte) bool {
 	switch ch {
-	case '\r', '\n', '\t', '\f', '\v':
+	case '\r', '\n', '\t', '\f', '\v', ' ':
 		return true
 	default:
 		return false


### PR DESCRIPTION
Unlike regexpSimplify, all warnings severity level
is Warning (instead of Maybe).

Uses RE parser mode that merges chars into literals.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>