### PR TITLE
solver: fix trait members accessLevel issues

### DIFF
--- a/src/langsrv/defs.go
+++ b/src/langsrv/defs.go
@@ -102,13 +102,13 @@ func (d *definitionWalker) EnterNode(w walker.Walkable) bool {
 			return true
 		}
 
-		fun, _, ok := solver.FindMethod(className, id.Value)
+		m, ok := solver.FindMethod(className, id.Value)
 		if ok {
 			d.result = append(d.result, vscode.Location{
-				URI: "file://" + fun.Pos.Filename,
+				URI: "file://" + m.Info.Pos.Filename,
 				Range: vscode.Range{
-					Start: vscode.Position{Line: int(fun.Pos.Line) - 1},
-					End:   vscode.Position{Line: int(fun.Pos.Line) - 1},
+					Start: vscode.Position{Line: int(m.Info.Pos.Line) - 1},
+					End:   vscode.Position{Line: int(m.Info.Pos.Line) - 1},
 				},
 			})
 		}
@@ -138,17 +138,17 @@ func (d *definitionWalker) EnterNode(w walker.Walkable) bool {
 		types := safeExprType(foundScope, &d.st, n.Variable)
 
 		types.Iterate(func(t string) {
-			fun, _, ok := solver.FindMethod(t, id.Value)
+			m, ok := solver.FindMethod(t, id.Value)
 			if !ok {
 				lintdebug.Send("Could not find method for %s::%s", t, id.Value)
 				return
 			}
 
 			d.result = append(d.result, vscode.Location{
-				URI: "file://" + fun.Pos.Filename,
+				URI: "file://" + m.Info.Pos.Filename,
 				Range: vscode.Range{
-					Start: vscode.Position{Line: int(fun.Pos.Line) - 1},
-					End:   vscode.Position{Line: int(fun.Pos.Line) - 1},
+					Start: vscode.Position{Line: int(m.Info.Pos.Line) - 1},
+					End:   vscode.Position{Line: int(m.Info.Pos.Line) - 1},
 				},
 			})
 		})
@@ -178,17 +178,17 @@ func (d *definitionWalker) EnterNode(w walker.Walkable) bool {
 		types := safeExprType(foundScope, &d.st, n.Variable)
 
 		types.Iterate(func(t string) {
-			prop, _, ok := solver.FindProperty(t, id.Value)
+			p, ok := solver.FindProperty(t, id.Value)
 			if !ok {
 				lintdebug.Send("Could not find property for %s->%s", t, id.Value)
 				return
 			}
 
 			d.result = append(d.result, vscode.Location{
-				URI: "file://" + prop.Pos.Filename,
+				URI: "file://" + p.Info.Pos.Filename,
 				Range: vscode.Range{
-					Start: vscode.Position{Line: int(prop.Pos.Line) - 1},
-					End:   vscode.Position{Line: int(prop.Pos.Line) - 1},
+					Start: vscode.Position{Line: int(p.Info.Pos.Line) - 1},
+					End:   vscode.Position{Line: int(p.Info.Pos.Line) - 1},
 				},
 			})
 		})

--- a/src/langsrv/langsrv.go
+++ b/src/langsrv/langsrv.go
@@ -559,7 +559,7 @@ func getHoverForMethodCall(n *expr.MethodCall, sc *meta.Scope, cs *meta.ClassPar
 
 	var fun meta.FuncInfo
 	types.Find(func(t string) bool {
-		fun, _, ok = solver.FindMethod(t, id.Value)
+		_, ok := solver.FindMethod(t, id.Value)
 		return ok
 	})
 
@@ -577,12 +577,12 @@ func getHoverForStaticCall(n *expr.StaticCall, sc *meta.Scope, cs *meta.ClassPar
 		return ""
 	}
 
-	fun, _, ok := solver.FindMethod(className, id.Value)
+	m, ok := solver.FindMethod(className, id.Value)
 	if !ok {
 		return ""
 	}
 
-	return linter.FlagsToString(fun.ExitFlags)
+	return linter.FlagsToString(m.Info.ExitFlags)
 }
 
 func handleTextDocumentCompletion(req *baseRequest) error {

--- a/src/langsrv/refs.go
+++ b/src/langsrv/refs.go
@@ -92,8 +92,9 @@ func (d *referencesWalker) EnterNode(w walker.Walkable) bool {
 			return true
 		}
 
-		_, realClassName, ok := solver.FindMethod(className, id.Value)
+		m, ok := solver.FindMethod(className, id.Value)
 		if ok {
+			realClassName := m.ImplName()
 			d.result = findStaticMethodReferences(realClassName, id.Value)
 		}
 	case *stmt.Function:

--- a/src/langsrv/refsvisitors.go
+++ b/src/langsrv/refsvisitors.go
@@ -183,7 +183,8 @@ func (d *staticMethodCallVisitor) EnterNode(w walker.Walkable) bool {
 		if !ok {
 			return true
 		}
-		_, realClassName, ok := solver.FindMethod(className, id.Value)
+		m, ok := solver.FindMethod(className, id.Value)
+		realClassName := m.ImplName()
 
 		if ok && realClassName == d.className && id.Value == d.methodName {
 			if pos := n.GetPosition(); pos != nil {
@@ -318,7 +319,8 @@ func (d *blockMethodCallVisitor) BeforeEnterNode(w walker.Walkable) {
 		exprType := solver.ExprType(d.ctx.Scope(), d.ctx.ClassParseState(), n.Variable)
 
 		exprType.Iterate(func(typ string) {
-			_, realClassName, ok := solver.FindMethod(typ, methodName)
+			m, ok := solver.FindMethod(typ, methodName)
+			realClassName := m.ImplName()
 
 			if ok && realClassName == d.className {
 				if pos := n.GetPosition(); pos != nil {
@@ -368,7 +370,8 @@ func (d *blockPropertyVisitor) handlePropertyFetch(n *expr.PropertyFetch) {
 
 	exprType := solver.ExprType(d.ctx.Scope(), d.ctx.ClassParseState(), n.Variable)
 	exprType.Iterate(func(className string) {
-		_, realClassName, ok := solver.FindProperty(className, id.Value)
+		p, ok := solver.FindProperty(className, id.Value)
+		realClassName := p.ImplName()
 
 		if ok && realClassName == d.className {
 			if pos := n.GetPosition(); pos != nil {

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -962,13 +962,16 @@ func (b *BlockWalker) handleMethodCall(e *expr.MethodCall) bool {
 		foundMethod bool
 		magic       bool
 		fn          meta.FuncInfo
-		implClass   string
+		className   string
 	)
 
 	exprType := solver.ExprTypeCustom(b.ctx.sc, b.r.st, e.Variable, b.ctx.customTypes)
 
 	exprType.Find(func(typ string) bool {
-		fn, implClass, foundMethod = solver.FindMethod(typ, methodName)
+		m, ok := solver.FindMethod(typ, methodName)
+		fn = m.Info
+		foundMethod = ok
+		className = m.ClassName
 		magic = haveMagicMethod(typ, `__call`)
 		return foundMethod || magic
 	})
@@ -1000,8 +1003,8 @@ func (b *BlockWalker) handleMethodCall(e *expr.MethodCall) bool {
 		}
 	}
 
-	if foundMethod && !b.canAccess(implClass, fn.AccessLevel) {
-		b.r.Report(e.Method, LevelError, "accessLevel", "Cannot access %s method %s->%s()", fn.AccessLevel, implClass, methodName)
+	if foundMethod && !b.canAccess(className, fn.AccessLevel) {
+		b.r.Report(e.Method, LevelError, "accessLevel", "Cannot access %s method %s->%s()", fn.AccessLevel, className, methodName)
 	}
 
 	b.handleCallArgs(e.Method, e.ArgumentList.Arguments, fn)
@@ -1029,7 +1032,8 @@ func (b *BlockWalker) handleStaticCall(e *expr.StaticCall) bool {
 		return true
 	}
 
-	fn, implClass, ok := solver.FindMethod(className, methodName)
+	m, ok := solver.FindMethod(className, methodName)
+	fn := m.Info
 
 	e.Class.Walk(b)
 	e.Call.Walk(b)
@@ -1048,8 +1052,8 @@ func (b *BlockWalker) handleStaticCall(e *expr.StaticCall) bool {
 		}
 	}
 
-	if ok && !b.canAccess(implClass, fn.AccessLevel) {
-		b.r.Report(e.Call, LevelError, "accessLevel", "Cannot access %s method %s::%s()", fn.AccessLevel, implClass, methodName)
+	if ok && !b.canAccess(m.ClassName, fn.AccessLevel) {
+		b.r.Report(e.Call, LevelError, "accessLevel", "Cannot access %s method %s::%s()", fn.AccessLevel, m.ClassName, methodName)
 	}
 
 	b.handleCallArgs(e.Call, e.ArgumentList.Arguments, fn)
@@ -1085,13 +1089,16 @@ func (b *BlockWalker) handlePropertyFetch(e *expr.PropertyFetch) bool {
 
 	found := false
 	magic := false
-	var implClass string
+	var className string
 	var info meta.PropertyInfo
 
 	typ := solver.ExprTypeCustom(b.ctx.sc, b.r.st, e.Variable, b.ctx.customTypes)
-	typ.Find(func(className string) bool {
-		info, implClass, found = solver.FindProperty(className, id.Value)
-		magic = haveMagicMethod(className, `__get`)
+	typ.Find(func(typ string) bool {
+		p, ok := solver.FindProperty(typ, id.Value)
+		info = p.Info
+		className = p.ClassName
+		found = ok
+		magic = haveMagicMethod(typ, `__get`)
 		return found || magic
 	})
 
@@ -1099,8 +1106,8 @@ func (b *BlockWalker) handlePropertyFetch(e *expr.PropertyFetch) bool {
 		b.r.Report(e.Property, LevelError, "undefined", "Property {%s}->%s does not exist", typ, id.Value)
 	}
 
-	if found && !b.canAccess(implClass, info.AccessLevel) {
-		b.r.Report(e.Property, LevelError, "accessLevel", "Cannot access %s property %s->%s", info.AccessLevel, implClass, id.Value)
+	if found && !b.canAccess(className, info.AccessLevel) {
+		b.r.Report(e.Property, LevelError, "accessLevel", "Cannot access %s property %s->%s", info.AccessLevel, className, id.Value)
 	}
 
 	return false
@@ -1125,13 +1132,13 @@ func (b *BlockWalker) handleStaticPropertyFetch(e *expr.StaticPropertyFetch) boo
 		return false
 	}
 
-	info, implClass, ok := solver.FindProperty(className, "$"+sv.Name)
+	p, ok := solver.FindProperty(className, "$"+sv.Name)
 	if !ok && !b.r.st.IsTrait {
 		b.r.Report(e.Property, LevelError, "undefined", "Property %s::$%s does not exist", className, sv.Name)
 	}
 
-	if ok && !b.canAccess(implClass, info.AccessLevel) {
-		b.r.Report(e.Property, LevelError, "accessLevel", "Cannot access %s property %s::$%s", info.AccessLevel, implClass, sv.Name)
+	if ok && !b.canAccess(p.ClassName, p.Info.AccessLevel) {
+		b.r.Report(e.Property, LevelError, "accessLevel", "Cannot access %s property %s::$%s", p.Info.AccessLevel, p.ClassName, sv.Name)
 	}
 
 	return false
@@ -1287,10 +1294,11 @@ func (b *BlockWalker) handleNew(e *expr.New) bool {
 	}
 
 	// Check implicitly invoked constructor method arguments count.
-	ctor, _, ok := solver.FindMethod(className, "__construct")
+	m, ok := solver.FindMethod(className, "__construct")
 	if !ok {
 		return true
 	}
+	ctor := m.Info
 	// If new expression is written without (), ArgumentList will be nil.
 	// It's equivalent of 0 arguments constructor call.
 	var args []node.Node

--- a/src/linter/side_effects_finder.go
+++ b/src/linter/side_effects_finder.go
@@ -93,8 +93,8 @@ func (f *sideEffectsFinder) staticCallIsPure(n *expr.StaticCall) bool {
 	if !ok {
 		return false
 	}
-	info, _, ok := solver.FindMethod(className, methodName.Value)
-	return ok && info.IsPure() && info.ExitFlags == 0
+	m, ok := solver.FindMethod(className, methodName.Value)
+	return ok && m.Info.IsPure() && m.Info.ExitFlags == 0
 }
 
 func (f *sideEffectsFinder) methodCallIsPure(n *expr.MethodCall) bool {
@@ -110,11 +110,11 @@ func (f *sideEffectsFinder) methodCallIsPure(n *expr.MethodCall) bool {
 		return false
 	}
 	return typ.Find(func(typ string) bool {
-		info, impl, ok := solver.FindMethod(typ, methodName.Value)
-		if meta.IsInternalClass(impl) {
+		m, ok := solver.FindMethod(typ, methodName.Value)
+		if meta.IsInternalClass(m.ClassName) {
 			return false
 		}
-		return ok && info.IsPure() && info.ExitFlags == 0
+		return ok && m.Info.IsPure() && m.Info.ExitFlags == 0
 	})
 }
 

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -49,7 +49,7 @@ func FlagsToString(f int) string {
 }
 
 func haveMagicMethod(class string, methodName string) bool {
-	_, _, ok := solver.FindMethod(class, methodName)
+	_, ok := solver.FindMethod(class, methodName)
 	return ok
 }
 
@@ -218,7 +218,9 @@ func resolveFunctionCall(sc *meta.Scope, st *meta.ClassParseState, customTypes [
 			if res.defined {
 				return
 			}
-			res.info, _, res.defined = solver.FindMethod(typ, `__invoke`)
+			m, ok := solver.FindMethod(typ, `__invoke`)
+			res.info = m.Info
+			res.defined = ok
 		})
 
 		if !res.defined {

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1080,3 +1080,126 @@ $_ = $x instanceof Box ? 0 : 1;
 	}
 	test.RunAndMatch()
 }
+
+func TestIssue283(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+trait YummyProps {
+  public $price = 'fair';
+  protected $taste = 'good';
+  private $secret = 'sauce';
+}
+
+class Borsch {
+  use YummyProps;
+
+  /** @return string */
+  public function getTaste() {
+    return $this->taste; // OK: using protected trait prop from embedding class
+  }
+
+  /** @return string */
+  public function getSecret() {
+    return $this->secret; // OK: using private trait prop from embedding class
+  }
+}
+
+class SaltyBorsch extends Borsch {
+  protected function getTaste2() {
+    return $this->taste; // OK: using protected trait prop from inherited class
+  }
+  protected function getSecret2() {
+    return $this->secret; // Bad: used private trait prop from inherited class
+  }
+}
+
+$borsch = new Borsch();
+$_ = $borsch->taste; // Bad: can't access protected trait prop from the outside
+$_ = $borsch->price; // OK: can use public trait prop here
+
+$borsch2 = new SaltyBorsch();
+$_ = $borsch2->price; // OK: can also access public trait prop from derived class
+`)
+	test.Expect = []string{
+		`Cannot access private property \Borsch->secret`,
+		`Cannot access protected property \Borsch->taste`,
+	}
+	test.RunAndMatch()
+}
+
+func TestIssue209_1(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+trait A {
+  private function priv() { return 1; }
+  protected function prot() { return 2; }
+  /** @return int */
+  public function pub() { return 3; }
+}
+
+class B {
+  use A;
+  /** @return int */
+  public function sum() {
+    return $this->priv() + $this->prot() + $this->pub();
+  }
+}
+
+echo (new B)->sum(); // actual PHP prints 6
+`)
+}
+
+func TestIssue209_2(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+trait Methods {
+  /***/
+  public function pubMethod() {}
+  protected function protMethod() {}
+  private function privMethod() {}
+
+  /***/
+  public static function staticPubMethod() {}
+  protected static function staticProtMethod() {}
+  private static function staticPrivMethod() {}
+}
+
+class Base {
+  use Methods;
+
+  private function f() {
+    $this->pubMethod();
+    $this->protMethod();
+    $this->privMethod();
+  }
+}
+
+class Derived extends Base {
+  private function f() {
+    $this->pubMethod();
+    $this->protMethod();
+    $this->privMethod(); // Bad: can't call private
+    Base::staticPubMethod();
+    Base::staticProtMethod();
+    parent::staticProtMethod();
+    parent::staticPrivMethod(); // Bad: can't call private
+  }
+}
+
+$b = new Base();
+$b->pubMethod();
+$b->protMethod(); // Bad: can't call from the outside
+$b->privMethod(); // Bad: can't call from the outside
+
+Base::staticPubMethod();
+Derived::staticPubMethod();
+Base::staticProtMethod();
+`)
+	test.Expect = []string{
+		`Cannot access private method \Base->privMethod()`,
+		`Cannot access protected method \Base->protMethod()`,
+		`Cannot access private method \Base->privMethod()`,
+		`Cannot access private method \Base::staticPrivMethod()`,
+		`Cannot access protected method \Base::staticProtMethod()`,
+	}
+	test.RunAndMatch()
+}

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -271,9 +271,9 @@ func findMethod(className string, methodName string, visitedMap map[string]struc
 		}
 
 		for trait := range class.Traits {
-			res, implClassName, ok = findMethod(trait, methodName, visitedMap)
+			res, _, ok = findMethod(trait, methodName, visitedMap)
 			if ok {
-				return res, implClassName, ok
+				return res, className, ok
 			}
 		}
 
@@ -319,9 +319,9 @@ func findProperty(className string, propertyName string, visitedMap map[string]s
 		}
 
 		for trait := range class.Traits {
-			res, implClassName, ok = findProperty(trait, propertyName, visitedMap)
+			res, _, ok = findProperty(trait, propertyName, visitedMap)
 			if ok {
-				return res, implClassName, ok
+				return res, className, ok
 			}
 		}
 


### PR DESCRIPTION
Since traits can't extend or implement anything,
it's 100% guarantee that if we find a symbol inside
a trait it comes from that exact trait.

We can use that to achieve PHP-like semantics of
traits access level.

Suppose we're looking for a symbol S in class C that
uses trait T. Class C doesn't have it so we fall back
into traits. If trait T has S, return it with
implClass=C, so it looks like C itself had it.

That way, we can check accessLevel using the unmodified
canAccess() method.

Fixes #283
Fixes #209

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>