### PR TITLE
php/parser: parse php7-style heredocs/nowdocs correctly

### DIFF
--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -6,6 +6,33 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestIssue327(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+function sink(...$args) {}
+
+function f() {
+  return <<<'SQL'
+    SELECT login, password FROM user WHERE login LIKE '%admin%'
+  SQL;
+}
+
+function f2($x) {
+  sink(<<<STR
+    $x $x
+    STR, 1, 2);
+
+  sink(<<<STR
+    abc
+  STR);
+
+  sink(<<<"STR"
+  STRNOTEND
+    abc
+  STR);
+}
+`)
+}
+
 func TestIssue289(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 class Foo { public $value = 11; }

--- a/src/php/parser/scanner/lexer.go
+++ b/src/php/parser/scanner/lexer.go
@@ -136,20 +136,30 @@ func (lex *Lexer) isHeredocEnd(p int) bool {
 		return false
 	}
 
+	for lex.data[p] == ' ' || lex.data[p] == '\t' {
+		p++
+	}
+
 	l := len(lex.heredocLabel)
 	if len(lex.data) < p+l {
 		return false
 	}
 
-	if len(lex.data) > p+l && lex.data[p+l] != ';' && lex.data[p+l] != '\r' && lex.data[p+l] != '\n' {
+	if len(lex.data) > p+l && isValidVarName(lex.data[p+l]) {
 		return false
 	}
 
-	if len(lex.data) > p+l+1 && lex.data[p+l] == ';' && lex.data[p+l+1] != '\r' && lex.data[p+l+1] != '\n' {
-		return false
+	a := string(lex.heredocLabel)
+	b := string(lex.data[p : p+l])
+
+	_, _ = a, b
+
+	if bytes.Equal(lex.heredocLabel, lex.data[p:p+l]) {
+		lex.p = p
+		return true
 	}
 
-	return bytes.Equal(lex.heredocLabel, lex.data[p:p+l])
+	return false
 }
 
 func (lex *Lexer) isNotHeredocEnd(p int) bool {
@@ -221,5 +231,9 @@ func (lex *Lexer) Error(msg string) {
 }
 
 func isValidVarNameStart(r byte) bool {
-	return r >= 'A' && r <= 'Z' || r == '_' || r >= 'a' && r <= 'z' || r >= '\u007f' && r <= 'ÿ'
+	return (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_' || (r >= 0x80 && r <= 0xff)
+}
+
+func isValidVarName(r byte) bool {
+	return (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || (r >= 0x80 && r <= 0xff)
 }

--- a/src/php/parser/scanner/scanner_test.go
+++ b/src/php/parser/scanner/scanner_test.go
@@ -1423,3 +1423,35 @@ func TestIgnoreControllCharactersAtStringVarOffset(t *testing.T) {
 	actual = lv.Tkn.Value
 	assert.DeepEqual(t, expected, actual)
 }
+
+func TestHereDocTokens73(t *testing.T) {
+	src := `<?php
+	<<<"CAT"
+		text
+	CAT, $b`
+
+	expected := []string{
+
+		T_START_HEREDOC.String(),
+		T_ENCAPSED_AND_WHITESPACE.String(),
+		T_END_HEREDOC.String(),
+		TokenID(int(',')).String(),
+		T_VARIABLE.String(),
+	}
+
+	lexer := NewLexer([]byte(src))
+	lexer.WithFreeFloating = true
+	lv := &lval{}
+	actual := []string{}
+
+	for {
+		token := lexer.Lex(lv)
+		if token == 0 {
+			break
+		}
+
+		actual = append(actual, TokenID(token).String())
+	}
+
+	assert.DeepEqual(t, expected, actual)
+}


### PR DESCRIPTION
This is a port of https://github.com/z7zmey/php-parser/commit/6afa2a089b2a9df25d08db76416d1c6ca7119fe8
commit from php-parser upstream repo.

Fixes #327

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>