### PR TITLE
linter: add precedence checker

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -206,13 +206,9 @@ func (b *BlockWalker) EnterNode(w walker.Walkable) (res bool) {
 		b.handleStmtExpression(s)
 
 	case *binary.BitwiseAnd:
-		b.checkBinaryVoidType(s.Left, s.Right)
-		b.checkBinaryDupArgs(s, s.Left, s.Right)
-		b.handleBitwiseAnd(s)
+		b.handleBitwiseOp(s, s.Left, s.Right)
 	case *binary.BitwiseOr:
-		b.checkBinaryVoidType(s.Left, s.Right)
-		b.checkBinaryDupArgs(s, s.Left, s.Right)
-		b.handleBitwiseOr(s)
+		b.handleBitwiseOp(s, s.Left, s.Right)
 	case *binary.BitwiseXor:
 		b.checkBinaryVoidType(s.Left, s.Right)
 		b.checkBinaryDupArgs(s, s.Left, s.Right)
@@ -2047,21 +2043,52 @@ func (b *BlockWalker) handleAssignList(items []*expr.ArrayItem) {
 	}
 }
 
-func (b *BlockWalker) handleBitwiseAnd(s *binary.BitwiseAnd) {
-	if b.isBool(s.Left) && b.isBool(s.Right) {
-		b.ReportBitwiseOp(s, "&", "&&")
-	}
-}
+func (b *BlockWalker) handleBitwiseOp(n, left, right node.Node) {
+	// Note: we report `$x & $mask != $y` as a precedence issue even
+	// if it can be caught with `typecheckOp` that checks both operand
+	// types (bool is not a good operand for bitwise operation).
+	//
+	// Reporting `invalid types, expected number found bool` is
+	// not that helpful, because the root of the problem is precedence.
+	// Invalid types are a result of that.
 
-func (b *BlockWalker) handleBitwiseOr(s *binary.BitwiseOr) {
-	if b.isBool(s.Left) && b.isBool(s.Right) {
-		b.ReportBitwiseOp(s, "|", "||")
+	tok := "|"
+	if _, ok := n.(*binary.BitwiseAnd); ok {
+		tok = "&"
 	}
-}
 
-func (b *BlockWalker) ReportBitwiseOp(s node.Node, op string, rightOp string) {
-	b.r.Report(s, LevelWarning, "bitwiseOps",
-		"Used %s bitwise op over bool operands, perhaps %s is intended?", op, rightOp)
+	hasParens := func(n node.Node) bool {
+		return findFreeFloatingToken(n, freefloating.Start, "(") ||
+			findFreeFloatingToken(n, freefloating.End, ")")
+	}
+	checkArg := func(n, arg node.Node, tok string) {
+		cmpTok := ""
+		switch arg.(type) {
+		case *binary.Equal:
+			cmpTok = "=="
+		case *binary.NotEqual:
+			cmpTok = "!="
+		case *binary.Identical:
+			cmpTok = "==="
+		case *binary.NotIdentical:
+			cmpTok = "!=="
+		}
+		if cmpTok != "" && !hasParens(arg) {
+			b.r.Report(n, LevelWarning, "precedence", "%s has higher precedence than %s", cmpTok, tok)
+		}
+	}
+
+	b.checkBinaryDupArgs(n, left, right)
+	b.checkBinaryVoidType(left, right)
+
+	if b.exprType(left).Is("bool") && b.exprType(right).Is("bool") {
+		b.r.Report(n, LevelWarning, "bitwiseOps",
+			"Used %s bitwise op over bool operands, perhaps %s is intended?", tok, tok+tok)
+		return
+	}
+	checkArg(n, left, tok)
+	checkArg(n, right, tok)
+
 }
 
 func (b *BlockWalker) handleStmtExpression(s *stmt.Expression) {
@@ -2281,10 +2308,6 @@ func (b *BlockWalker) caseHasFallthroughComment(n node.Node) bool {
 
 func (b *BlockWalker) sideEffectFree(n node.Node) bool {
 	return sideEffectFree(b.ctx.sc, b.r.ctx.st, b.ctx.customTypes, n)
-}
-
-func (b *BlockWalker) isBool(n node.Node) bool {
-	return b.exprType(n).Is("bool")
 }
 
 func (b *BlockWalker) isVoid(n node.Node) bool {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -25,6 +25,12 @@ func init() {
 		},
 
 		{
+			Name:    "precedence",
+			Default: true,
+			Comment: `Report potential operation precedence issues.`,
+		},
+
+		{
 			Name:    "voidResultUsed",
 			Default: true,
 			Comment: `Report usages of the void-type expressions`,

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -7,6 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/VKCOM/noverify/src/meta"
+	"github.com/VKCOM/noverify/src/php/parser/freefloating"
 	"github.com/VKCOM/noverify/src/php/parser/node"
 	"github.com/VKCOM/noverify/src/php/parser/node/expr"
 	"github.com/VKCOM/noverify/src/php/parser/node/expr/binary"
@@ -285,6 +286,22 @@ func binaryOpString(n node.Node) string {
 	default:
 		return ""
 	}
+}
+
+func findFreeFloatingToken(n node.Node, pos freefloating.Position, s string) bool {
+	ff := n.GetFreeFloating()
+	if ff == nil {
+		return false
+	}
+	for _, tok := range (*ff)[pos] {
+		if tok.StringType != freefloating.TokenType {
+			continue
+		}
+		if tok.Value == s {
+			return true
+		}
+	}
+	return false
 }
 
 // List taken from https://wiki.php.net/rfc/context_sensitive_lexer

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -403,6 +403,98 @@ func TestFuncComplexity(t *testing.T) {
 	test.RunAndMatch()
 }
 
+func TestPrecedenceBadLHS(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function lhs($x, $mask) {
+  $_ = 0 == $mask & $x;
+  $_ = 0 != $mask & $x;
+  $_ = 0 === $mask & $x;
+  $_ = 0 !== $mask & $x;
+
+  $_ = 0 == $mask | $x;
+  $_ = 0 != $mask | $x;
+  $_ = 0 === $mask | $x;
+  $_ = 0 !== $mask | $x;
+}
+`)
+	test.Expect = []string{
+		`== has higher precedence than &`,
+		`!= has higher precedence than &`,
+		`=== has higher precedence than &`,
+		`!== has higher precedence than &`,
+		`== has higher precedence than |`,
+		`!= has higher precedence than |`,
+		`=== has higher precedence than |`,
+		`!== has higher precedence than |`,
+	}
+	test.RunAndMatch()
+}
+
+func TestPrecedenceBadRHS(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function rhs($x, $mask) {
+  $_ = $x & $mask == 0;
+  $_ = $x & $mask != 0;
+  $_ = $x & $mask === 0;
+  $_ = $x & $mask !== 0;
+
+  $_ = $x | $mask == 0;
+  $_ = $x | $mask != 0;
+  $_ = $x | $mask === 0;
+  $_ = $x | $mask !== 0;
+}
+`)
+	test.Expect = []string{
+		`== has higher precedence than &`,
+		`!= has higher precedence than &`,
+		`=== has higher precedence than &`,
+		`!== has higher precedence than &`,
+		`== has higher precedence than |`,
+		`!= has higher precedence than |`,
+		`=== has higher precedence than |`,
+		`!== has higher precedence than |`,
+	}
+	test.RunAndMatch()
+}
+
+func TestPrecedenceGood(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+function foo() { return 10; }
+
+function rhs($x, $mask) {
+  $_ = ($x & $mask) == 0;
+  $_ = ($x & $mask) != 0;
+  $_ = ($x & $mask) === 0;
+  $_ = ($x & $mask) !== 0;
+
+  $_ = ($x | $mask) == 0;
+  $_ = ($x | $mask) != 0;
+  $_ = ($x | $mask) === 0;
+  $_ = ($x | $mask) !== 0;
+
+  $_ = 0x02 | (($x & $mask) != 0);
+  $_ = 0x02 & (foo() !== 0);
+}
+
+function lhs($x, $mask) {
+  $_ = 0 == ($mask & $x);
+  $_ = 0 != ($mask & $x);
+  $_ = 0 === ($mask & $x);
+  $_ = 0 !== ($mask & $x);
+
+  $_ = 0 == ($mask | $x);
+  $_ = 0 != ($mask | $x);
+  $_ = 0 === ($mask | $x);
+  $_ = 0 !== ($mask | $x);
+
+  $_ = (($x & $mask) != 0) | 0x02;
+  $_ = (foo() !== 0) & 0x02;
+}
+`)
+}
+
 func TestBitwiseOps(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
```
A precedence checker detects suspicious expressions
that may behave incorrectly due to the precedence issues.

Right now it only handles & and | with ==/!=/===/!===,
but it may also cover ternary operator patterns in future.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
```