### PR TITLE
linter: add LevelSecurity severity level

### DIFF
--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -207,6 +207,7 @@ const (
 	LevelUnused      = lintapi.LevelUnused
 	LevelDoNotReject = lintapi.LevelMaybe
 	LevelSyntax      = lintapi.LevelSyntax
+	LevelSecurity    = lintapi.LevelSecurity // Like warning, but reported without a context line
 )
 
 var vscodeLevelMap = map[int]int{
@@ -216,6 +217,7 @@ var vscodeLevelMap = map[int]int{
 	LevelHint:        vscode.Hint,
 	LevelUnused:      vscode.Information,
 	LevelDoNotReject: vscode.Warning,
+	LevelSecurity:    vscode.Warning,
 	// LevelSyntax is intentionally not included here
 }
 
@@ -227,6 +229,7 @@ var severityNames = map[int]string{
 	LevelUnused:      "UNUSED ",
 	LevelDoNotReject: "MAYBE  ",
 	LevelSyntax:      "SYNTAX ",
+	LevelSecurity:    "WARNING",
 }
 
 var (

--- a/src/linter/lintapi/lintapi.go
+++ b/src/linter/lintapi/lintapi.go
@@ -17,4 +17,5 @@ const (
 	LevelUnused      = 5
 	LevelMaybe       = 6 // do not treat this warning as a reason to reject if we get this kind of warning
 	LevelSyntax      = 7
+	LevelSecurity    = 8
 )

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -287,6 +287,16 @@ func (r *Report) MarshalJSON() ([]byte, error) {
 }
 
 func (r *Report) String() string {
+	msg := r.msg
+	if r.checkName != "" {
+		msg = r.checkName + ": " + msg
+	}
+
+	// No context line for security-level warnings.
+	if r.level == LevelSecurity {
+		return fmt.Sprintf("%s %s at %s:%d", severityNames[r.level], msg, r.filename, r.startLine)
+	}
+
 	contextLn := strings.Builder{}
 	for i, ch := range r.startLn {
 		if i == r.startChar {
@@ -301,11 +311,6 @@ func (r *Report) String() string {
 
 	if r.endChar > r.startChar {
 		contextLn.WriteString(strings.Repeat("^", r.endChar-r.startChar))
-	}
-
-	msg := r.msg
-	if r.checkName != "" {
-		msg = r.checkName + ": " + msg
 	}
 	return fmt.Sprintf("%s %s at %s:%d\n%s\n%s", severityNames[r.level], msg, r.filename, r.startLine, r.startLn, contextLn.String())
 }


### PR DESCRIPTION
Behaves like LevelWarning, reported warnings do not contain
a context string or a source code line to avoid sensitive
information leaking to things like CI agent logs, etc.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>