### PR TITLE
linter: add redundantGlobal checker

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -288,6 +288,9 @@ func (b *BlockWalker) EnterNode(w walker.Walkable) (res bool) {
 			if nm == "" {
 				continue
 			}
+			if _, ok := superGlobals[nm]; ok {
+				b.r.Report(v, LevelWarning, "redundantGlobal", "%s is superglobal", nm)
+			}
 			b.addVar(v, meta.NewTypesMap(meta.WrapGlobal(nm)), "global", meta.VarAlwaysDefined)
 			b.addNonLocalVar(v)
 		}

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -55,6 +55,12 @@ func init() {
 		},
 
 		{
+			Name:    "redundantGlobal",
+			Default: true,
+			Comment: `Report global statement over superglobal variables (which is redundant).`,
+		},
+
+		{
 			Name:    "arrayAccess",
 			Default: true,
 			Comment: `Report array access to non-array objects.`,

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -10,6 +10,33 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestRedundantGlobal(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+$foo = 0;
+
+function f1() {
+  global $GLOBALS;
+  global $_GET;
+  global $foo; // OK
+  return $foo;
+}
+
+function f2() {
+  global $_POST, $foo, $_ENV;
+  return $foo;
+}
+`)
+	// A full warning message is `redundantGlobal: $varname is superglobal`.
+	test.Expect = []string{
+		`GLOBALS is superglobal`,
+		`_GET is superglobal`,
+		`_POST is superglobal`,
+		`_ENV is superglobal`,
+	}
+	test.RunAndMatch()
+}
+
 func TestForeachEmpty(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
`global $superglobal` is redundant and should not be used.

https://www.php.net/manual/en/language.variables.superglobals.php

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>