### PR TITLE
cmd/stubs: update embedded phpstorm stubs

### DIFF
--- a/src/linttest/testdata/flysystem/golden.txt
+++ b/src/linttest/testdata/flysystem/golden.txt
@@ -1,9 +1,6 @@
 MAYBE   regexpSimplify: May re-write '/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/' as '/^\d{2,4}-\d{2}-\d{2}/' at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:536
         return preg_match('/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/', $item) ? 'windows' : 'unix';
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING argCount: Too few arguments for strtr at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:569
-        $permissions = strtr($permissions, $map);
-                       ^^^^^
 MAYBE   regexpSimplify: May re-write '/^total [0-9]*$/' as '/^total \d*$/' at testdata/flysystem/src/Adapter/Ftp.php:407
         if (preg_match('/^total [0-9]*$/', $listing[0])) {
                        ^^^^^^^^^^^^^^^^^^

--- a/src/linttest/testdata/phprocksyd/golden.txt
+++ b/src/linttest/testdata/phprocksyd/golden.txt
@@ -1,4 +1,4 @@
-MAYBE   deprecated: Call to deprecated function dl (5.3.0 since 5.3.0) at testdata/phprocksyd/Phprocksyd.php:73
+MAYBE   deprecated: Call to deprecated function dl (5.3) at testdata/phprocksyd/Phprocksyd.php:73
             if (!extension_loaded($ext) && !dl($ext . '.so')) {
                                             ^^
 ERROR   undefined: Use null instead of NULL at testdata/phprocksyd/Phprocksyd.php:321

--- a/src/linttest/testdata/underscore/golden.txt
+++ b/src/linttest/testdata/underscore/golden.txt
@@ -145,7 +145,7 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 ERROR   undefined: Property {mixed}->_template_settings does not exist at testdata/underscore/underscore.php:909
       $ts = $class_name::getInstance()->_template_settings;
                                         ^^^^^^^^^^^^^^^^^^
-MAYBE   deprecated: Call to deprecated function create_function (7.2) at testdata/underscore/underscore.php:940
+MAYBE   deprecated: Call to deprecated function create_function (7.2 Use anonymous functions instead.) at testdata/underscore/underscore.php:940
       $func = create_function('$context', $code);
               ^^^^^^^^^^^^^^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:970


### PR DESCRIPTION
Accidentally, strtr function with 2 arguments causes no
warnings after the update. It depends on the definitions
order inside stubs, so #409 still needs to be solved.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>