### PR TITLE
phpdoc: stop parsing invalid expr at whitespace

### DIFF
--- a/src/phpdoc/type_parser.go
+++ b/src/phpdoc/type_parser.go
@@ -232,7 +232,7 @@ func (p *TypeParser) parseExpr(precedence byte) *TypeExpr {
 			// Stop if we found infix or postfix token and emit invalid expr.
 			// Stop if we found something that looks like a terminating token.
 			ch := p.peek()
-			if infixPrecedenceTab[ch] != 0 || ch == ')' || ch == '>' || ch == ']' {
+			if infixPrecedenceTab[ch] != 0 || ch == ')' || ch == '>' || ch == ']' || ch == ' ' {
 				left = p.newExpr(ExprInvalid, begin, uint16(p.pos))
 				break
 			}

--- a/src/phpdoc/type_parser_test.go
+++ b/src/phpdoc/type_parser_test.go
@@ -118,6 +118,10 @@ func TestParser(t *testing.T) {
 		{`x?y`, `Optional="x?"{Name="x"}`},
 		{`x[]y`, `Array="x[]"{Name="x"}`},
 		{`() $x`, `Paren="()"{Invalid=""}`},
+		{`@ @`, `Invalid="@"`},
+		{`@ @ | x`, `Invalid="@"`},
+		{`@ @| x`, `Invalid="@"`},
+		{`x| @ @`, `Union="x| @"{Name="x" Invalid="@"}`},
 
 		// Unknown expressions.
 		{`-foo`, `Unknown="-foo"{Name="foo"}`},
@@ -128,10 +132,6 @@ func TestParser(t *testing.T) {
 		{`@`, `Invalid="@"`},
 		{`@#%`, `Invalid="@#%"`},
 		{`x|@`, `Union="x|@"{Name="x" Invalid="@"}`},
-		{`@ @`, `Invalid="@ @"`},
-		{`@ @ | x`, `Union="@ @ | x"{Invalid="@ @ " Name="x"}`},
-		{`@ @| x`, `Union="@ @| x"{Invalid="@ @" Name="x"}`},
-		{`x| @ @`, `Union="x| @ @"{Name="x" Invalid="@ @"}`},
 		{`x|@@`, `Union="x|@@"{Name="x" Invalid="@@"}`},
 		{`A<|b`, `Generic="A<|b"{Name="A" Unknown="|b"{Name="b"}}`},
 		{`A<,>`, `Generic="A<,>"{Name="A" Invalid=","}`},


### PR DESCRIPTION
"@ @" should be parsed as Invalid="@" and rest " @"
should be left as unconsumed input.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>