### PR TITLE
phpdoc: parse "()" as parens with invalid expr

### DIFF
--- a/src/phpdoc/type_parser.go
+++ b/src/phpdoc/type_parser.go
@@ -199,6 +199,12 @@ func (p *TypeParser) parseExpr(precedence byte) *TypeExpr {
 		elem := p.parseExpr(prefixPrecedenceTab['['])
 		left = p.newExprShape(ExprArray, ShapeArrayPrefix, begin, uint16(p.pos), elem)
 	case ch == '(':
+		if p.peek() == ')' {
+			p.pos++
+			expr := p.newExpr(ExprInvalid, begin+1, begin+1)
+			left = p.newExpr(ExprParen, begin, uint16(p.pos), expr)
+			break
+		}
 		expr := p.parseExpr(0)
 		if p.peek() == ')' {
 			p.pos++

--- a/src/phpdoc/type_parser_test.go
+++ b/src/phpdoc/type_parser_test.go
@@ -29,6 +29,7 @@ func TestParser(t *testing.T) {
 		// Parens.
 		{`(x)`, `Paren="(x)"{Name="x"}`},
 		{`((x))`, `Paren="((x))"{Paren="(x)"{Name="x"}}`},
+		{`()`, `Paren="()"{Invalid=""}`},
 
 		// Unclosed parens.
 		{`(x`, `Paren="(x"{Name="x"}`},
@@ -114,9 +115,9 @@ func TestParser(t *testing.T) {
 		{`x [ ][  ]`, `Array="x [ ][  ]"{Array="x [ ]"{Name="x"}}`},
 
 		// If no postfix/infix token is found, the parser stops.
-		// Maybe we need to consume rest of the input as "Unknown"?
 		{`x?y`, `Optional="x?"{Name="x"}`},
 		{`x[]y`, `Array="x[]"{Name="x"}`},
+		{`() $x`, `Paren="()"{Invalid=""}`},
 
 		// Unknown expressions.
 		{`-foo`, `Unknown="-foo"{Name="foo"}`},


### PR DESCRIPTION
Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>