### PR TITLE
optimize discardExpr checker

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -2060,7 +2060,14 @@ func (b *BlockWalker) handleStmtExpression(s *stmt.Expression) {
 
 	report := false
 
+	// All branches except default try to filter-out common
+	// cases to reduce the number of type solving performed.
+	if astutil.IsAssign(s.Expr) {
+		return
+	}
 	switch s.Expr.(type) {
+	case *expr.Require, *expr.RequireOnce, *expr.Include, *expr.IncludeOnce, *expr.Exit:
+		// Skip.
 	case *expr.Array, *expr.New:
 		// Report these even if they are not pure.
 		report = true

--- a/src/php/astutil/astutil.go
+++ b/src/php/astutil/astutil.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/VKCOM/noverify/src/php/parser/node"
+	"github.com/VKCOM/noverify/src/php/parser/node/expr/assign"
 	"github.com/VKCOM/noverify/src/php/parser/printer"
 )
 
@@ -19,6 +20,28 @@ func NodeSliceEqual(xs, ys []node.Node) bool {
 		}
 	}
 	return true
+}
+
+func IsAssign(n node.Node) bool {
+	switch n.(type) {
+	case *assign.Assign,
+		*assign.Concat,
+		*assign.Plus,
+		*assign.Reference,
+		*assign.Div,
+		*assign.Pow,
+		*assign.BitwiseAnd,
+		*assign.BitwiseOr,
+		*assign.BitwiseXor,
+		*assign.ShiftLeft,
+		*assign.ShiftRight,
+		*assign.Minus,
+		*assign.Mod,
+		*assign.Mul:
+		return true
+	default:
+		return false
+	}
 }
 
 // FmtNode is used for debug purposes and returns string representation of a specified node.


### PR DESCRIPTION
Do 5 times less calls to typeExpr() in discardExpr checker.

Achieved by filtering-out non-interesting nodes that should
no be checked anyway. Previously, assignment expressions
were rejected at the very last step when we do side-effects
checking. Since assignments are considered impure, we
did not report them in discardExpr.

Now they're rejected before type solving and side effects calculation.

On the test project it lead to 929336 -> 188471 (5 times decrease)
calls to exprType() in handleStmtExpression().

The distribution of handled nodes in a new code (sum=188471):
```
 139362 *expr.FunctionCall
  23551 *expr.StaticCall
  19517 *expr.MethodCall
   3983 *expr.PostInc
    441 *expr.PreInc
    440 *expr.Print
    420 *expr.PostDec
    281 *expr.ErrorSuppress
    236 *binary.LogicalAnd
    118 *expr.PreDec
     56 *binary.LogicalOr
     19 *expr.Ternary
     16 *binary.BooleanOr
     12 *binary.BooleanAnd
      5 *node.SimpleVar
      3 *scalar.String
      2 *expr.Yield
      2 *expr.Eval
      2 *expr.ArrayDimFetch
      2 *binary.Equal
      1 *expr.PropertyFetch
      1 *expr.BooleanNot
      1 *binary.Div
```

We could avoid type solving in cases like node.SimpleVar and always
report them, but it doesn't seem worthwhile.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>