### PR TITLE
update phpstorm stubs

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1214,7 +1214,7 @@ func (d *RootWalker) enterFunction(fun *stmt.Function) bool {
 	if sideEffectFreeFunc(d.scope(), d.st, nil, fun.Stmts) {
 		funcFlags |= meta.FuncPure
 	}
-	d.meta.Functions[nm] = meta.FuncInfo{
+	meta.AddFunctionToMap(d.meta.Functions, nm, meta.FuncInfo{
 		Params:       params,
 		Pos:          d.getElementPos(fun),
 		Typ:          returnType.Immutable(),
@@ -1222,7 +1222,7 @@ func (d *RootWalker) enterFunction(fun *stmt.Function) bool {
 		Flags:        funcFlags,
 		ExitFlags:    exitFlags,
 		Doc:          doc.info,
-	}
+	})
 
 	return false
 }

--- a/src/linttest/testdata/flysystem/golden.txt
+++ b/src/linttest/testdata/flysystem/golden.txt
@@ -1,9 +1,6 @@
 MAYBE   regexpSimplify: May re-write '/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/' as '/^\d{2,4}-\d{2}-\d{2}/' at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:536
         return preg_match('/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/', $item) ? 'windows' : 'unix';
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING argCount: Too few arguments for strtr at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:569
-        $permissions = strtr($permissions, $map);
-                       ^^^^^
 MAYBE   regexpSimplify: May re-write '/^total [0-9]*$/' as '/^total \d*$/' at testdata/flysystem/src/Adapter/Ftp.php:407
         if (preg_match('/^total [0-9]*$/', $listing[0])) {
                        ^^^^^^^^^^^^^^^^^^

--- a/src/linttest/testdata/phprocksyd/golden.txt
+++ b/src/linttest/testdata/phprocksyd/golden.txt
@@ -1,4 +1,4 @@
-MAYBE   deprecated: Call to deprecated function dl (5.3.0 since 5.3.0) at testdata/phprocksyd/Phprocksyd.php:73
+MAYBE   deprecated: Call to deprecated function dl (5.3) at testdata/phprocksyd/Phprocksyd.php:73
             if (!extension_loaded($ext) && !dl($ext . '.so')) {
                                             ^^
 ERROR   undefined: Use null instead of NULL at testdata/phprocksyd/Phprocksyd.php:321

--- a/src/linttest/testdata/underscore/golden.txt
+++ b/src/linttest/testdata/underscore/golden.txt
@@ -145,7 +145,7 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 ERROR   undefined: Property {mixed}->_template_settings does not exist at testdata/underscore/underscore.php:909
       $ts = $class_name::getInstance()->_template_settings;
                                         ^^^^^^^^^^^^^^^^^^
-MAYBE   deprecated: Call to deprecated function create_function (7.2) at testdata/underscore/underscore.php:940
+MAYBE   deprecated: Call to deprecated function create_function (7.2 Use anonymous functions instead.) at testdata/underscore/underscore.php:940
       $func = create_function('$context', $code);
               ^^^^^^^^^^^^^^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:970


### PR DESCRIPTION
Also added a heuristic that tries to choose min(MinParamsCnt)
among all function overloadings.

Such overloadings only occur in PhpStorm stubs:
	\strtr: 2 or 3 args
	\stream_context_set_option: 2 or 4 args

Fixes #409

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>