### PR TITLE
linter: add "unimplemented" checker

### DIFF
--- a/src/langsrv/langsrv.go
+++ b/src/langsrv/langsrv.go
@@ -277,16 +277,16 @@ func handleTextDocumentSymbol(req *baseRequest) error {
 			filename := strings.TrimPrefix(uri, "file://")
 			res := meta.Info.GetMetaForFile(filename)
 
-			for className, classInfo := range res.Classes {
+			for _, classInfo := range res.Classes.H {
 				result = append(result, vscode.SymbolInformation{
-					Name:     baseSymbolName(className),
+					Name:     baseSymbolName(classInfo.Name),
 					Kind:     vscode.CompletionKindClass,
 					Location: posToLocation(classInfo.Pos),
 				})
 
-				for methodName, info := range classInfo.Methods {
+				for _, info := range classInfo.Methods.H {
 					result = append(result, vscode.SymbolInformation{
-						Name:     methodName,
+						Name:     info.Name,
 						Kind:     vscode.CompletionKindMethod,
 						Location: posToLocation(info.Pos),
 					})
@@ -309,9 +309,9 @@ func handleTextDocumentSymbol(req *baseRequest) error {
 				}
 			}
 
-			for funcName, info := range res.Functions {
+			for _, info := range res.Functions.H {
 				result = append(result, vscode.SymbolInformation{
-					Name:     baseSymbolName(funcName),
+					Name:     baseSymbolName(info.Name),
 					Kind:     vscode.CompletionKindFunction,
 					Location: posToLocation(info.Pos),
 				})
@@ -771,8 +771,8 @@ func getMethods(className string) (res []string) {
 			return res
 		}
 
-		for m := range class.Methods {
-			res = append(res, m)
+		for _, info := range class.Methods.H {
+			res = append(res, info.Name)
 		}
 
 		className = class.Parent

--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -28,7 +28,12 @@ import (
 //     33 - support parsing of array<k,v> and list<type>
 //     34 - support parsing of ?ClassName as "ClassName|null"
 //     35 - added Flags:uint8 to meta.ClassInfo
-const cacheVersion = 35
+//     36 - added FuncAbstract bit to FuncFlags
+//          added FuncFinal bit to FuncFlags
+//          added ClassFinal bit to ClassFlags
+//          FuncInfo now stores original function name
+//          ClassInfo now stores original class name
+const cacheVersion = 36
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -39,6 +39,10 @@ final class Consts {
   const C3 = ['a'];
 }
 
+abstract class AbstractClass {
+  abstract public function f1();
+}
+
 class Point implements Arrayable {
   public $x = 0.0;
   public $y = 0.0;
@@ -99,7 +103,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 2815
+		wantLen := 3233
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -108,7 +112,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "97356a3906ec935c43b2a23a7ad70d62442ef7cdf9f53666b7a66d54828db601756443fd13ae7d382abb42b4bce021ee832b51d1e97ff63565fb0beca2597527"
+		wantStrings := "97c6dd187bfedb2f337fb82aaa75f5b3b706162f08c839d194c6914bf5abcc0cfafd347ee46563694e5285d0139364cb5e827d4e3530f9bbaf273f136d848c39"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/linter/phpdoc_test.go
+++ b/src/linter/phpdoc_test.go
@@ -65,15 +65,15 @@ func TestParseClassPHPDoc(t *testing.T) {
 
 		switch {
 		case test.method != "":
-			if len(result.methods) != 1 {
-				t.Errorf("parse(`%s`): expected 1 methods, found %d", test.line, len(result.methods))
+			if result.methods.Len() != 1 {
+				t.Errorf("parse(`%s`): expected 1 methods, found %d", test.line, result.methods.Len())
 				continue
 			}
-			m, ok := result.methods[test.method]
+			m, ok := result.methods.Get(test.method)
 			if !ok {
 				foundInstead := ""
-				for name := range result.methods {
-					foundInstead = name
+				for _, info := range result.methods.H {
+					foundInstead = info.Name
 					break
 				}
 				t.Errorf("parse(`%s`): expected %s method, found %s", test.line, test.method, foundInstead)

--- a/src/linter/phpdoc_util.go
+++ b/src/linter/phpdoc_util.go
@@ -104,7 +104,7 @@ func parseClassPHPDoc(st *meta.ClassParseState, doc string) classPhpDocParseResu
 	// Class may not have any @property or @method annotations.
 	// In that case we can handle avoid map allocations.
 	result.properties = make(meta.PropertiesMap)
-	result.methods = make(meta.FunctionsMap)
+	result.methods = meta.NewFunctionsMap()
 
 	for _, part := range phpdoc.Parse(doc) {
 		switch part.Name {
@@ -153,12 +153,13 @@ func parseClassPHPDocMethod(st *meta.ClassParseState, result *classPhpDocParseRe
 	if static {
 		funcFlags |= meta.FuncStatic
 	}
-	result.methods[methodName] = meta.FuncInfo{
+	result.methods.Set(methodName, meta.FuncInfo{
 		Typ:          meta.NewTypesMap(normalizeType(st, typ)),
+		Name:         methodName,
 		Flags:        funcFlags,
 		MinParamsCnt: 0, // TODO: parse signature and assign a proper value
 		AccessLevel:  meta.Public,
-	}
+	})
 }
 
 func parseClassPHPDocProperty(st *meta.ClassParseState, result *classPhpDocParseResult, part phpdoc.CommentPart) {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -127,6 +127,12 @@ func init() {
 		},
 
 		{
+			Name:    "unimplemented",
+			Default: true,
+			Comment: `Report classes that don't implement their contract.`,
+		},
+
+		{
 			Name:    "syntax",
 			Default: true,
 			Comment: `Report syntax errors.`,

--- a/src/linter/side_effects_finder.go
+++ b/src/linter/side_effects_finder.go
@@ -129,7 +129,6 @@ func (f *sideEffectsFinder) EnterNode(w walker.Walkable) bool {
 
 	switch n := w.(type) {
 	case *expr.FunctionCall:
-		// fmt.Printf("node=%T %s\n", w, FmtNode(w.(node.Node)))
 		if f.functionCallIsPure(n) {
 			return true
 		}

--- a/src/meta/case_insensitive_map.go
+++ b/src/meta/case_insensitive_map.go
@@ -1,0 +1,77 @@
+package meta
+
+import (
+	"strings"
+)
+
+// lowercaseString type is used to avoid invalid mixing of normal strings
+// and ones that are guaranteed to be lowercase.
+type lowercaseString string
+
+type ClassesMap struct {
+	H map[lowercaseString]ClassInfo
+}
+
+func NewClassesMap() ClassesMap {
+	return ClassesMap{H: make(map[lowercaseString]ClassInfo)}
+}
+
+func (m ClassesMap) Len() int           { return len(m.H) }
+func (m ClassesMap) Delete(name string) { delete(m.H, toLower(name)) }
+
+func (m ClassesMap) Get(name string) (ClassInfo, bool) {
+	res, ok := m.H[toLower(name)]
+	return res, ok
+}
+
+func (m ClassesMap) Set(name string, class ClassInfo) {
+	m.H[toLower(name)] = class
+}
+
+type FunctionsMap struct {
+	H map[lowercaseString]FuncInfo
+}
+
+func NewFunctionsMap() FunctionsMap {
+	return FunctionsMap{H: make(map[lowercaseString]FuncInfo)}
+}
+
+func (m FunctionsMap) Len() int           { return len(m.H) }
+func (m FunctionsMap) Delete(name string) { delete(m.H, toLower(name)) }
+
+func (m FunctionsMap) Get(name string) (FuncInfo, bool) {
+	res, ok := m.H[toLower(name)]
+	return res, ok
+}
+
+func (m FunctionsMap) Set(name string, fn FuncInfo) {
+	m.H[toLower(name)] = fn
+}
+
+// toLower is like strings.ToLower, but specialized for ascii-only.
+// It also returns lowercaseString type.
+func toLower(s string) lowercaseString {
+	hasUpper := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			hasUpper = true
+			break
+		}
+	}
+
+	if !hasUpper {
+		return lowercaseString(s)
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		b.WriteByte(c)
+	}
+	return lowercaseString(b.String())
+}

--- a/src/solver/solver_test.go
+++ b/src/solver/solver_test.go
@@ -30,21 +30,20 @@ func TestSolver(t *testing.T) {
 	sc := meta.NewScope()
 	sc.AddVarName("MC", tm("Memcache"), "global", true)
 
-	fm := meta.FunctionsMap{
-		`\array_map`: {Typ: tm(`array|bool|` + meta.WrapFunctionCall(`\my_func`))},
-		`\my_func`:   {Typ: tm(meta.WrapFunctionCall(`\array_map`) + `|float`)},
-	}
+	fm := meta.NewFunctionsMap()
+	fm.Set(`\array_map`, meta.FuncInfo{Typ: tm(`array|bool|` + meta.WrapFunctionCall(`\my_func`))})
+	fm.Set(`\my_func`, meta.FuncInfo{Typ: tm(meta.WrapFunctionCall(`\array_map`) + `|float`)})
 
-	cm := meta.ClassesMap{
-		`\Test`: {
-			Methods: meta.FunctionsMap{
-				`do_something`: {Typ: tm(`string`)},
-			},
-			Properties: meta.PropertiesMap{
-				`$instance`: {Typ: tm(`\Test`)},
-			},
+	cmfm := meta.NewFunctionsMap()
+	cmfm.Set(`do_something`, meta.FuncInfo{Typ: tm(`string`)})
+
+	cm := meta.NewClassesMap()
+	cm.Set(`\Test`, meta.ClassInfo{
+		Methods: cmfm,
+		Properties: meta.PropertiesMap{
+			`$instance`: {Typ: tm(`\Test`)},
 		},
-	}
+	})
 
 	meta.Info.AddToGlobalScopeNonLocked("test", sc)
 	meta.Info.AddFunctionsNonLocked("test", fm)


### PR DESCRIPTION
For every interface in "implements" and class in "extends" run
a method set check.

That check is skipped for abstract classes.

Non-abstract classes must implement every abstract method of their
parents (directly or via traits) and every method from interfaces chain.

Related changes:

- Added FuncAbstract bit to FuncFlags

- solver.FindFunc now correctly prefers concrete method definitions
  instead of the closest one.

- Using undefined class in extend/implements clause cause "undefined" error.

Fixes #395
Fixes #368

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>