### PR TITLE
linter: add 2 exceptions to type precision inference

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -338,7 +338,11 @@ func (b *BlockWalker) EnterNode(w walker.Walkable) (res bool) {
 		for _, vv := range s.Vars {
 			v := vv.(*stmt.StaticVar)
 			ev := v.Variable
-			b.addVarName(v, ev.Name, solver.ExprTypeLocalCustom(b.ctx.sc, b.r.ctx.st, v.Expr, b.ctx.customTypes), "static", meta.VarAlwaysDefined)
+			typ := solver.ExprTypeLocalCustom(b.ctx.sc, b.r.ctx.st, v.Expr, b.ctx.customTypes)
+			// Static vars can be assigned below and preserve the type of
+			// the previously assigned value.
+			typ.MarkAsImprecise()
+			b.addVarName(v, ev.Name, typ, "static", meta.VarAlwaysDefined)
 			b.addNonLocalVarName(ev.Name)
 			if v.Expr != nil {
 				v.Expr.Walk(b)

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1222,6 +1222,12 @@ func (d *RootWalker) parseFuncArgs(params []node.Node, parTypes phpDocParamsMap,
 			}
 		} else if typ.IsEmpty() && p.DefaultValue != nil {
 			typ = solver.ExprTypeLocal(sc, d.ctx.st, p.DefaultValue)
+			// For the type resolver default value can look like a
+			// precise source of information (e.g. "false" is a precise bool),
+			// but it's not assigned unconditionally.
+			// If explicit argument is provided, that parameter can have
+			// almost any type possible.
+			typ.MarkAsImprecise()
 		}
 
 		if p.Variadic {

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -48,6 +48,10 @@ type TypesMap struct {
 // Important invariant: a precise map contains no lazy types.
 func (m TypesMap) IsPrecise() bool { return m.flags&mapPrecise != 0 }
 
+func (m *TypesMap) MarkAsImprecise() {
+	m.flags &^= mapPrecise
+}
+
 func (m TypesMap) isImmutable() bool { return m.flags&mapImmutable != 0 }
 
 // IsResolved reports whether all types inside types map are resolved.
@@ -211,7 +215,7 @@ func (m TypesMap) AppendString(str string) TypesMap {
 
 		// Since we have no idea where str is coming from,
 		// mark map as imprecise.
-		m.flags &^= mapPrecise
+		m.MarkAsImprecise()
 
 		return m
 	}


### PR DESCRIPTION
1. Parameter default value is not a precise source.

2. Static variables should be skipped as their assignment
   is only executed once (type can change after another assignment).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>