### PR TITLE
linter: validate @see references

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1440,7 +1440,7 @@ func (b *BlockWalker) enterClosure(fun *expr.Closure, haveThis bool, thisType me
 		sc.AddVarName("this", meta.NewTypesMap("possibly_late_bound"), "possibly late bound $this", meta.VarAlwaysDefined)
 	}
 
-	doc := b.r.parsePHPDoc(fun.PhpDocComment, fun.Params)
+	doc := b.r.parsePHPDoc(fun, fun.PhpDocComment, fun.Params)
 	b.r.reportPhpdocErrors(fun, doc.errs)
 	phpDocParamTypes := doc.types
 

--- a/src/linter/phpdoc_test.go
+++ b/src/linter/phpdoc_test.go
@@ -59,10 +59,10 @@ func TestParseClassPHPDoc(t *testing.T) {
 	}
 
 	st := &meta.ClassParseState{}
-	ctx := newRootContext(st)
+	walker := RootWalker{ctx: newRootContext(st)}
 	for _, test := range tests {
 		doc := fmt.Sprintf(`/** %s */`, test.line)
-		result := parseClassPHPDoc(&ctx, doc)
+		result := walker.parseClassPHPDoc(nil, doc)
 
 		switch {
 		case test.method != "":

--- a/src/linter/phpdoc_util.go
+++ b/src/linter/phpdoc_util.go
@@ -27,31 +27,6 @@ type classPhpDocParseResult struct {
 	errs       phpdocErrors
 }
 
-func parseClassPHPDoc(ctx *rootContext, doc string) classPhpDocParseResult {
-	var result classPhpDocParseResult
-
-	if doc == "" {
-		return result
-	}
-
-	// TODO: allocate maps lazily.
-	// Class may not have any @property or @method annotations.
-	// In that case we can handle avoid map allocations.
-	result.properties = make(meta.PropertiesMap)
-	result.methods = meta.NewFunctionsMap()
-
-	for _, part := range phpdoc.Parse(ctx.phpdocTypeParser, doc) {
-		switch part.Name() {
-		case "property":
-			parseClassPHPDocProperty(ctx, &result, part.(*phpdoc.TypeVarCommentPart))
-		case "method":
-			parseClassPHPDocMethod(ctx, &result, part.(*phpdoc.RawCommentPart))
-		}
-	}
-
-	return result
-}
-
 func parseClassPHPDocMethod(ctx *rootContext, result *classPhpDocParseResult, part *phpdoc.RawCommentPart) {
 	// The syntax is:
 	//	@method [[static] return type] [name]([[type] [parameter]<, ...>]) [<description>]

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -145,6 +145,12 @@ func init() {
 		},
 
 		{
+			Name:    "phpdocRef",
+			Default: true,
+			Comment: `Report invalid symbol references inside phpdoc.`,
+		},
+
+		{
 			Name:    "phpdoc",
 			Default: true,
 			Comment: `Report missing phpdoc on public methods.`,

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -234,6 +234,25 @@ func findVarNode(n node.Node) node.Node {
 	}
 }
 
+func classHasProp(className, propName string) bool {
+	var nameWithDollar string
+	var nameWithoutDollar string
+	if strings.HasPrefix(propName, "$") {
+		nameWithDollar = propName
+		nameWithoutDollar = strings.TrimPrefix(propName, "$")
+	} else {
+		nameWithDollar = "$" + propName
+		nameWithoutDollar = propName
+	}
+
+	// Static props stored with leading "$".
+	if _, ok := solver.FindProperty(className, nameWithDollar); ok {
+		return true
+	}
+	_, ok := solver.FindProperty(className, nameWithoutDollar)
+	return ok
+}
+
 func binaryOpString(n node.Node) string {
 	switch n.(type) {
 	case *binary.BitwiseAnd:

--- a/src/linttest/testdata/flysystem/golden.txt
+++ b/src/linttest/testdata/flysystem/golden.txt
@@ -4,6 +4,12 @@ MAYBE   regexpSimplify: May re-write '/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/' as '/^\d{
 MAYBE   regexpSimplify: May re-write '/^total [0-9]*$/' as '/^total \d*$/' at testdata/flysystem/src/Adapter/Ftp.php:407
         if (preg_match('/^total [0-9]*$/', $listing[0])) {
                        ^^^^^^^^^^^^^^^^^^
+WARNING phpdocRef: line 8: @see tag refers to unknown symbol League\Flysystem\ReadInterface::readStream at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:19
+    public function readStream($path)
+                    ^^^^^^^^^^
+WARNING phpdocRef: line 8: @see tag refers to unknown symbol League\Flysystem\ReadInterface::read at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:43
+    abstract public function read($path);
+                             ^^^^
 MAYBE   phpdoc: Missing PHPDoc for "write" public method at testdata/flysystem/src/Adapter/Polyfill/StreamedWritingTrait.php:58
     abstract public function write($pash, $contents, Config $config);
                              ^^^^^


### PR DESCRIPTION
phpdocRef is slightly pickier than PhpStorm reference
resolving as it does not permit referencing a type from
another namespace by incorrect relative name.

On the other side, if PhpStorm can't resolve the link,
phpdocRef will give a warning for sure.

The intention is to make it easier to keep @see code
references precise and up to date.

New warnings in flysystem are due to the relative namespace
reference is used: `League\Flysystem\ReadInterface` should be
`\League\Flysystem\ReadInterface` (with leading `\`).
PhpStorm can't resolve this reference either.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>