### PR TITLE
meta: fix precision issue for mutable type maps

### DIFF
--- a/src/meta/scope.go
+++ b/src/meta/scope.go
@@ -288,7 +288,7 @@ func (s *Scope) Clone() *Scope {
 	res := &Scope{vars: make(map[string]*scopeVar, len(s.vars))}
 	for k, v := range s.vars {
 		res.vars[k] = &scopeVar{
-			typesMap: v.typesMap.clone(),
+			typesMap: v.typesMap.Clone(),
 			flags:    v.flags,
 		}
 	}

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -130,7 +130,7 @@ func NewTypesMapFromMap(m map[string]struct{}) TypesMap {
 	return TypesMap{m: m}
 }
 
-// Immutable returns immutable copy of TypesMap
+// Immutable returns immutable view of TypesMap
 func (m TypesMap) Immutable() TypesMap {
 	return TypesMap{
 		flags: m.flags | mapImmutable,
@@ -233,7 +233,7 @@ func (m TypesMap) AppendString(str string) TypesMap {
 	return TypesMap{m: mm}
 }
 
-func (m TypesMap) clone() TypesMap {
+func (m TypesMap) Clone() TypesMap {
 	if m.Len() == 0 || m.isImmutable() {
 		return m
 	}
@@ -242,7 +242,7 @@ func (m TypesMap) clone() TypesMap {
 	for typ := range m.m {
 		mm[typ] = struct{}{}
 	}
-	return TypesMap{m: mm}
+	return TypesMap{m: mm, flags: m.flags}
 }
 
 // Append adds provided types to current map and returns new one (immutable maps are always copied)
@@ -262,6 +262,7 @@ func (m TypesMap) Append(n TypesMap) TypesMap {
 			m.m = make(map[string]struct{}, n.Len())
 		}
 
+		m.MarkAsImprecise()
 		for k, v := range n.m {
 			m.m[k] = v
 		}


### PR DESCRIPTION
```
Append(n TypesMap) case for mutable maps had no
checks for the precision. This made mutable maps
keep precision bit even if the imprecise map was appended.

We mark all mutable maps that are being appended
to as imprecise because we're lacking a good control
flow support (several open issues with how we deal with
if statements, etc.) and exprtype tests are not
exhaustive on the type precision yet.
More investigation is needed.

exprtype tests were fixed along the way.
If typesmap comes from a *scope.Var and it happens
to be mutable, it can change over the course of
the analysis. We need to do a Clone() to avoid that.

Note that TypesMap.Immutable() is not enough as it
only works if the map ownership was transferred.
In our case, it's not true as *scope.Var is still
the owner and this may result in our immutable
map being mutated after the exprTypeCollect is done.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
```