### PR TITLE
linter: bump cache version to 37

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -34,7 +34,8 @@ import (
 //          FuncInfo now stores original function name
 //          ClassInfo now stores original class name
 //     37 - added ClassShape bit to ClassFlags
-const cacheVersion = 36
+//          changed meta.scopeVar bool fields representation
+const cacheVersion = 37
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")


### PR DESCRIPTION
We changed the interpretation of scopeVar fields.

Since previous cache change missed version increase as well,
merge both and increase the version by one.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>