### PR TITLE
phpgrep: make matcher faster and thread safe

### DIFF
--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -127,9 +127,7 @@ func cloneRulesForFile(filename string, ruleSet *rules.ScopedSet) *rules.ScopedS
 			if !strings.Contains(filename, rule.Path) {
 				continue
 			}
-			ruleClone := rule
-			ruleClone.Matcher = rule.Matcher.Clone()
-			res = append(res, ruleClone)
+			res = append(res, rule)
 		}
 		clone.RulesByKind[i] = res
 	}
@@ -150,9 +148,8 @@ func analyzeFile(filename string, contents []byte, parser *php7.Parser, lineRang
 		lineRanges: lineRanges,
 		ctx:        newRootContext(st),
 
-		// We need to clone rules since phpgrep matchers
-		// contain mutable state that we don't want to share
-		// between goroutines.
+		// We clone rules sets to remove all rules that
+		// should not be applied to this file because of the @path.
 		anyRset:   cloneRulesForFile(filename, Rules.Any),
 		rootRset:  cloneRulesForFile(filename, Rules.Root),
 		localRset: cloneRulesForFile(filename, Rules.Local),

--- a/src/phpgrep/matcher.go
+++ b/src/phpgrep/matcher.go
@@ -13,14 +13,13 @@ import (
 	"github.com/VKCOM/noverify/src/php/parser/node/name"
 	"github.com/VKCOM/noverify/src/php/parser/node/scalar"
 	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
-	"github.com/VKCOM/noverify/src/php/parser/walker"
 )
 
 type matcher struct {
+	// root is a compiled pattern node.
 	root node.Node
 
-	handler func(*MatchData) bool
-	named   map[string]node.Node
+	named map[string]node.Node
 
 	literalMatch bool
 
@@ -43,11 +42,6 @@ func (m *matcher) match(n node.Node) bool {
 	m.data.Node = n
 	m.data.Named = m.named
 	return true
-}
-
-func (m *matcher) findAST(root node.Node, callback func(*MatchData) bool) {
-	m.handler = callback
-	root.Walk(m)
 }
 
 func (m *matcher) eqNameParts(xs, ys []node.Node) bool {
@@ -791,12 +785,3 @@ func (m *matcher) eqVar(x *node.Var, y node.Node) bool {
 	}
 	return false
 }
-
-func (m *matcher) EnterNode(w walker.Walkable) bool {
-	if m.match(w.(node.Node)) {
-		return m.handler(&m.data)
-	}
-	return true
-}
-
-func (m *matcher) LeaveNode(w walker.Walkable) {}

--- a/src/phpgrep/matcher.go
+++ b/src/phpgrep/matcher.go
@@ -15,33 +15,36 @@ import (
 	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
 )
 
+type matcherState struct {
+	literalMatch bool
+
+	capture []CapturedNode
+}
+
 type matcher struct {
 	// root is a compiled pattern node.
 	root node.Node
 
-	named map[string]node.Node
-
-	literalMatch bool
-
-	data MatchData
+	// numVars is a max number of named captures this matcher may need.
+	numVars int
 
 	// Used only when -tracing build tag is specified.
 	tracingBuf   *bytes.Buffer
 	tracingDepth int
 }
 
-func (m *matcher) match(n node.Node) bool {
-	m.named = map[string]node.Node{}
-	if !m.eqNode(m.root, n) {
-		return false
+func (m *matcher) match(state *matcherState, n node.Node) (data MatchData, ok bool) {
+	state.capture = state.capture[:0]
+	if !m.eqNode(state, m.root, n) {
+		return data, false
 	}
 	pos := getNodePos(n)
 	if pos == nil {
-		return false
+		return data, false
 	}
-	m.data.Node = n
-	m.data.Named = m.named
-	return true
+	data.Node = n
+	data.Capture = state.capture
+	return data, true
 }
 
 func (m *matcher) eqNameParts(xs, ys []node.Node) bool {
@@ -58,13 +61,13 @@ func (m *matcher) eqNameParts(xs, ys []node.Node) bool {
 	return true
 }
 
-func (m *matcher) eqNodeSliceNoMeta(xs, ys []node.Node) bool {
+func (m *matcher) eqNodeSliceNoMeta(state *matcherState, xs, ys []node.Node) bool {
 	if len(xs) != len(ys) {
 		return false
 	}
 
 	for i, x := range xs {
-		if !m.eqNode(x, ys[i]) {
+		if !m.eqNode(state, x, ys[i]) {
 			return false
 		}
 	}
@@ -72,7 +75,7 @@ func (m *matcher) eqNodeSliceNoMeta(xs, ys []node.Node) bool {
 	return true
 }
 
-func (m *matcher) eqArrayItemSlice(xs, ys []*expr.ArrayItem) bool {
+func (m *matcher) eqArrayItemSlice(state *matcherState, xs, ys []*expr.ArrayItem) bool {
 	// FIXME.
 
 	if len(xs) == 0 && len(ys) != 0 {
@@ -96,7 +99,7 @@ func (m *matcher) eqArrayItemSlice(xs, ys []*expr.ArrayItem) bool {
 				matchAny = false
 				i++
 			// Lookahead for non-greedy matching.
-			case i+1 < len(xs) && m.eqNode(xs[i+1], ys[0]):
+			case i+1 < len(xs) && m.eqNode(state, xs[i+1], ys[0]):
 				matchAny = false
 				i += 2
 				ys = ys[1:]
@@ -106,7 +109,7 @@ func (m *matcher) eqArrayItemSlice(xs, ys []*expr.ArrayItem) bool {
 			continue
 		}
 
-		if len(ys) == 0 || !m.eqNode(x, ys[0]) {
+		if len(ys) == 0 || !m.eqNode(state, x, ys[0]) {
 			return false
 		}
 		i++
@@ -116,7 +119,7 @@ func (m *matcher) eqArrayItemSlice(xs, ys []*expr.ArrayItem) bool {
 	return len(ys) == 0
 }
 
-func (m *matcher) eqNodeSlice(xs, ys []node.Node) bool {
+func (m *matcher) eqNodeSlice(state *matcherState, xs, ys []node.Node) bool {
 	if len(xs) == 0 && len(ys) != 0 {
 		return false
 	}
@@ -138,7 +141,7 @@ func (m *matcher) eqNodeSlice(xs, ys []node.Node) bool {
 				matchAny = false
 				i++
 			// Lookahead for non-greedy matching.
-			case i+1 < len(xs) && m.eqNode(xs[i+1], ys[0]):
+			case i+1 < len(xs) && m.eqNode(state, xs[i+1], ys[0]):
 				matchAny = false
 				i += 2
 				ys = ys[1:]
@@ -148,7 +151,7 @@ func (m *matcher) eqNodeSlice(xs, ys []node.Node) bool {
 			continue
 		}
 
-		if len(ys) == 0 || !m.eqNode(x, ys[0]) {
+		if len(ys) == 0 || !m.eqNode(state, x, ys[0]) {
 			return false
 		}
 		i++
@@ -158,19 +161,19 @@ func (m *matcher) eqNodeSlice(xs, ys []node.Node) bool {
 	return len(ys) == 0
 }
 
-func (m *matcher) eqEncapsedStringPartSlice(xs, ys []node.Node) bool {
+func (m *matcher) eqEncapsedStringPartSlice(state *matcherState, xs, ys []node.Node) bool {
 	if len(xs) != len(ys) {
 		return false
 	}
 	for i, x := range xs {
-		if !m.eqEncapsedStringPart(x, ys[i]) {
+		if !m.eqEncapsedStringPart(state, x, ys[i]) {
 			return false
 		}
 	}
 	return true
 }
 
-func (m *matcher) eqEncapsedStringPart(x, y node.Node) bool {
+func (m *matcher) eqEncapsedStringPart(state *matcherState, x, y node.Node) bool {
 	switch x := x.(type) {
 	case *scalar.EncapsedStringPart:
 		y, ok := y.(*scalar.EncapsedStringPart)
@@ -180,11 +183,11 @@ func (m *matcher) eqEncapsedStringPart(x, y node.Node) bool {
 		y, ok := y.(*node.SimpleVar)
 		return ok && x.Name == y.Name
 	default:
-		return m.eqNode(x, y)
+		return m.eqNode(state, x, y)
 	}
 }
 
-func (m *matcher) eqNode(x, y node.Node) bool {
+func (m *matcher) eqNode(state *matcherState, x, y node.Node) bool {
 	if tracingEnabled && m.tracingBuf != nil {
 		pad := strings.Repeat(" • ", m.tracingDepth)
 		fmt.Fprintf(m.tracingBuf, "%seqNode x=%T y=%T\n", pad, x, y)
@@ -206,14 +209,14 @@ func (m *matcher) eqNode(x, y node.Node) bool {
 		// To make it possible to match statements with $-expressions,
 		// check whether expression inside x.Expr is a variable.
 		if x, ok := x.Expr.(*node.SimpleVar); ok {
-			return m.eqSimpleVar(x, y)
+			return m.eqSimpleVar(state, x, y)
 		}
 		y, ok := y.(*stmt.Expression)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 
 	case *stmt.StmtList:
 		y, ok := y.(*stmt.StmtList)
-		return ok && m.eqNodeSlice(x.Stmts, y.Stmts)
+		return ok && m.eqNodeSlice(state, x.Stmts, y.Stmts)
 
 	case *stmt.Function:
 		return false // FIXME #23
@@ -229,277 +232,278 @@ func (m *matcher) eqNode(x, y node.Node) bool {
 		return ok && x.Value == y.Value
 	case *stmt.StaticVar:
 		y, ok := y.(*stmt.StaticVar)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *stmt.Static:
 		y, ok := y.(*stmt.Static)
-		return ok && m.eqNodeSlice(x.Vars, y.Vars)
+		return ok && m.eqNodeSlice(state, x.Vars, y.Vars)
 	case *stmt.Global:
 		y, ok := y.(*stmt.Global)
-		return ok && m.eqNodeSlice(x.Vars, y.Vars)
+		return ok && m.eqNodeSlice(state, x.Vars, y.Vars)
 	case *stmt.Break:
 		y, ok := y.(*stmt.Break)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *stmt.Continue:
 		y, ok := y.(*stmt.Continue)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *stmt.Unset:
 		y, ok := y.(*stmt.Unset)
-		return ok && m.eqNodeSlice(x.Vars, y.Vars)
+		return ok && m.eqNodeSlice(state, x.Vars, y.Vars)
 	case *expr.Print:
 		y, ok := y.(*expr.Print)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *stmt.Echo:
 		y, ok := y.(*stmt.Echo)
-		return ok && m.eqNodeSlice(x.Exprs, y.Exprs)
+		return ok && m.eqNodeSlice(state, x.Exprs, y.Exprs)
 	case *stmt.Nop:
 		_, ok := y.(*stmt.Nop)
 		return ok
 	case *stmt.Do:
 		y, ok := y.(*stmt.Do)
-		return ok && m.eqNode(x.Cond, y.Cond) && m.eqNode(x.Stmt, y.Stmt)
+		return ok && m.eqNode(state, x.Cond, y.Cond) && m.eqNode(state, x.Stmt, y.Stmt)
 	case *stmt.While:
 		y, ok := y.(*stmt.While)
 		return ok && x.AltSyntax == y.AltSyntax &&
-			m.eqNode(x.Cond, y.Cond) && m.eqNode(x.Stmt, y.Stmt)
+			m.eqNode(state, x.Cond, y.Cond) && m.eqNode(state, x.Stmt, y.Stmt)
 	case *stmt.For:
 		y, ok := y.(*stmt.For)
 		return ok && x.AltSyntax == y.AltSyntax &&
-			m.eqNodeSlice(x.Init, y.Init) &&
-			m.eqNodeSlice(x.Cond, y.Cond) &&
-			m.eqNodeSlice(x.Loop, y.Loop) &&
-			m.eqNode(x.Stmt, y.Stmt)
+			m.eqNodeSlice(state, x.Init, y.Init) &&
+			m.eqNodeSlice(state, x.Cond, y.Cond) &&
+			m.eqNodeSlice(state, x.Loop, y.Loop) &&
+			m.eqNode(state, x.Stmt, y.Stmt)
 	case *stmt.Foreach:
 		y, ok := y.(*stmt.Foreach)
 		return ok && x.AltSyntax == y.AltSyntax &&
-			m.eqNode(x.Expr, y.Expr) &&
-			m.eqNode(x.Key, y.Key) &&
-			m.eqNode(x.Variable, y.Variable) &&
-			m.eqNode(x.Stmt, y.Stmt)
+			m.eqNode(state, x.Expr, y.Expr) &&
+			m.eqNode(state, x.Key, y.Key) &&
+			m.eqNode(state, x.Variable, y.Variable) &&
+			m.eqNode(state, x.Stmt, y.Stmt)
 
 	case *stmt.Else:
 		y, ok := y.(*stmt.Else)
-		return ok && x.AltSyntax == y.AltSyntax && m.eqNode(x.Stmt, y.Stmt)
+		return ok && x.AltSyntax == y.AltSyntax && m.eqNode(state, x.Stmt, y.Stmt)
 	case *stmt.ElseIf:
 		y, ok := y.(*stmt.ElseIf)
 		return ok && x.AltSyntax == y.AltSyntax &&
-			m.eqNode(x.Cond, y.Cond) && m.eqNode(x.Stmt, y.Stmt)
+			m.eqNode(state, x.Cond, y.Cond) && m.eqNode(state, x.Stmt, y.Stmt)
 	case *stmt.If:
 		y, ok := y.(*stmt.If)
 		return ok && x.AltSyntax == y.AltSyntax &&
-			m.eqNodeSliceNoMeta(x.ElseIf, y.ElseIf) &&
-			m.eqNode(x.Cond, y.Cond) &&
-			m.eqNode(x.Stmt, y.Stmt) &&
-			m.eqNode(x.Else, y.Else)
+			m.eqNodeSliceNoMeta(state, x.ElseIf, y.ElseIf) &&
+			m.eqNode(state, x.Cond, y.Cond) &&
+			m.eqNode(state, x.Stmt, y.Stmt) &&
+			m.eqNode(state, x.Else, y.Else)
 
 	case *stmt.Throw:
 		y, ok := y.(*stmt.Throw)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *stmt.Try:
 		y, ok := y.(*stmt.Try)
-		return ok && m.eqNodeSlice(x.Stmts, y.Stmts) &&
-			m.eqNodeSlice(x.Catches, y.Catches) &&
-			m.eqNode(x.Finally, y.Finally)
+		return ok && m.eqNodeSlice(state, x.Stmts, y.Stmts) &&
+			m.eqNodeSlice(state, x.Catches, y.Catches) &&
+			m.eqNode(state, x.Finally, y.Finally)
 
 	case *expr.Yield:
 		y, ok := y.(*expr.Yield)
-		return ok && m.eqNode(x.Key, y.Key) && m.eqNode(x.Value, y.Value)
+		return ok && m.eqNode(state, x.Key, y.Key) && m.eqNode(state, x.Value, y.Value)
 	case *expr.YieldFrom:
 		y, ok := y.(*expr.YieldFrom)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 
 	case *expr.InstanceOf:
 		y, ok := y.(*expr.InstanceOf)
-		return ok && m.eqNode(x.Expr, y.Expr) && m.eqNode(x.Class, y.Class)
+		return ok && m.eqNode(state, x.Expr, y.Expr) && m.eqNode(state, x.Class, y.Class)
 
 	case *expr.List:
 		y, ok := y.(*expr.List)
-		return ok && x.ShortSyntax == y.ShortSyntax && m.eqArrayItemSlice(x.Items, y.Items)
+		return ok && x.ShortSyntax == y.ShortSyntax &&
+			m.eqArrayItemSlice(state, x.Items, y.Items)
 
 	case *expr.New:
 		y, ok := y.(*expr.New)
-		if !ok || !m.eqNode(x.Class, y.Class) {
+		if !ok || !m.eqNode(state, x.Class, y.Class) {
 			return false
 		}
 		if x.ArgumentList == nil || y.ArgumentList == nil {
 			return x.ArgumentList == y.ArgumentList
 		}
-		return m.eqNodeSlice(x.ArgumentList.Arguments, y.ArgumentList.Arguments)
+		return m.eqNodeSlice(state, x.ArgumentList.Arguments, y.ArgumentList.Arguments)
 
 	case *stmt.Case:
 		y, ok := y.(*stmt.Case)
-		return ok && m.eqNode(x.Cond, y.Cond) && m.eqNodeSlice(x.Stmts, y.Stmts)
+		return ok && m.eqNode(state, x.Cond, y.Cond) && m.eqNodeSlice(state, x.Stmts, y.Stmts)
 	case *stmt.Default:
 		y, ok := y.(*stmt.Default)
-		return ok && m.eqNodeSlice(x.Stmts, y.Stmts)
+		return ok && m.eqNodeSlice(state, x.Stmts, y.Stmts)
 	case *stmt.Switch:
 		y, ok := y.(*stmt.Switch)
 		return ok && x.AltSyntax == y.AltSyntax &&
-			m.eqNode(x.Cond, y.Cond) &&
-			m.eqNodeSlice(x.CaseList.Cases, y.CaseList.Cases)
+			m.eqNode(state, x.Cond, y.Cond) &&
+			m.eqNodeSlice(state, x.CaseList.Cases, y.CaseList.Cases)
 
 	case *stmt.Return:
 		y, ok := y.(*stmt.Return)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 
 	case *assign.Assign:
 		y, ok := y.(*assign.Assign)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.Plus:
 		y, ok := y.(*assign.Plus)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.Reference:
 		y, ok := y.(*assign.Reference)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.BitwiseAnd:
 		y, ok := y.(*assign.BitwiseAnd)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.BitwiseOr:
 		y, ok := y.(*assign.BitwiseOr)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.BitwiseXor:
 		y, ok := y.(*assign.BitwiseXor)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.Concat:
 		y, ok := y.(*assign.Concat)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.Div:
 		y, ok := y.(*assign.Div)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.Minus:
 		y, ok := y.(*assign.Minus)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.Mod:
 		y, ok := y.(*assign.Mod)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.Mul:
 		y, ok := y.(*assign.Mul)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.Pow:
 		y, ok := y.(*assign.Pow)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.ShiftLeft:
 		y, ok := y.(*assign.ShiftLeft)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 	case *assign.ShiftRight:
 		y, ok := y.(*assign.ShiftRight)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
 
 	case *expr.ArrayDimFetch:
 		y, ok := y.(*expr.ArrayDimFetch)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Dim, y.Dim)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Dim, y.Dim)
 	case *expr.ArrayItem:
 		y, ok := y.(*expr.ArrayItem)
 		if !ok {
 			return false
 		}
 		if x.Key == nil || y.Key == nil {
-			return x.Key == y.Key && m.eqNode(x.Val, y.Val)
+			return x.Key == y.Key && m.eqNode(state, x.Val, y.Val)
 		}
-		return m.eqNode(x.Key, y.Key) && m.eqNode(x.Val, y.Val)
+		return m.eqNode(state, x.Key, y.Key) && m.eqNode(state, x.Val, y.Val)
 	case *expr.Array:
 		y, ok := y.(*expr.Array)
 		return ok && x.ShortSyntax == y.ShortSyntax &&
-			m.eqArrayItemSlice(x.Items, y.Items)
+			m.eqArrayItemSlice(state, x.Items, y.Items)
 
 	case *node.Argument:
 		y, ok := y.(*node.Argument)
 		return ok && x.IsReference == y.IsReference &&
 			x.Variadic == y.Variadic &&
-			m.eqNode(x.Expr, y.Expr)
+			m.eqNode(state, x.Expr, y.Expr)
 	case *expr.FunctionCall:
 		y, ok := y.(*expr.FunctionCall)
-		if !ok || !m.eqNode(x.Function, y.Function) {
+		if !ok || !m.eqNode(state, x.Function, y.Function) {
 			return false
 		}
-		return m.eqNodeSlice(x.ArgumentList.Arguments, y.ArgumentList.Arguments)
+		return m.eqNodeSlice(state, x.ArgumentList.Arguments, y.ArgumentList.Arguments)
 
 	case *expr.PostInc:
 		y, ok := y.(*expr.PostInc)
-		return ok && m.eqNode(x.Variable, y.Variable)
+		return ok && m.eqNode(state, x.Variable, y.Variable)
 	case *expr.PostDec:
 		y, ok := y.(*expr.PostDec)
-		return ok && m.eqNode(x.Variable, y.Variable)
+		return ok && m.eqNode(state, x.Variable, y.Variable)
 	case *expr.PreInc:
 		y, ok := y.(*expr.PreInc)
-		return ok && m.eqNode(x.Variable, y.Variable)
+		return ok && m.eqNode(state, x.Variable, y.Variable)
 	case *expr.PreDec:
 		y, ok := y.(*expr.PreDec)
-		return ok && m.eqNode(x.Variable, y.Variable)
+		return ok && m.eqNode(state, x.Variable, y.Variable)
 
 	case *expr.Exit:
 		y, ok := y.(*expr.Exit)
-		return ok && x.Die == y.Die && m.eqNode(x.Expr, y.Expr)
+		return ok && x.Die == y.Die && m.eqNode(state, x.Expr, y.Expr)
 
 	case *expr.Include:
 		y, ok := y.(*expr.Include)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.IncludeOnce:
 		y, ok := y.(*expr.IncludeOnce)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.Require:
 		y, ok := y.(*expr.Require)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.RequireOnce:
 		y, ok := y.(*expr.RequireOnce)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.Empty:
 		y, ok := y.(*expr.Empty)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.Eval:
 		y, ok := y.(*expr.Eval)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.ErrorSuppress:
 		y, ok := y.(*expr.ErrorSuppress)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.Clone:
 		y, ok := y.(*expr.Clone)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.BitwiseNot:
 		y, ok := y.(*expr.BitwiseNot)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.BooleanNot:
 		y, ok := y.(*expr.BooleanNot)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.UnaryMinus:
 		y, ok := y.(*expr.UnaryMinus)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *expr.UnaryPlus:
 		y, ok := y.(*expr.UnaryPlus)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 
 	case *expr.StaticPropertyFetch:
 		switch y := y.(type) {
 		case *expr.StaticPropertyFetch:
-			return m.eqNode(x.Class, y.Class) &&
-				m.eqNode(x.Property, y.Property)
+			return m.eqNode(state, x.Class, y.Class) &&
+				m.eqNode(state, x.Property, y.Property)
 		case *expr.ClassConstFetch:
 			return nodeIsVar(x.Property) &&
-				m.eqNode(x.Class, y.Class) &&
-				m.eqNode(x.Property, y.ConstantName)
+				m.eqNode(state, x.Class, y.Class) &&
+				m.eqNode(state, x.Property, y.ConstantName)
 		default:
 			return false
 		}
 
 	case *expr.ClassConstFetch:
 		y, ok := y.(*expr.ClassConstFetch)
-		return ok && m.eqNode(x.Class, y.Class) && m.eqNode(x.ConstantName, y.ConstantName)
+		return ok && m.eqNode(state, x.Class, y.Class) && m.eqNode(state, x.ConstantName, y.ConstantName)
 	case *expr.StaticCall:
 		y, ok := y.(*expr.StaticCall)
 		return ok &&
-			m.eqNode(x.Class, y.Class) &&
-			m.eqNode(x.Call, y.Call) &&
-			m.eqNodeSlice(x.ArgumentList.Arguments, y.ArgumentList.Arguments)
+			m.eqNode(state, x.Class, y.Class) &&
+			m.eqNode(state, x.Call, y.Call) &&
+			m.eqNodeSlice(state, x.ArgumentList.Arguments, y.ArgumentList.Arguments)
 
 	case *expr.ShellExec:
 		y, ok := y.(*expr.ShellExec)
-		return ok && m.eqEncapsedStringPartSlice(x.Parts, y.Parts)
+		return ok && m.eqEncapsedStringPartSlice(state, x.Parts, y.Parts)
 	case *scalar.Encapsed:
 		y, ok := y.(*scalar.Encapsed)
-		return ok && m.eqEncapsedStringPartSlice(x.Parts, y.Parts)
+		return ok && m.eqEncapsedStringPartSlice(state, x.Parts, y.Parts)
 
 	case *scalar.Heredoc:
 		y, ok := y.(*scalar.Heredoc)
-		return ok && x.Label == y.Label && m.eqEncapsedStringPartSlice(x.Parts, y.Parts)
+		return ok && x.Label == y.Label && m.eqEncapsedStringPartSlice(state, x.Parts, y.Parts)
 	case *scalar.MagicConstant:
 		y, ok := y.(*scalar.MagicConstant)
 		return ok && y.Value == x.Value
@@ -515,89 +519,89 @@ func (m *matcher) eqNode(x, y node.Node) bool {
 
 	case *binary.Coalesce:
 		y, ok := y.(*binary.Coalesce)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Concat:
 		y, ok := y.(*binary.Concat)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Div:
 		y, ok := y.(*binary.Div)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Mod:
 		y, ok := y.(*binary.Mod)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Mul:
 		y, ok := y.(*binary.Mul)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Pow:
 		y, ok := y.(*binary.Pow)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.BitwiseAnd:
 		y, ok := y.(*binary.BitwiseAnd)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.BitwiseOr:
 		y, ok := y.(*binary.BitwiseOr)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.BitwiseXor:
 		y, ok := y.(*binary.BitwiseXor)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.ShiftLeft:
 		y, ok := y.(*binary.ShiftLeft)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.ShiftRight:
 		y, ok := y.(*binary.ShiftRight)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.LogicalAnd:
 		y, ok := y.(*binary.LogicalAnd)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.LogicalOr:
 		y, ok := y.(*binary.LogicalOr)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.LogicalXor:
 		y, ok := y.(*binary.LogicalXor)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.BooleanAnd:
 		y, ok := y.(*binary.BooleanAnd)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.BooleanOr:
 		y, ok := y.(*binary.BooleanOr)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.NotEqual:
 		y, ok := y.(*binary.NotEqual)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.NotIdentical:
 		y, ok := y.(*binary.NotIdentical)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Equal:
 		y, ok := y.(*binary.Equal)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Identical:
 		y, ok := y.(*binary.Identical)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Greater:
 		y, ok := y.(*binary.Greater)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.GreaterOrEqual:
 		y, ok := y.(*binary.GreaterOrEqual)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Smaller:
 		y, ok := y.(*binary.Smaller)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.SmallerOrEqual:
 		y, ok := y.(*binary.SmallerOrEqual)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Spaceship:
 		y, ok := y.(*binary.Spaceship)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Plus:
 		y, ok := y.(*binary.Plus)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 	case *binary.Minus:
 		y, ok := y.(*binary.Minus)
-		return ok && m.eqNode(x.Left, y.Left) && m.eqNode(x.Right, y.Right)
+		return ok && m.eqNode(state, x.Left, y.Left) && m.eqNode(state, x.Right, y.Right)
 
 	case *expr.ConstFetch:
 		y, ok := y.(*expr.ConstFetch)
-		return ok && m.eqNode(x.Constant, y.Constant)
+		return ok && m.eqNode(state, x.Constant, y.Constant)
 	case *name.Name:
 		y, ok := y.(*name.Name)
 		return ok && m.eqNameParts(x.Parts, y.Parts)
@@ -608,58 +612,58 @@ func (m *matcher) eqNode(x, y node.Node) bool {
 		y, ok := y.(*node.Identifier)
 		return ok && x.Value == y.Value
 	case *node.SimpleVar:
-		return m.eqSimpleVar(x, y)
+		return m.eqSimpleVar(state, x, y)
 	case *node.Var:
-		return m.eqVar(x, y)
+		return m.eqVar(state, x, y)
 
 	case *expr.Reference:
 		y, ok := y.(*expr.Reference)
-		return ok && m.eqNode(x.Variable, y.Variable)
+		return ok && m.eqNode(state, x.Variable, y.Variable)
 
 	case *node.Parameter:
 		y, ok := y.(*node.Parameter)
 		return ok && x.ByRef == y.ByRef &&
 			x.Variadic == y.Variadic &&
-			m.eqNode(x.VariableType, y.VariableType) &&
-			m.eqNode(x.Variable, y.Variable) &&
-			m.eqNode(x.DefaultValue, y.DefaultValue)
+			m.eqNode(state, x.VariableType, y.VariableType) &&
+			m.eqNode(state, x.Variable, y.Variable) &&
+			m.eqNode(state, x.DefaultValue, y.DefaultValue)
 	case *expr.Closure:
-		return m.eqClosure(x, y)
+		return m.eqClosure(state, x, y)
 
 	case *expr.Ternary:
-		return m.eqTernary(x, y)
+		return m.eqTernary(state, x, y)
 
 	case *expr.Isset:
 		y, ok := y.(*expr.Isset)
-		return ok && m.eqNodeSlice(x.Variables, y.Variables)
+		return ok && m.eqNodeSlice(state, x.Variables, y.Variables)
 
 	case *expr.PropertyFetch:
 		y, ok := y.(*expr.PropertyFetch)
-		return ok && m.eqNode(x.Variable, y.Variable) && m.eqNode(x.Property, y.Property)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Property, y.Property)
 	case *expr.MethodCall:
 		y, ok := y.(*expr.MethodCall)
-		return ok && m.eqNode(x.Variable, y.Variable) &&
-			m.eqNode(x.Method, y.Method) &&
-			m.eqNodeSlice(x.ArgumentList.Arguments, y.ArgumentList.Arguments)
+		return ok && m.eqNode(state, x.Variable, y.Variable) &&
+			m.eqNode(state, x.Method, y.Method) &&
+			m.eqNodeSlice(state, x.ArgumentList.Arguments, y.ArgumentList.Arguments)
 
 	case *cast.Double:
 		y, ok := y.(*cast.Double)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *cast.Array:
 		y, ok := y.(*cast.Array)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *cast.Bool:
 		y, ok := y.(*cast.Bool)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *cast.Int:
 		y, ok := y.(*cast.Int)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *cast.Object:
 		y, ok := y.(*cast.Object)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *cast.String:
 		y, ok := y.(*cast.String)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 
 	case *node.Root:
 		return false
@@ -669,7 +673,7 @@ func (m *matcher) eqNode(x, y node.Node) bool {
 	}
 }
 
-func (m *matcher) matchNamed(name string, y node.Node) bool {
+func (m *matcher) matchNamed(state *matcherState, name string, y node.Node) bool {
 	// Special case.
 	// "_" name matches anything, always.
 	// Anonymous names replaced with "_" during the compilation.
@@ -677,38 +681,42 @@ func (m *matcher) matchNamed(name string, y node.Node) bool {
 		return true
 	}
 
-	z, ok := m.named[name]
+	z, ok := findNamed(state.capture, name)
 	if !ok {
-		m.named[name] = y
+		// We allocate capture slice lazily and to the max capacity.
+		if state.capture == nil {
+			state.capture = make([]CapturedNode, 0, m.numVars)
+		}
+		state.capture = append(state.capture, CapturedNode{Name: name, Node: y})
 		return true
 	}
 	if z == nil {
 		return y == nil
 	}
 
-	m.literalMatch = true
-	result := m.eqNode(z, y)
-	m.literalMatch = false
+	state.literalMatch = true
+	result := m.eqNode(state, z, y)
+	state.literalMatch = false
 	return result
 }
 
-func (m *matcher) eqTernary(x *expr.Ternary, y node.Node) bool {
+func (m *matcher) eqTernary(state *matcherState, x *expr.Ternary, y node.Node) bool {
 	if y, ok := y.(*expr.Ternary); ok {
 		// To avoid matching `$x ?: $y` with `$x ? $y : $z` pattern.
 		if x.IfTrue == nil || y.IfTrue == nil {
 			return y.IfTrue == x.IfTrue &&
-				m.eqNode(x.Condition, y.Condition) &&
-				m.eqNode(x.IfFalse, y.IfFalse)
+				m.eqNode(state, x.Condition, y.Condition) &&
+				m.eqNode(state, x.IfFalse, y.IfFalse)
 		}
-		return m.eqNode(x.Condition, y.Condition) &&
-			m.eqNode(x.IfTrue, y.IfTrue) &&
-			m.eqNode(x.IfFalse, y.IfFalse)
+		return m.eqNode(state, x.Condition, y.Condition) &&
+			m.eqNode(state, x.IfTrue, y.IfTrue) &&
+			m.eqNode(state, x.IfFalse, y.IfFalse)
 	}
 
 	return false
 }
 
-func (m *matcher) eqClosure(x *expr.Closure, y node.Node) bool {
+func (m *matcher) eqClosure(state *matcherState, x *expr.Closure, y node.Node) bool {
 	if y, ok := y.(*expr.Closure); ok {
 		var xUses, yUses []node.Node
 		if x.ClosureUse != nil {
@@ -719,69 +727,69 @@ func (m *matcher) eqClosure(x *expr.Closure, y node.Node) bool {
 		}
 		return ok && x.ReturnsRef == y.ReturnsRef &&
 			x.Static == y.Static &&
-			m.eqNodeSlice(x.Params, y.Params) &&
-			m.eqNode(x.ReturnType, y.ReturnType) &&
-			m.eqNodeSlice(x.Stmts, y.Stmts) &&
-			m.eqNodeSlice(xUses, yUses)
+			m.eqNodeSlice(state, x.Params, y.Params) &&
+			m.eqNode(state, x.ReturnType, y.ReturnType) &&
+			m.eqNodeSlice(state, x.Stmts, y.Stmts) &&
+			m.eqNodeSlice(state, xUses, yUses)
 	}
 
 	return false
 }
 
-func (m *matcher) eqSimpleVar(x *node.SimpleVar, y node.Node) bool {
-	if m.literalMatch {
+func (m *matcher) eqSimpleVar(state *matcherState, x *node.SimpleVar, y node.Node) bool {
+	if state.literalMatch {
 		y, ok := y.(*node.SimpleVar)
 		return ok && x.Name == y.Name
 	}
-	return m.matchNamed(x.Name, y)
+	return m.matchNamed(state, x.Name, y)
 }
 
-func (m *matcher) eqVar(x *node.Var, y node.Node) bool {
-	if m.literalMatch {
+func (m *matcher) eqVar(state *matcherState, x *node.Var, y node.Node) bool {
+	if state.literalMatch {
 		y, ok := y.(*node.Var)
-		return ok && m.eqNode(x.Expr, y.Expr)
+		return ok && m.eqNode(state, x.Expr, y.Expr)
 	}
 
 	switch vn := x.Expr.(type) {
 	case anyFunc:
 		_, ok := y.(*expr.Closure)
-		return ok && m.matchNamed(vn.name, y)
+		return ok && m.matchNamed(state, vn.name, y)
 	case anyConst:
 		switch y.(type) {
 		case *expr.ConstFetch, *expr.ClassConstFetch:
-			return m.matchNamed(vn.name, y)
+			return m.matchNamed(state, vn.name, y)
 		default:
 			return false
 		}
 	case anyVar:
 		switch y.(type) {
 		case *node.SimpleVar, *node.Var:
-			return m.matchNamed(vn.name, y)
+			return m.matchNamed(state, vn.name, y)
 		default:
 			return false
 		}
 	case anyInt:
 		_, ok := y.(*scalar.Lnumber)
-		return ok && m.matchNamed(vn.name, y)
+		return ok && m.matchNamed(state, vn.name, y)
 	case anyFloat:
 		_, ok := y.(*scalar.Dnumber)
-		return ok && m.matchNamed(vn.name, y)
+		return ok && m.matchNamed(state, vn.name, y)
 	case anyStr:
 		_, ok := y.(*scalar.String)
-		return ok && m.matchNamed(vn.name, y)
+		return ok && m.matchNamed(state, vn.name, y)
 	case anyNum:
 		switch y.(type) {
 		case *scalar.Lnumber, *scalar.Dnumber:
-			return m.matchNamed(vn.name, y)
+			return m.matchNamed(state, vn.name, y)
 		default:
 			return false
 		}
 	case anyExpr:
-		return nodeIsExpr(y) && m.matchNamed(vn.name, y)
+		return nodeIsExpr(y) && m.matchNamed(state, vn.name, y)
 	}
 
 	if y, ok := y.(*node.Var); ok {
-		return m.eqNode(x.Expr, y.Expr)
+		return m.eqNode(state, x.Expr, y.Expr)
 	}
 	return false
 }

--- a/src/phpgrep/matcher_test.go
+++ b/src/phpgrep/matcher_test.go
@@ -2,17 +2,16 @@ package phpgrep
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/VKCOM/noverify/src/php/parser/node"
 	"github.com/VKCOM/noverify/src/php/parser/node/stmt"
 )
 
-func mustParse(t *testing.T, code []byte) node.Node {
+func mustParse(t testing.TB, code []byte) node.Node {
 	n, _, err := parsePHP7(code)
 	if err != nil {
-		t.Errorf("parse `%s`: %v", code, err)
+		t.Fatalf("parse `%s`: %v", code, err)
 	}
 	if n, ok := n.(*stmt.Expression); ok {
 		return n.Expr
@@ -486,10 +485,7 @@ func BenchmarkFind(b *testing.B) {
 	runBench := func(name, pattern string, input []byte) {
 		b.Run(name, func(b *testing.B) {
 			matcher := mustCompile(b, &c, pattern)
-			root, _, err := parsePHP7(input)
-			if err != nil {
-				b.Fatal(err)
-			}
+			root := mustParse(b, input)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				matcher.m.match(root)
@@ -497,154 +493,29 @@ func BenchmarkFind(b *testing.B) {
 		})
 	}
 
-	// f(), f($x), ..., f($x{i})
-	lotsOfCalls := []byte("<?php\n")
-	for i := 0; i < 50; i++ {
-		call := "f(" + strings.Repeat("$x,", i) + ");\n"
-		lotsOfCalls = append(lotsOfCalls, []byte(call)...)
-	}
+	const (
+		functionCall = `f(1, 2, 'abc', $x, [FOO => BAR])`
+	)
 
 	benchmarks := []struct {
 		name    string
 		pattern string
-		input   []byte
+		input   string
 	}{
-		// Benchmarking list matching.
-		{"positive/call*", `$_(${"*"})`, lotsOfCalls},
-		{"positive/call_*", `$_($_, ${"*"})`, lotsOfCalls},
-		{"positive/call*_", `$_(${"*"}, $_)`, lotsOfCalls},
-		{"positive/call*_*", `$_(${"*"}, $_, ${"*"})`, lotsOfCalls},
-		{"negative/call_", `$_($_)`, lotsOfCalls},
+		{"negative/const-tail", `[${"*"}, 1, 1]`, `[0,0,0,0,0,0,0,0,0]`},
 
-		// Benchmarking named variables.
-		{"positive/with-1-named", `$x`, benchmarkInput},
-		{"positive/with-5-named", `$x1 + $x2 + $x3 + $x4 + $x5`, benchmarkInput},
-		{"negative/with-0-named", `1 + 7 - 103`, benchmarkInput},
+		{"positive/call*", `$_(${"*"})`, functionCall},
+		{"positive/call_*", `$_($_, ${"*"})`, functionCall},
+		{"positive/call*_", `$_(${"*"}, $_)`, functionCall},
+		{"positive/call*_*", `$_(${"*"}, $_, ${"*"})`, functionCall},
+		{"negative/call_", `$_($_)`, functionCall},
+
+		{"positive/with-1-named", `$x + 1 * $x`, `$a[0] + 1 * $a[0]`},
+		{"negative/with-1-named", `$x + 1 * $x`, `$a[0] + 1 * $a[1]`},
+		{"positive/with-5-named", `$x1 + $x2 + $x3 + $x4 + $x5`, `1 + 2 + 3 + 4 + 5`},
 	}
 
 	for _, bench := range benchmarks {
-		runBench(bench.name, bench.pattern, bench.input)
+		runBench(bench.name, bench.pattern, []byte(bench.input))
 	}
 }
-
-var benchmarkInput = []byte(`<?php
-
-use N\{ClassName,
-  AnotherClassName,
-  OneMoreClassName};
-
-namespace A {
-  function foo() {
-    return 0;
-  }
-
-  function bar($x,
-    $y, int $z = 1) {
-    $x = 0;
-// $x = 1
-    do {
-      $y += 1;
-    } while ($y < 10);
-    if (true)
-      $x = 10;
-    elseif ($y < 10)
-      $x = 5;
-    elseif (true)
-      $x = 5;
-    for ($i = 0; $i < 10; $i++)
-      $yy = $x > 2 ? 1 : 2;
-    while (true)
-      $x = 0;
-    do {
-      $x += 1;
-    } while (true);
-    foreach (["a" => 0, "b" => 1,
-              "c" => 2] as $e1) {
-      echo $e1;
-    }
-    $count = 10;
-    $x     = ["x", "y",
-      [1 => "abc",
-       2 => "def", 3 => "ghi"]];
-    $zz    = [0.1, 0.2,
-      0.3, 0.4];
-    $x     = [
-      0   => "zero",
-      123 => "one two three",
-      25  => "two five",
-    ];
-    bar(0, bar(1,
-      "b"));
-  }
-
-  abstract class Foo extends FooBaseClass implements Bar1, Bar2, Bar3 {
-
-    var $numbers = ["one", "two", "three", "four", "five", "six"];
-    var $v = 0;
-    public $path = "root";
-
-    const FIRST  = 'first';
-    const SECOND = 0;
-    const Z      = -1;
-
-    function bar($v,
-      $w = "a") {
-      $y      = $w;
-      $result = foo("arg1",
-        "arg2",
-        10);
-      switch ($v) {
-        case 0:
-          return 1;
-        case 1:
-          echo '1';
-          break;
-        case 2:
-          break;
-        default:
-          $result = 10;
-      }
-      return $result;
-    }
-
-    public static function fOne($argA, $argB, $argC, $argD, $argE, $argF, $argG, $argH) {
-      $x = $argA + $argB + $argC + $argD + $argE + $argF + $argG + $argH;
-      list($field1, $field2, $field3, $filed4, $field5, $field6) = explode(",", $x);
-      fTwo($argA, $argB, $argC, fThree($argD, $argE, $argF, $argG, $argH));
-      $z      = $argA == "Some string" ? "yes" : "no";
-      $colors = ["red", "green", "blue", "black", "white", "gray"];
-      $count  = count($colors);
-      for ($i = 0; $i < $count; $i++) {
-        $colorString = $colors[$i];
-      }
-    }
-
-    function fTwo($strA, $strB, $strC, $strD) {
-      if ($strA == "one" || $strB == "two" || $strC == "three") {
-        return $strA + $strB + $strC;
-      }
-      $x = $foo->one("a", "b")->two("c", "d", "e")->three("fg")->four();
-      $y = a()->b()->c();
-      return $strD;
-    }
-
-    function fThree($strA, $strB, $strC, $strD, $strE) {
-      try {
-      } catch (Exception $e) {
-        foo();
-      } finally {
-        // do something
-      }
-      return $strA + $strB + $strC + $strD + $strE;
-    }
-
-    protected abstract function fFour();
-
-  }
-}
-
-function f() {}
-
-$_ = f(1 + 2 + 3 + 4 + 5);
-$_ = f(f() + f() + f() + f() + f());
-`)

--- a/src/phpgrep/phpgrep.go
+++ b/src/phpgrep/phpgrep.go
@@ -28,12 +28,6 @@ func (m *Matcher) Clone() *Matcher {
 	return &Matcher{m: m.m}
 }
 
-// Find executed a callback for every match inside root.
-// If callback returns false, currently matched node children are not visited.
-func (m *Matcher) Find(root node.Node, callback func(*MatchData) bool) {
-	m.m.findAST(root, callback)
-}
-
 // Match attempts to match n without recursing into it.
 //
 // Returned match data should only be examined if the

--- a/src/phpgrep/phpgrep.go
+++ b/src/phpgrep/phpgrep.go
@@ -18,9 +18,18 @@ type Matcher struct {
 	m matcher
 }
 
+type CapturedNode struct {
+	Name string
+	Node node.Node
+}
+
 type MatchData struct {
-	Node  node.Node
-	Named map[string]node.Node
+	Node    node.Node
+	Capture []CapturedNode
+}
+
+func (data MatchData) CapturedByName(name string) (node.Node, bool) {
+	return findNamed(data.Capture, name)
 }
 
 // Clone returns a deep copy of m.
@@ -33,6 +42,6 @@ func (m *Matcher) Clone() *Matcher {
 // Returned match data should only be examined if the
 // second return value is true.
 func (m *Matcher) Match(n node.Node) (MatchData, bool) {
-	found := m.m.match(n)
-	return m.m.data, found
+	var state matcherState
+	return m.m.match(&state, n)
 }

--- a/src/phpgrep/tracing_test.go
+++ b/src/phpgrep/tracing_test.go
@@ -13,8 +13,6 @@ func TestTracing(t *testing.T) {
 		t.Skip("tracingEnabled is false; run tests with `-tags tracing`")
 	}
 
-	var c Compiler
-
 	tests := []struct {
 		pattern string
 		input   string
@@ -228,9 +226,9 @@ func TestTracing(t *testing.T) {
 
 	for _, test := range tests {
 		var buf bytes.Buffer
-		matcher := mustCompile(t, &c, test.pattern)
+		matcher := mustCompile(t, test.pattern)
 		matcher.m.tracingBuf = &buf
-		matcher.Match(mustParse(t, []byte(test.input)))
+		matcher.Match(mustParse(t, test.input))
 		trace := strings.Split(buf.String(), "\n")
 		trace = trace[:len(trace)-1] // Drop ""
 		if diff := cmp.Diff(trace, test.trace); diff != "" {

--- a/src/phpgrep/utils.go
+++ b/src/phpgrep/utils.go
@@ -14,6 +14,15 @@ import (
 	"github.com/VKCOM/noverify/src/php/parser/position"
 )
 
+func findNamed(capture []CapturedNode, name string) (node.Node, bool) {
+	for _, c := range capture {
+		if c.Name == name {
+			return c.Node, true
+		}
+	}
+	return nil, false
+}
+
 func getNodePos(n node.Node) *position.Position {
 	pos := n.GetPosition()
 	if pos == nil {


### PR DESCRIPTION
```
All mutable state is now passed explicitly through
the matcher methods. This way we can decouple readonly
shared state (fields inside the matcher) and state
that needs to be changed during the matching.

Since most patterns have 0-3 variables, a slice
with linear search is a viable alternative to a map.
It's easier to re-use memory and make less
allocations with a slice.

Numbers below show the performance difference where "old"
is a map-based solution and "new" is based on slices.

name                              old time/op    new time/op    delta
Find/positive/call_parent_ctor-8     273ns ± 2%     156ns ± 1%   -42.90%  (p=0.008 n=5+5)
Find/negative/call_parent_ctor-8    86.0ns ± 3%    13.8ns ± 1%   -83.96%  (p=0.008 n=5+5)
Find/negative/const-tail-8           811ns ± 2%     658ns ± 1%   -18.86%  (p=0.008 n=5+5)
Find/positive/call*-8                311ns ± 2%     197ns ± 1%   -36.70%  (p=0.008 n=5+5)
Find/positive/call_*-8               337ns ± 1%     219ns ± 1%   -34.93%  (p=0.008 n=5+5)
Find/positive/call*_-8               207ns ± 1%     101ns ± 0%   -51.16%  (p=0.016 n=5+4)
Find/positive/call*_*-8              347ns ± 1%     228ns ± 0%   -34.26%  (p=0.016 n=5+4)
Find/negative/call_-8                171ns ± 2%      91ns ± 1%   -46.93%  (p=0.008 n=5+5)
Find/positive/with-1-named-8         496ns ± 1%     267ns ± 1%   -46.09%  (p=0.008 n=5+5)
Find/negative/with-1-named-8         496ns ± 1%     264ns ± 2%   -46.71%  (p=0.016 n=4+5)
Find/positive/with-5-named-8         724ns ± 0%     454ns ± 0%   -37.33%  (p=0.016 n=5+4)

name                              old alloc/op   new alloc/op   delta
Find/positive/call_parent_ctor-8     48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Find/negative/call_parent_ctor-8     48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Find/negative/const-tail-8           48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Find/positive/call*-8                48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Find/positive/call_*-8               48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Find/positive/call*_-8               48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Find/positive/call*_*-8              48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Find/negative/call_-8                48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Find/positive/with-1-named-8          336B ± 0%       32B ± 0%   -90.48%  (p=0.008 n=5+5)
Find/negative/with-1-named-8          336B ± 0%       32B ± 0%   -90.48%  (p=0.008 n=5+5)
Find/positive/with-5-named-8          336B ± 0%      160B ± 0%   -52.38%  (p=0.008 n=5+5)

name                              old allocs/op  new allocs/op  delta
Find/positive/call_parent_ctor-8      1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Find/negative/call_parent_ctor-8      1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Find/negative/const-tail-8            1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Find/positive/call*-8                 1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Find/positive/call_*-8                1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Find/positive/call*_-8                1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Find/positive/call*_*-8               1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Find/negative/call_-8                 1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Find/positive/with-1-named-8          2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.008 n=5+5)
Find/negative/with-1-named-8          2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.008 n=5+5)
Find/positive/with-5-named-8          2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.008 n=5+5)

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
```