### PR TITLE
add NodeSet type and start implementing dupCond check

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1786,6 +1786,20 @@ func (b *BlockWalker) handleSwitch(s *stmt.Switch) bool {
 	haveDefault := false
 	breakFlags := FlagBreak | FlagContinue
 
+	b.r.nodeSet.Reset()
+	for i, c := range s.CaseList.Cases {
+		c, ok := c.(*stmt.Case)
+		if !ok {
+			continue
+		}
+		if !sideEffectFree(b.ctx.sc, b.r.st, b.ctx.customTypes, c.Cond) {
+			continue
+		}
+		if !b.r.nodeSet.Add(c.Cond) {
+			b.r.Report(c.Cond, LevelWarning, "dupCond", "duplicated switch case #%d", i+1)
+		}
+	}
+
 	for idx, c := range s.CaseList.Cases {
 		var list []node.Node
 

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -73,6 +73,12 @@ func init() {
 		},
 
 		{
+			Name:    "dupCond",
+			Default: true,
+			Comment: `Report duplicated conditions in switch and if/else statements.`,
+		},
+
+		{
 			Name:    "arraySyntax",
 			Default: true,
 			Comment: `Report usages of old array() syntax.`,

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/VKCOM/noverify/src/git"
 	"github.com/VKCOM/noverify/src/meta"
+	"github.com/VKCOM/noverify/src/php/astutil"
 	"github.com/VKCOM/noverify/src/php/parser/freefloating"
 	"github.com/VKCOM/noverify/src/php/parser/node"
 	"github.com/VKCOM/noverify/src/php/parser/node/expr"
@@ -45,6 +46,9 @@ type RootWalker struct {
 	rootRset  *rules.ScopedSet
 	localRset *rules.ScopedSet
 	anyRset   *rules.ScopedSet
+
+	// nodeSet is a reusable node set for both root and block walkers.
+	nodeSet astutil.NodeSet
 
 	reSimplifier *regexpSimplifier
 	reVet        *regexpVet

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -1,7 +1,6 @@
 package linter
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 	"unicode"
@@ -12,18 +11,10 @@ import (
 	"github.com/VKCOM/noverify/src/php/parser/node/expr"
 	"github.com/VKCOM/noverify/src/php/parser/node/name"
 	"github.com/VKCOM/noverify/src/php/parser/node/scalar"
-	"github.com/VKCOM/noverify/src/php/parser/printer"
 	"github.com/VKCOM/noverify/src/php/parser/walker"
 	"github.com/VKCOM/noverify/src/phpdoc"
 	"github.com/VKCOM/noverify/src/solver"
 )
-
-// FmtNode is used for debug purposes and returns string representation of a specified node.
-func FmtNode(n node.Node) string {
-	var b bytes.Buffer
-	printer.NewPrettyPrinter(&b, " ").Print(n)
-	return b.String()
-}
 
 // FlagsToString is designed for debugging flags.
 func FlagsToString(f int) string {

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -91,7 +91,7 @@ FUNCTION f() {
   DEFAULT: return 0;
   }
   if (0) {
-  } ELSEIF (0) {
+  } ELSEIF (1) {
   } ELSE {}
   Do {
   } While (0);

--- a/src/linttest/codedup_test.go
+++ b/src/linttest/codedup_test.go
@@ -1,0 +1,105 @@
+package linttest_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestDupIfCond(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+const C1 = 1;
+const C2 = 2;
+const C3 = 3;
+
+$glob = 0;
+
+function purefunc($x) { return $x+1; }
+
+function impurefunc($x) {
+  global $glob;
+  $glob += $x;
+  return $glob;
+}
+
+function f($cond) {
+  if ($cond + 1) {
+  } elseif ($cond + 1) {
+  }
+
+  if ($cond) {
+  } elseif ($cond) {
+  } else {}
+}
+`)
+	test.RunAndMatch()
+}
+
+func TestDupCaseCond(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+const C1 = 1;
+const C2 = 2;
+const C3 = 3;
+
+$glob = 0;
+
+function purefunc($x) { return $x+1; }
+
+function impurefunc($x) {
+  global $glob;
+  $glob += $x;
+  return $glob;
+}
+
+function f($cond) {
+  switch ($cond) {
+  case 'abc':
+    echo 1; break;
+  case 'abc':
+    echo 2; break; // Bad: duplicated string literal
+  }
+
+  switch ($cond) {
+  case 2:
+    echo 2; break;
+  case 1:
+    echo 1; break;
+  case 3:
+    echo 3; break;
+  case 1:
+    echo 4; break; // Bad: duplicated int literal
+  case 5:
+    echo 5; break;
+  }
+
+  switch ($cond) {
+  default: break;
+  case C1: break;
+  case C2: break;
+  case C3: break;
+  case C2: break; // Bad: duplicated const
+  }
+
+  // Pure function calls are tracked.
+  switch ($cond) {
+  case purefunc(1): break;
+  case purefunc(1): break; // Bad: duplicated pure func call
+  }
+
+  // No warnings for duplicated expressions with potential side effects.
+  switch ($cond) {
+  case impurefunc(1): break;
+  case impurefunc(1): break;
+  }
+}
+`)
+	test.Expect = []string{
+		`duplicated switch case #2`,
+		`duplicated switch case #4`,
+		`duplicated switch case #5`,
+		`duplicated switch case #2`,
+	}
+	test.RunAndMatch()
+}

--- a/src/php/astutil/astutil.go
+++ b/src/php/astutil/astutil.go
@@ -1,7 +1,10 @@
 package astutil
 
 import (
+	"bytes"
+
 	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/printer"
 )
 
 //go:generate go run ./gen_equal.go
@@ -16,4 +19,11 @@ func NodeSliceEqual(xs, ys []node.Node) bool {
 		}
 	}
 	return true
+}
+
+// FmtNode is used for debug purposes and returns string representation of a specified node.
+func FmtNode(n node.Node) string {
+	var b bytes.Buffer
+	printer.NewPrettyPrinter(&b, " ").Print(n)
+	return b.String()
 }

--- a/src/php/astutil/nodeSet.go
+++ b/src/php/astutil/nodeSet.go
@@ -1,0 +1,106 @@
+package astutil
+
+import (
+	"github.com/VKCOM/noverify/src/php/parser/node"
+)
+
+// nodeSetListMax specifies how much entries we store inside a
+// slice of NodeSet.
+//
+// Using high value is prone to O(N^2) complexity penalty.
+// Lower values mean that we need to allocate a map more often.
+//
+// Using NodeSet for branch if/else conditions and switch cases
+// shows that we can use n=4 or n=5 as a sweet spot.
+//
+// PHP corpus results (if conditions + switch cases):
+//	256131 only slice is used (slice=1 map=0)
+//	56628  only slice is used (slice=2 map=0)
+//	5844   only slice is used (slice=3 map=0)
+//	1637   only slice is used (slice=4 map=0)
+//	788    only slice is used (slice=5 map=0)
+//	395    map is used (slice=5 map=1)
+//	310    map is used (slice=5 map=2)
+//	194    map is used (slice=5 map=3)
+//	146    map is used (slice=5 map=5)
+//	132    map is used (slice=5 map=4)
+//	89     map is used (slice=5 map=6)
+//
+// Note that some cases include 300+ elements which would require
+// us to do 50k+ comparisons during the duplicated switch case analysis.
+// This is why map fallback is needed just to handle pathological cases
+// without unexpected performance degradations.
+//
+// When not using a list with linear search, we use printed AST
+// as a unique key for a map. This is the same thing staticcheck linter does.
+//
+// A comparison of slice-only (old) and hybrid solutions (new):
+//	name            old time/op  new time/op  delta
+//	NodeSet/1-8     9.42ns ± 0%  9.47ns ± 1%     ~     (p=0.222 n=4+5)
+//	NodeSet/5-8      923ns ± 3%   908ns ± 1%     ~     (p=0.159 n=5+4)
+//	NodeSet/6-8     1.38µs ± 2%  2.38µs ± 1%  +72.05%  (p=0.008 n=5+5)
+//	NodeSet/100-8    413µs ± 4%   132µs ± 2%  -68.06%  (p=0.008 n=5+5)
+//	NodeSet/400-8   6.35ms ± 1%  0.55ms ± 2%  -91.41%  (p=0.008 n=5+5)
+//	NodeSet/1000-8  40.4ms ± 0%   1.4ms ± 3%  -96.46%  (p=0.008 n=5+5)
+//
+// Map-only implementation works 5 times slower on the most commons cases (n=1 and n=2).
+const nodeSetListMax = 5
+
+// NodeSet is a set of unique AST nodes.
+//
+// It's possible to avoid allocations in most cases if node set is
+// reused with Reset(). If this is not possible, use newNodeSet()
+// to create a set that can do fewer allocations than a zero value set.
+//
+// NodeSet is not thread-safe, but since Root/Block walkers always operate
+// in isolation, we can share on per RootWalker level.
+type NodeSet struct {
+	list []node.Node
+	m    map[string]struct{}
+}
+
+// newNodeSet returns a node set with preallocated storage.
+//
+// Intended to be used in places where reusing root node set is
+// tricky or impossible (function is reentrant).
+func newNodeSet() NodeSet {
+	return NodeSet{list: make([]node.Node, 0, nodeSetListMax)}
+}
+
+// Reset clears the set state and prepares it for another round.
+func (set *NodeSet) Reset() {
+	set.list = set.list[:0]
+	set.m = nil
+}
+
+// Len returns the number of unique node elements present in the set.
+func (set *NodeSet) Len() int {
+	return len(set.list) + len(set.m)
+}
+
+// Add attempts to insert x into the node set.
+//
+// Returns true if element was inserted.
+// If x is already in the set, false is returned
+// and no insertion is performed.
+func (set *NodeSet) Add(x node.Node) bool {
+	for _, y := range set.list {
+		if NodeEqual(x, y) {
+			return false
+		}
+	}
+	if len(set.list) < nodeSetListMax {
+		set.list = append(set.list, x)
+		return true
+	}
+
+	key := FmtNode(x)
+	if set.m == nil {
+		set.m = map[string]struct{}{}
+	}
+	if _, ok := set.m[key]; ok {
+		return false
+	}
+	set.m[key] = struct{}{}
+	return true
+}

--- a/src/php/astutil/nodeSet_test.go
+++ b/src/php/astutil/nodeSet_test.go
@@ -1,0 +1,59 @@
+package astutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr"
+	"github.com/VKCOM/noverify/src/php/parser/node/name"
+	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
+)
+
+func BenchmarkNodeSet(b *testing.B) {
+	runBench := func(n int) {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			cases := createSwitchCases(n)
+			b.ResetTimer()
+			var nset NodeSet
+			for i := 0; i < b.N; i++ {
+				nset.Reset()
+				for _, c := range cases {
+					if !nset.Add(c) {
+						b.Error("unexpected duplicate reported")
+					}
+				}
+			}
+		})
+	}
+
+	runBench(1)
+	runBench(5)
+	runBench(6)
+	runBench(100)
+	runBench(400)
+	runBench(1000)
+}
+
+func createFQN(parts ...string) *name.FullyQualified {
+	nm := &name.FullyQualified{
+		Parts: make([]node.Node, len(parts)),
+	}
+	for i, s := range parts {
+		nm.Parts[i] = &name.NamePart{Value: s}
+	}
+	return nm
+}
+
+func createSwitchCases(ncases int) []node.Node {
+	cases := make([]node.Node, ncases)
+	for i := range cases {
+		cases[i] = &stmt.Case{
+			Cond: &expr.ClassConstFetch{
+				Class:        createFQN("Namespace", "Foo"),
+				ConstantName: &node.Identifier{Value: fmt.Sprintf("Bar%d", i)},
+			},
+		}
+	}
+	return cases
+}


### PR DESCRIPTION
NodeSet is a set-like data structure that only has 1 method - Add.

Add either adds an element and returns true or it returns false
if element is already in the set. The complexity is amortized to O(1)
due to the map[string] usage, but creating a map key is somewhat expensive.
There is an optimization for small N to make NodeSet alloc-free.

Moved FmtNode from linter package to astutil to avoid circular deps.

As an example of how we can use NodeSet there is a new dupCond check
that checks switch statement case clauses for duplicated entries.
It's planned to also check if-else chains, but it can wait until we
parse "elseif" and "else if" in the same way.

Refs #365

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>