### PR TITLE
linter: reduce stutter in unused warnings

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -2064,7 +2064,7 @@ func (b *BlockWalker) flushUnused() {
 			}
 
 			visitedMap[n] = struct{}{}
-			b.r.Report(n, LevelUnused, "unused", `Unused variable %s (use $_ to ignore this inspection)`, name)
+			b.r.Report(n, LevelUnused, "unused", `Variable %s is unused (use $_ to ignore this inspection)`, name)
 		}
 	}
 }

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -397,6 +397,10 @@ func (d *RootWalker) Report(n node.Node, level int, checkName, msg string, args 
 			d.Diagnostics = append(d.Diagnostics, diag)
 		}
 	} else {
+		// Replace Unused with Info (Notice) in non-LSP mode.
+		if level == LevelUnused {
+			level = LevelInformation
+		}
 		d.reports = append(d.reports, &Report{
 			checkName:  checkName,
 			startLn:    string(startLn),

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -644,7 +644,7 @@ function foo() {
 }
 `)
 	test.Expect = []string{
-		`Unused variable x`,
+		`Variable x is unused`,
 		`Undefined variable: y`,
 	}
 	test.RunAndMatch()
@@ -706,7 +706,7 @@ func TestUnusedInSwitch(t *testing.T) {
 		}
 		return 20;
 	}`)
-	test.Expect = []string{`Unused variable x`}
+	test.Expect = []string{`Variable x is unused`}
 	runFilterMatch(test, "unused")
 }
 
@@ -1058,9 +1058,9 @@ func TestUnused(t *testing.T) {
 		}
 	}`)
 	test.Expect = []string{
-		"Unused variable g ",
-		"Unused variable a ",
-		"Unused variable v ",
+		"Variable g is unused",
+		"Variable a is unused",
+		"Variable v is unused",
 	}
 	test.RunAndMatch()
 }

--- a/src/linttest/testdata/parsedown/golden.txt
+++ b/src/linttest/testdata/parsedown/golden.txt
@@ -25,6 +25,6 @@ INFO    undefined: Variable might have not been defined: text at testdata/parsed
 INFO    undefined: Variable might have not been defined: text at testdata/parsedown/parsedown.php:1759
                     $markup .= $text;
                                ^^^^^
-UNUSED  unused: Unused variable val (use $_ to ignore this inspection) at testdata/parsedown/parsedown.php:1882
+INFO    unused: Variable val is unused (use $_ to ignore this inspection) at testdata/parsedown/parsedown.php:1882
             foreach ($Element['attributes'] as $att => $val)
                                                        ^^^^

--- a/src/linttest/testdata/phprocksyd/golden.txt
+++ b/src/linttest/testdata/phprocksyd/golden.txt
@@ -16,7 +16,7 @@ INFO    phpdocLint: malformed @param $stream_id tag (maybe type is missing?) on 
 INFO    phpdocLint: malformed @param $req tag (maybe type is missing?) on line 3 at testdata/phprocksyd/Phprocksyd.php:392
     private function requestCheck($stream_id, $req)
                      ^^^^^^^^^^^^
-UNUSED  unused: Unused variable status (use $_ to ignore this inspection) at testdata/phprocksyd/Phprocksyd.php:394
+INFO    unused: Variable status is unused (use $_ to ignore this inspection) at testdata/phprocksyd/Phprocksyd.php:394
         $status = null;
         ^^^^^^^
 INFO    phpdocLint: malformed @param $stream_id tag (maybe type is missing?) on line 2 at testdata/phprocksyd/Phprocksyd.php:424

--- a/src/linttest/testdata/qrcode/golden.txt
+++ b/src/linttest/testdata/qrcode/golden.txt
@@ -7,7 +7,7 @@ MAYBE   phpdoc: Missing PHPDoc for "render_image" public method at testdata/qrco
 INFO    deadCode: Unreachable code at testdata/qrcode/qrcode.php:155
     return null;
            ^^^^
-UNUSED  unused: Unused variable mode (use $_ to ignore this inspection) at testdata/qrcode/qrcode.php:177
+INFO    unused: Variable mode is unused (use $_ to ignore this inspection) at testdata/qrcode/qrcode.php:177
     list($mode, $vers, $ec, $data) = $this->qr_encode_data($data, $ecl);
          ^^^^^
 INFO    undefined: Variable might have not been defined: code at testdata/qrcode/qrcode.php:221

--- a/src/linttest/testdata/underscore/golden.txt
+++ b/src/linttest/testdata/underscore/golden.txt
@@ -31,7 +31,7 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:363
     $calculated = array();
                   ^^^^^^^
-UNUSED  unused: Unused variable is_sorted (use $_ to ignore this inspection) at testdata/underscore/underscore.php:356
+INFO    unused: Variable is_sorted is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:356
     list($collection, $is_sorted, $iterator) = self::_wrapArgs(func_get_args(), 3);
                       ^^^^^^^^^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:448
@@ -79,7 +79,7 @@ MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/unders
 MAYBE   arrayAccess: Array access to non-array type \__|empty_array[]|mixed at testdata/underscore/underscore.php:483
         $return_arrays[$k][$a] = array_key_exists($k, $array) ? $array[$k] : null;
         ^^^^^^^^^^^^^^
-UNUSED  unused: Unused variable v (use $_ to ignore this inspection) at testdata/underscore/underscore.php:479
+INFO    unused: Variable v is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:479
     foreach($return_arrays as $k=>$v) {
                                   ^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:497
@@ -91,7 +91,7 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:529
     $results = array();
                ^^^^^^^
-UNUSED  unused: Unused variable v (use $_ to ignore this inspection) at testdata/underscore/underscore.php:534
+INFO    unused: Variable v is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:534
     foreach($results as $k=>$v) {
                             ^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:545
@@ -100,10 +100,10 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:549
       if(!array_key_exists($key, $result)) $result[$key] = array();
                                                            ^^^^^^^
-UNUSED  unused: Unused variable __ (use $_ to ignore this inspection) at testdata/underscore/underscore.php:561
+INFO    unused: Variable __ is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:561
     $__ = new self;
     ^^^
-UNUSED  unused: Unused variable args (use $_ to ignore this inspection) at testdata/underscore/underscore.php:615
+INFO    unused: Variable args is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:615
     $args = self::_wrapArgs(func_get_args(), 1);
     ^^^^^
 ERROR   undefined: Property {\__|null|unknown_from_list}->isEqual does not exist at testdata/underscore/underscore.php:723
@@ -160,6 +160,6 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:1102
     $filled_args = array();
                    ^^^^^^^
-UNUSED  unused: Unused variable k (use $_ to ignore this inspection) at testdata/underscore/underscore.php:1107
+INFO    unused: Variable k is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:1107
       foreach($caller_args as $k=>$v) {
                               ^^


### PR DESCRIPTION
```
Before:
	UNUSED  unused: Unused variable v

1. Replace UNUSED with INFO in non-LSP mode:
	INFO    unused: Unused variable v

2. Re-word message:
	INFO    unused: Vairable v is unused
```

Fixes #397

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>