### PR TITLE
linter: add tuple type support

### DIFF
--- a/src/linter/types.go
+++ b/src/linter/types.go
@@ -159,21 +159,17 @@ func (conv *phpdocTypeConverter) mapTupleType(params []phpdoc.TypeExpr) []meta.T
 		if p.Value == "*" || p.Value == "..." {
 			continue
 		}
-		if p.Kind != phpdoc.ExprName && p.Kind != phpdoc.ExprGeneric {
-			conv.warn(fmt.Sprintf("tuple param #%d: want type, found %s", i+1, p.Value))
-			continue
-		}
 
-		args := []phpdoc.TypeExpr{
-			phpdoc.TypeExpr{
-				Kind:  phpdoc.ExprInt,
-				Value: fmt.Sprint(i),
-			}, p}
+		key := phpdoc.TypeExpr{
+			Kind:  phpdoc.ExprInt,
+			Value: fmt.Sprint(i),
+		}
+		typ := p
+		args := []phpdoc.TypeExpr{key, typ}
 
 		typeExpr := phpdoc.TypeExpr{
-			Kind:  phpdoc.ExprKeyVal,
-			Value: fmt.Sprintf("%d:%s", i, p.Value),
-			Args:  args,
+			Kind: phpdoc.ExprKeyVal,
+			Args: args,
 		}
 		types = append(types, typeExpr)
 	}

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -166,6 +166,12 @@ func TestExprTypeShape(t *testing.T) {
 
 		// Optional keys are resolved identically.
 		{`$opt['x']`, `\Foo\Bar`},
+
+		{`$t0[0]`, `int`},
+		{`$t0['1']`, `float`},
+		{`$t1[0]`, `string`},
+		{`$t1[1]['b']`, `bool`},
+		{`$t1[1]['t'][1]`, `float`},
 	}
 
 	global := `<?php
@@ -193,6 +199,13 @@ function shape_intkey($s) { return $s; }
 
 /** @return shape(*) */
 function shape(array $a) { return $a; }
+
+
+/** @param $t tuple(int, float) */
+function tuple_self0($t) { return $t; }
+
+/** @param $t tuple(string, shape(b:bool, t:tuple(int, float))) */
+function tuple_self1($t) { return $t; }
 `
 	local := `
 $s0 = shape_self0(shape(['x' => 1, 'y' => 1.5]));
@@ -200,6 +213,8 @@ $s2 = shape_self2(shape([]));
 $s3 = shape_self3(shape([]));
 $si = shape_intkey(shape([]));
 $opt = optional_shape(shape([]));
+$t0 = tuple_self0(tuple([]));
+$t1 = tuple_self1(tuple([]));
 `
 	runExprTypeTest(t, &exprTypeTestContext{global: global, local: local}, tests)
 }

--- a/src/linttest/shape_test.go
+++ b/src/linttest/shape_test.go
@@ -146,8 +146,7 @@ echo $s1['list']->next->next;
 }
 
 func TestTuple(t *testing.T) {
-	test := linttest.NewSuite(t)
-	test.AddFile(`<?php
+	linttest.SimpleNegativeTest(t, `<?php
 class Box { public $value; }
 
 class T {
@@ -159,28 +158,10 @@ class T {
 
   /** @var tuple(int, tuple(Box)) */
   public $good3;
-
-  /** @var tuple(x:Box) */
-  public $bad1; // Bad: invalid tuple element.
-
-  /** @var tuple(bool, x[]) */
-  public $bad2; // Bad: invalid tuple element.
-
-  /** @var tuple(0, int) */
-  public $bad3; // Bad: invalid tuple element.
 }
 
 $t = new T();
-echo $t->bad1['x']->value;
-
 echo $t->good2[0]->value;
 echo $t->good3[1][0]->value;
 `)
-	test.Expect = []string{
-		`tuple param #1: want type, found x:Box`,
-		`tuple param #2: want type, found x[]`,
-		`tuple param #1: want type, found 0`,
-		`Property {mixed}->value does not exist`,
-	}
-	test.RunAndMatch()
 }


### PR DESCRIPTION
The `tuple` type is a shorthand for `shape` with numerical keys: 
`tuple(T1, T2) = shape{0:T1, 1:T2}`

Fix #436 