### PR TITLE
meta: add type precision info to a types map

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -477,9 +477,7 @@ func (b *BlockWalker) handleReturn(ret *stmt.Return) {
 	b.returnsValue = true
 
 	typ := solver.ExprTypeLocalCustom(b.ctx.sc, b.r.ctx.st, ret.Expr, b.ctx.customTypes)
-	typ.Iterate(func(t string) {
-		b.returnTypes = b.returnTypes.AppendString(t)
-	})
+	b.returnTypes = b.returnTypes.Append(typ)
 }
 
 func (b *BlockWalker) handleLogicalOr(or *binary.LogicalOr) bool {

--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -35,7 +35,9 @@ import (
 //          ClassInfo now stores original class name
 //     37 - added ClassShape bit to ClassFlags
 //          changed meta.scopeVar bool fields representation
-const cacheVersion = 37
+//     38 - replaced TypesMap.immutable:bool with flags:uint8.
+//          added mapPrecise flag to mark precise type maps.
+const cacheVersion = 38
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")


### PR DESCRIPTION
The new `TypesMap.IsPrecise()` can be used to determine if
type info is precise enough to perform typecheck-like analysis.

Right now we are quite conservative and create precise types
for language operations that have a predictable result type:

```
	- Operators that return a single type in all situations.
	  We avoid `int|float` operations like `+`, since
	  the result may depend on how well we infer the
	  LHS/RHS operand type.

	- new() expressions where the class name is known.
```

It's planned to favor the lack of false positives for IsPrecise
rather than false negatives, so some precise types may still
be reported as imprecise and the linter will not perform the
analyzis that requires precise types info.

An example of such analysis is function parameter type checking
and operands type checking. It can also be useful in currently
disabled redundantCast check that may suggest incorrect code
changes just because our type inference can't be precise
in 100% of situations.

To avoid having 2 bools (and maybe more later on), `immutable` field is replaced with uint8 flags.

New IsResolved() function is used to avoid excessive types resolving.
If a type does not contain any lazy types, there is no need to do additional computations.

I did some experiments and found that around 50% of type solving
can be avoided if we don't to `resolveTypes()` on type maps that
are free of lazy types.

For this PR, to make it easier to review, only partial implementation
of IsResolved() is provided that is based on IsPrecise() invariant.
This alone gives us a 27% win.

In exact numbers (on some big PHP project):
```
	 532695 avoided types resolving  (27%)
	1984584 repeated types resolving (73%)
```

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>