### PR TITLE
meta: 2 bools -> 1 flags field

### DIFF
--- a/src/langsrv/langsrv.go
+++ b/src/langsrv/langsrv.go
@@ -660,7 +660,7 @@ func handleTextDocumentCompletion(req *baseRequest) error {
 		if strings.HasSuffix(chStr, "->") {
 			result = append(result, getMethodCompletionItems(&compl.st, chStr, compl.foundScope)...)
 		} else {
-			compl.foundScope.Iterate(func(varName string, typ meta.TypesMap, alwaysDefined bool) {
+			compl.foundScope.Iterate(func(varName string, typ meta.TypesMap, flags meta.VarFlags) {
 				result = append(result, vscode.CompletionItem{
 					Kind:  vscode.CompletionKindVariable,
 					Label: "$" + varName,

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -193,8 +193,8 @@ func analyzeFile(filename string, contents []byte, parser *php7.Parser, lineRang
 // do not need to call it yourself.
 func AnalyzeFileRootLevel(rootNode node.Node, d *RootWalker) {
 	sc := meta.NewScope()
-	sc.AddVarName("argv", meta.NewTypesMap("string[]"), "predefined", true)
-	sc.AddVarName("argc", meta.NewTypesMap("int"), "predefined", true)
+	sc.AddVarName("argv", meta.NewTypesMap("string[]"), "predefined", meta.VarAlwaysDefined)
+	sc.AddVarName("argc", meta.NewTypesMap("int"), "predefined", meta.VarAlwaysDefined)
 	b := &BlockWalker{
 		ctx:                  &blockContext{sc: sc},
 		r:                    d,

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -304,7 +304,7 @@ func (d *RootWalker) EnterNode(w walker.Walkable) (res bool) {
 			break
 		}
 
-		d.scope().AddVar(v, solver.ExprTypeLocal(d.scope(), d.ctx.st, n.Expression), "global variable", true)
+		d.scope().AddVar(v, solver.ExprTypeLocal(d.scope(), d.ctx.st, n.Expression), "global variable", meta.VarAlwaysDefined)
 	case *stmt.Function:
 		res = d.enterFunction(n)
 		d.checkKeywordCase(n, "function")
@@ -513,7 +513,7 @@ func (d *RootWalker) handleFuncStmts(params []meta.FuncParam, uses, stmts []node
 			typ = meta.NewTypesMap("TODO_use_var")
 		}
 
-		sc.AddVar(v, typ, "use", true)
+		sc.AddVar(v, typ, "use", meta.VarAlwaysDefined)
 
 		if !byRef {
 			b.unusedVars[v.Name] = append(b.unusedVars[v.Name], v)
@@ -752,7 +752,7 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 
 	sc := meta.NewScope()
 	if !modif.static {
-		sc.AddVarName("this", meta.NewTypesMap(d.ctx.st.CurrentClass).Immutable(), "instance method", true)
+		sc.AddVarName("this", meta.NewTypesMap(d.ctx.st.CurrentClass).Immutable(), "instance method", meta.VarAlwaysDefined)
 		sc.SetInInstanceMethod(true)
 	}
 
@@ -810,7 +810,7 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 			res := make(map[string]struct{})
 			res[meta.WrapBaseMethodParam(i, d.ctx.st.CurrentClass, nm)] = struct{}{}
 			params[i].Typ = meta.NewTypesMapFromMap(res)
-			sc.AddVarName(p.Name, params[i].Typ, "param", true)
+			sc.AddVarName(p.Name, params[i].Typ, "param", meta.VarAlwaysDefined)
 		}
 	}
 
@@ -1016,7 +1016,7 @@ func (d *RootWalker) parseFuncArgs(params []node.Node, parTypes phpDocParamsMap,
 		parTyp := parTypes[v.Name]
 
 		if !parTyp.typ.IsEmpty() {
-			sc.AddVarName(v.Name, parTyp.typ, "param", true)
+			sc.AddVarName(v.Name, parTyp.typ, "param", meta.VarAlwaysDefined)
 		}
 
 		typ := parTyp.typ
@@ -1039,7 +1039,7 @@ func (d *RootWalker) parseFuncArgs(params []node.Node, parTypes phpDocParamsMap,
 			typ = arrTyp
 		}
 
-		sc.AddVarName(v.Name, typ, "param", true)
+		sc.AddVarName(v.Name, typ, "param", meta.VarAlwaysDefined)
 
 		par := meta.FuncParam{
 			Typ:   typ.Immutable(),

--- a/src/linttest/bench_test.go
+++ b/src/linttest/bench_test.go
@@ -60,7 +60,7 @@ class Foo {
 	st := &meta.ClassParseState{}
 	sc := meta.NewScope()
 
-	sc.AddVarName("foo", meta.NewTypesMap(`\Foo|int|null`), "test", true)
+	sc.AddVarName("foo", meta.NewTypesMap(`\Foo|int|null`), "test", meta.VarAlwaysDefined)
 
 	b.Run("simplevar", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -270,8 +270,8 @@ func (i *info) AddConstantsNonLocked(filename string, m ConstantsMap) {
 }
 
 func (i *info) AddToGlobalScopeNonLocked(filename string, sc *Scope) {
-	sc.Iterate(func(nm string, typ TypesMap, alwaysDefined bool) {
-		i.AddVarName(nm, typ, "global", alwaysDefined)
+	sc.Iterate(func(nm string, typ TypesMap, flags VarFlags) {
+		i.AddVarName(nm, typ, "global", flags)
 	})
 }
 

--- a/src/solver/solver_test.go
+++ b/src/solver/solver_test.go
@@ -28,7 +28,7 @@ func TestSolver(t *testing.T) {
 	tm := meta.NewTypesMap
 
 	sc := meta.NewScope()
-	sc.AddVarName("MC", tm("Memcache"), "global", true)
+	sc.AddVarName("MC", tm("Memcache"), "global", meta.VarAlwaysDefined)
 
 	fm := meta.NewFunctionsMap()
 	fm.Set(`\array_map`, meta.FuncInfo{Typ: tm(`array|bool|` + meta.WrapFunctionCall(`\my_func`))})


### PR DESCRIPTION
Adding a new bool field would require us to add 1 parameter
to every scope function and a call could look like (false, true, false)
which is not very readable. With flags, it can look a little better.

The NoReplace flag is unexported, so the callers from other packages can't set
that flag just as before.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>