### PR TITLE
linter: report non-strict comparison with true, false and null

### DIFF
--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -10,6 +10,44 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestStrictCmp(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{`stubs/phpstorm-stubs/Core/Core_d.php`}
+	test.AddFile(`<?php
+function f($x) {
+  $_ = ($x == false);
+  $_ = (false == $x);
+  $_ = ($x == true);
+  $_ = (true == $x);
+  $_ = ($x == null);
+  $_ = (null == $x);
+  return true;
+}
+
+$_ = (f(0) != false);
+$_ = (false != f(0));
+$_ = (f(0) != true);
+$_ = (true != f(0));
+$_ = (f(0) != null);
+$_ = (null != f(0));
+`)
+	test.Expect = []string{
+		`non-strict comparison with false (use ===)`,
+		`non-strict comparison with false (use ===)`,
+		`non-strict comparison with false (use !==)`,
+		`non-strict comparison with false (use !==)`,
+		`non-strict comparison with true (use ===)`,
+		`non-strict comparison with true (use ===)`,
+		`non-strict comparison with true (use !==)`,
+		`non-strict comparison with true (use !==)`,
+		`non-strict comparison with null (use ===)`,
+		`non-strict comparison with null (use ===)`,
+		`non-strict comparison with null (use !==)`,
+		`non-strict comparison with null (use !==)`,
+	}
+	test.RunAndMatch()
+}
+
 func TestRedundantGlobal(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
New strictCmp checker suggests using a strict comparison
when comparing something with ==/!= against true/false/null consts.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>