### PR TITLE
linter: add parentConstructor checker

### DIFF
--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -235,6 +235,12 @@ func init() {
 		},
 
 		{
+			Name:    "parentConstructor",
+			Default: true,
+			Comment: `Report missing parent::__construct calls in class constructors.`,
+		},
+
+		{
 			Name:    "oldStyleConstructor",
 			Default: true,
 			Comment: `Report old-style (PHP4) class constructors.`,


### PR DESCRIPTION
parentConstructor reports __construct() methods that
do not call parent::__construct() when they need to do so.

We require a parent constructor call if a class extends
the other class that has a explicitly defined constructor
(which is callable from the derived class).

Fixes #408

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>