### PR TITLE
linter: don't recurse when matching rules

### DIFF
--- a/src/linttest/rules_test.go
+++ b/src/linttest/rules_test.go
@@ -36,6 +36,12 @@ eval(${"var"});
 func TestAnyRules(t *testing.T) {
 	rfile := `<?php
 /**
+ * @warning string value used in if condition
+ * @type string $cond
+ */
+if ($cond) $_;
+
+/**
  * @warning implode() first arg must be a string and second should be an array
  * @type !string $glue
  * @or
@@ -101,6 +107,13 @@ function implode($glue, $pieces) { return ''; }
 
 define('true', 1 == 1);
 define('false', 1 == 0);
+
+function stringCond(string $s) {
+  if ($s !== '') { // Good
+    if ($s) { // Bad
+    }
+  }
+}
 
 /**
  * @param Foo[] $arr
@@ -180,6 +193,7 @@ $_ = implode($s, $i); // BAD: string, int
 `)
 
 	test.Expect = []string{
+		`string value used in if condition`,
 		`duplicated sub-expressions inside boolean expression`,
 		`suspicious order of stripos function arguments`,
 		`don't call explode with empty delimiter`,

--- a/src/phpgrep/matcher_test.go
+++ b/src/phpgrep/matcher_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
 )
 
 func matchInText(m *matcher, code []byte) bool {
@@ -11,7 +13,10 @@ func matchInText(m *matcher, code []byte) bool {
 	if err != nil {
 		return false
 	}
-	return m.matchAST(root)
+	if x, ok := root.(*stmt.Expression); ok {
+		root = x.Expr
+	}
+	return m.match(root)
 }
 
 func findInText(m *matcher, code []byte, callback func(*MatchData) bool) {
@@ -543,7 +548,7 @@ func BenchmarkFind(b *testing.B) {
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				matcher.m.matchAST(root)
+				matcher.m.match(root)
 			}
 		})
 	}

--- a/src/phpgrep/phpgrep.go
+++ b/src/phpgrep/phpgrep.go
@@ -28,13 +28,17 @@ func (m *Matcher) Clone() *Matcher {
 	return &Matcher{m: m.m}
 }
 
-// Match reports whether given PHP code matches the bound pattern.
-//
-// For malformed inputs (like code with syntax errors), returns false.
-func (m *Matcher) Match(root node.Node) bool {
-	return m.m.matchAST(root)
-}
-
+// Find executed a callback for every match inside root.
+// If callback returns false, currently matched node children are not visited.
 func (m *Matcher) Find(root node.Node, callback func(*MatchData) bool) {
 	m.m.findAST(root, callback)
+}
+
+// Match attempts to match n without recursing into it.
+//
+// Returned match data should only be examined if the
+// second return value is true.
+func (m *Matcher) Match(n node.Node) (MatchData, bool) {
+	found := m.m.match(n)
+	return m.m.data, found
 }


### PR DESCRIPTION
phpgrep Find() method is recursive.
It tries to match at the top leven, then it traverses
the AST and calls the callback for every matching node.

A new tests (added in this change) resulted in 2 warnings
instead of 1 due to this.

It's not enough to do "return false" to stop the traversal.

To avoid this confusion in future, Find is renamed to FindAll.
A new Find method does not perform any traversal, which is
exactly what we need.

More refactoring can be done later. This change goal
is to fix a bug.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>