### PR TITLE
add dupBranchBody and dupSubExpr checks

### DIFF
--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -79,6 +79,18 @@ func init() {
 		},
 
 		{
+			Name:    "dupBranchBody",
+			Default: true,
+			Comment: `Report suspicious conditional branches that execute the same action.`,
+		},
+
+		{
+			Name:    "dupSubExpr",
+			Default: true,
+			Comment: `Report suspicious duplicated operands in expressions.`,
+		},
+
+		{
 			Name:    "arraySyntax",
 			Default: true,
 			Comment: `Report usages of old array() syntax.`,

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/php/parser/node"
 	"github.com/VKCOM/noverify/src/php/parser/node/expr"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/binary"
 	"github.com/VKCOM/noverify/src/php/parser/node/name"
 	"github.com/VKCOM/noverify/src/php/parser/node/scalar"
 	"github.com/VKCOM/noverify/src/php/parser/walker"
@@ -320,6 +321,60 @@ func findVarNode(n node.Node) node.Node {
 		return findVarNode(n.Variable)
 	default:
 		return nil
+	}
+}
+
+func binaryOpString(n node.Node) string {
+	switch n.(type) {
+	case *binary.BitwiseAnd:
+		return "&"
+	case *binary.BitwiseOr:
+		return "|"
+	case *binary.BitwiseXor:
+		return "^"
+	case *binary.LogicalAnd:
+		return "and"
+	case *binary.BooleanAnd:
+		return "&&"
+	case *binary.LogicalOr:
+		return "or"
+	case *binary.BooleanOr:
+		return "||"
+	case *binary.LogicalXor:
+		return "xor"
+	case *binary.Plus:
+		return "+"
+	case *binary.Minus:
+		return "-"
+	case *binary.Mul:
+		return "*"
+	case *binary.Div:
+		return "/"
+	case *binary.Mod:
+		return "%"
+	case *binary.Pow:
+		return "**"
+	case *binary.Equal:
+		return "=="
+	case *binary.NotEqual:
+		return "!="
+	case *binary.Identical:
+		return "==="
+	case *binary.NotIdentical:
+		return "!=="
+	case *binary.Smaller:
+		return "<"
+	case *binary.SmallerOrEqual:
+		return "<="
+	case *binary.Greater:
+		return ">"
+	case *binary.GreaterOrEqual:
+		return ">="
+	case *binary.Spaceship:
+		return "<=>"
+
+	default:
+		return ""
 	}
 }
 

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -250,7 +250,7 @@ func TestVoidResultUsedInBinary(t *testing.T) {
 	test.AddFile(`<?php
 	function define($_, $_) {}
 	define('false', 1 == 0);
-	define('true', 1 == 1);
+	define('true', 1 != 0);
 
 	/**
 	 * @return void

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -909,7 +909,7 @@ func TestIssue183(t *testing.T) {
 
 func TestIssue362_1(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
-function method_exists($object, $method_name) { return 1 == 1; }
+function method_exists($object, $method_name) { return 1 != 0; }
 
 class Foo {
   public $value;
@@ -943,7 +943,7 @@ if (method_exists($x, 'x1')) {
 func TestIssue362_2(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
-function method_exists($object, $method_name) { return 1 == 1; }
+function method_exists($object, $method_name) { return 1 != 0; }
 
 class Foo {}
 

--- a/src/linttest/rules_test.go
+++ b/src/linttest/rules_test.go
@@ -294,6 +294,14 @@ func runRulesTest(t *testing.T, test *linttest.Suite, rfile string) {
 	}
 	oldRules := linter.Rules
 	linter.Rules = rset
-	test.RunAndMatch()
+
+	var filtered []*linter.Report
+	for _, r := range test.RunLinter() {
+		if strings.HasPrefix(r.CheckName(), "<test>") {
+			filtered = append(filtered, r)
+		}
+	}
+	test.Match(filtered)
+
 	linter.Rules = oldRules
 }

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -246,6 +246,18 @@ func (m *TypesMap) GobDecode(buf []byte) error {
 	return decoder.Decode(&m.m)
 }
 
+func (m TypesMap) Contains(typ string) bool {
+	if m.Len() == 0 {
+		return false
+	}
+	for typ2 := range m.m {
+		if typ2 == typ {
+			return true
+		}
+	}
+	return false
+}
+
 // Find applies a predicate function to every contained type.
 // If callback returns true for any of them, this is a result of Find call.
 // False is returned if none of the contained types made pred function return true.


### PR DESCRIPTION
dupBranchBody detects two patterns:
```
	1. `if (...) { $x } else { $x }`
	2. `... ? $x : $x`
```

dupSubExpr handles most binary operations, except `+`, `*` and` **`.
Some float-typed expressions are excluded from this list (for example, `$x==$x` can be related to a `NaN` check).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>