### PR TITLE
cmd: add Run() function

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -74,11 +74,16 @@ func canBeDisabled(filename string) bool {
 	return allowDisableRegex.MatchString(filename)
 }
 
-// Main is the actual main function to be run. It is separate from linter so that you can insert your own hooks
-// before running main().
+// Run executes linter main function.
+//
+// It is separate from linter so that you can insert your own hooks
+// before running Run().
+//
+// It returns a status code to be used for os.Exit() and
+// initialization error (if any).
 //
 // Optionally, non-nil config can be passed to customize function behavior.
-func Main(cfg *MainConfig) {
+func Run(cfg *MainConfig) (int, error) {
 	if cfg == nil {
 		cfg = &MainConfig{}
 	}
@@ -92,7 +97,12 @@ func Main(cfg *MainConfig) {
 		cfg.AfterFlagParse()
 	}
 
-	status, err := mainNoExit()
+	return mainNoExit()
+}
+
+// Main is like Run(), but it calls os.Exit() and does not return.
+func Main(cfg *MainConfig) {
+	status, err := Run(cfg)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Run() is like Main(), but it returns <int,error>
instead of doing log.Fatal()/os.Exit().

Fixes #490

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>