### PR TITLE
refactor phpdoc parsing

### DIFF
--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -75,6 +75,69 @@ function mixed_info1(int $v) {
 	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
 }
 
+func TestExprTypeWithSpaces(t *testing.T) {
+	tests := []exprTypeTest{
+		{`shape_param1($v)`, `int`},
+		{`shape_param2($v)`, `float`},
+		{`array_param3($v)`, `int`},
+		{`array_param4($v)`, `float`},
+
+		{`$var1['y']`, `int[]`},
+		{`$var2['z']`, `float[]`},
+
+		{`shape_return1()['x']`, `string`},
+
+		{`$foo->prop1`, `int[]`},
+		{`$foo->prop2`, `string[]`},
+		{`$foo->prop3`, `float[]`},
+		{`$foo->magicprop1['k1']`, `\Foo`},
+		{`$foo->magicprop1['k2']`, `string`},
+	}
+
+	global := `<?php
+/**
+ * @property $magicprop1 shape( k1: \Foo , k2 : string )
+ */
+class Foo {
+  /** @var array<string, int> */
+  public $prop1;
+
+  /** @var $prop2 array< string, string> */
+  public $prop2;
+
+  /** @var array< string , float > $prop3 */
+  public $prop3;
+}
+
+/** @param shape(a: int, b:float) $x */
+function shape_param1($x) { return $x['a']; }
+
+/** @param shape(a: int, b:float) $x */
+function shape_param2($x) { return $x['b']; }
+
+/** @param $x array{a: int, b: float} */
+function array_param3($x) { return $x['a']; }
+
+/** @param $x array{a : int, b:float} */
+function array_param4($x) { return $x['b']; }
+
+/** @return shape( x : string ) */
+function shape_return1() {}
+`
+
+	local := `
+/** @var shape< y : int[] > $var1 */
+$var1;
+
+/** @var $var2 shape< z : float[] > */
+$var2;
+
+$foo = new Foo();
+`
+
+	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
+}
+
 func TestExprTypeShape(t *testing.T) {
 	tests := []exprTypeTest{
 		{`shape_self0()`, `\shape$exprtype_global.php$0$`},

--- a/src/phpdoc/type_parser.go
+++ b/src/phpdoc/type_parser.go
@@ -9,11 +9,13 @@ type Type struct {
 	Expr   TypeExpr
 }
 
-func (t Type) Clone() Type {
-	return Type{Source: t.Source, Expr: t.Expr.Clone()}
+func (typ Type) Clone() Type {
+	return Type{Source: typ.Source, Expr: typ.Expr.Clone()}
 }
 
 func (typ Type) String() string { return typ.Source }
+
+func (typ Type) IsEmpty() bool { return typ.Expr.Value == "" }
 
 type TypeExpr struct {
 	Kind  ExprKind

--- a/src/phpdoc/type_parser_test.go
+++ b/src/phpdoc/type_parser_test.go
@@ -11,6 +11,8 @@ func TestParser(t *testing.T) {
 		input string
 		want  string
 	}{
+		{``, `Invalid=""`},
+
 		// Names.
 		{`a`, `Name="a"`},
 		{`\`, `Name="\"`},

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -95,8 +95,9 @@ func (p *parser) parseRule(st node.Node) error {
 	var filterSet map[string]Filter
 	dst := p.res.Any // Use "any" set by default
 
-	for _, part := range phpdoc.Parse(comment) {
-		switch part.Name {
+	for _, part := range phpdoc.Parse(p.typeParser, comment) {
+		part := part.(*phpdoc.RawCommentPart)
+		switch part.Name() {
 		case "name":
 			if len(part.Params) != 1 {
 				return p.errorf(st, "@name expects exactly 1 param, got %d", len(part.Params))
@@ -185,7 +186,7 @@ func (p *parser) parseRule(st node.Node) error {
 			filterSet[name] = filter
 
 		default:
-			return p.errorf(st, "unknown attribute @%s on line %d", part.Name, part.Line)
+			return p.errorf(st, "unknown attribute @%s on line %d", part.Name(), part.Line())
 		}
 	}
 


### PR DESCRIPTION
phpdoc.Parse now returns a more structured result.

It does handle both `<$var, type>` and `<type, $var>` order
for param/var/property annotations.

Types are parsed with TypeParser, so we don't need to shrink
type strings anymore. It also fixes T{} and T() type expressions
that were not handled by whitespace shrinking code before
(it only handled <> pairs).

Refs #344

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>