### PR TITLE
improve exprtype tests

### DIFF
--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -157,6 +157,11 @@ type BlockContext struct {
 	w *BlockWalker
 }
 
+// ExprType resolves the type of e expression node.
+func (ctx *BlockContext) ExprType(e node.Node) meta.TypesMap {
+	return ctx.w.exprType(e)
+}
+
 // Report records linter warning of specified level.
 // chechName is a key that identifies the "checker" (diagnostic name) that found
 // issue being reported.

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -91,15 +91,7 @@ func varToString(v node.Node) string {
 }
 
 func typesMapToTypeExpr(p *phpdoc.TypeParser, m meta.TypesMap) phpdoc.Type {
-	// TODO: when ExprType stops returning
-	// "empty_array" type, remove the extra check.
-	var typeString string
-	if m.Is("empty_array") {
-		typeString = "mixed[]"
-	} else {
-		typeString = m.String()
-	}
-
+	typeString := m.String()
 	return p.Parse(typeString)
 }
 

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -65,27 +65,9 @@ func ExprTypeCustom(sc *meta.Scope, cs *meta.ClassParseState, n node.Node, custo
 		return m
 	}
 
-	newMap := make(map[string]struct{}, m.Len())
 	visitedMap := make(map[string]struct{})
-
-	m.Iterate(func(k string) {
-		defer func() {
-			if r := recover(); r != nil {
-				log.Printf("Panic during parsing '%s'", meta.NewTypesMap(k))
-				log.Printf("Scope: %s", sc)
-				panic(r)
-			}
-		}()
-
-		for kk := range resolveType(cs.CurrentClass, k, visitedMap) {
-			newMap[kk] = struct{}{}
-		}
-	})
-
-	if len(newMap) == 0 {
-		return meta.MixedType
-	}
-	return meta.NewTypesMapFromMap(newMap)
+	resolvedTypes := ResolveTypes(cs.CurrentClass, m, visitedMap)
+	return meta.NewTypesMapFromMap(resolvedTypes)
 }
 
 func internalFuncType(nm string, sc *meta.Scope, cs *meta.ClassParseState, c *expr.FunctionCall, custom []CustomType) (typ meta.TypesMap, ok bool) {


### PR DESCRIPTION
```
Summary:

- Re-written all exprtype tests (see below).

- Used ResolveTypes in ExprType because we had
  a code duplication there that did not handle empty_array.

- Added ExprType() method to make it easier for custom
  checkers to evaluate the expression type.

How exprtype tests worked before:

	For every test expression we generated a function
	that performed `return expr`. Then we were
	comparing function inferred return type with
	expected type. The problem is, this approach
	does not allow us to test ExprType() function
	in arbitrary context. A simple example is that
	we can't test global scope type resolving.

New approach:

	Instead of having a separate test cases,
	a special exprtype($expr, $typestring) calls
	are expected to be used.
	That function can be placed anywhere inside
	a code that is being tested.
	During the first phase, all types are collected
	by exprTypeCollector. When we have all the types,
	second traversal is performed by exprTypeWalker
	that uses exprTypeCollector results to check
	whether the actual types map the expectations.
	We can't do it in a single phase due to the fact
	that it's impossible to pass a *testing.T to a checker.
	With this approach it's easier to test a type inside
	some condition body, like if with instanceof check.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
```