### PR TITLE
all: add meta.IsLoadingStubs and use meta.InitStubs everywhere

### DIFF
--- a/src/cmd/git_main.go
+++ b/src/cmd/git_main.go
@@ -54,7 +54,9 @@ func gitRepoComputeReportsFromCommits(logArgs, diffArgs []string) (oldReports, r
 
 	if gitFullDiff {
 		meta.ResetInfo()
-		linter.InitStubs()
+		if err := loadEmbeddedStubs(); err != nil {
+			log.Panicf("Load embedded stubs: %v", err)
+		}
 
 		start = time.Now()
 		linter.ParseFilenames(linter.ReadFilesFromGit(gitRepo, gitCommitFrom, nil))
@@ -68,7 +70,9 @@ func gitRepoComputeReportsFromCommits(logArgs, diffArgs []string) (oldReports, r
 		log.Printf("Parsed old commit for %s (%d reports)", time.Since(start), len(oldReports))
 
 		meta.ResetInfo()
-		linter.InitStubs()
+		if err := loadEmbeddedStubs(); err != nil {
+			log.Panicf("Load embedded stubs: %v", err)
+		}
 
 		start = time.Now()
 		linter.ParseFilenames(linter.ReadFilesFromGit(gitRepo, gitCommitTo, nil))

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -427,7 +427,7 @@ func initRules() error {
 
 func initStubs() error {
 	if linter.StubsDir != "" {
-		linter.InitStubs()
+		linter.InitStubsFromDir(linter.StubsDir)
 		return nil
 	}
 
@@ -457,8 +457,7 @@ func LoadEmbeddedStubs(filenames []string) error {
 		}
 	}
 
-	linter.ParseFilenames(readStubs)
-	meta.Info.InitStubs()
+	linter.InitStubs(readStubs)
 
 	// Using atomic here for consistency.
 	if atomic.LoadInt64(&errorsCount) != 0 {

--- a/src/langsrv/langsrv.go
+++ b/src/langsrv/langsrv.go
@@ -897,7 +897,7 @@ func Start() {
 	rd := bufio.NewReader(os.Stdin)
 	connWr = os.Stdout
 
-	linter.InitStubs()
+	linter.InitStubsFromDir(linter.StubsDir)
 
 	for {
 		ln, err := rd.ReadString('\n')

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -535,8 +535,14 @@ func doParseFile(f FileInfo, needReports bool) (reports []*Report) {
 	return reports
 }
 
-// InitStubs parses directory with PHPStorm stubs which has all internal PHP classes and functions declared.
-func InitStubs() {
-	ParseFilenames(ReadFilenames([]string{StubsDir}, nil))
+func InitStubs(readFileNamesFunc ReadCallback) {
+	meta.SetLoadingStubs(true)
+	ParseFilenames(readFileNamesFunc)
 	meta.Info.InitStubs()
+	meta.SetLoadingStubs(false)
+}
+
+// InitStubsFromDir parses directory with PHPStorm stubs which has all internal PHP classes and functions declared.
+func InitStubsFromDir(dir string) {
+	InitStubs(ReadFilenames([]string{dir}, nil))
 }

--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -1560,8 +1560,12 @@ exprtype(array_map(function($x) { return $x; }, $ints), 'mixed[]');
 func runExprTypeTest(t *testing.T, params *exprTypeTestParams) {
 	meta.ResetInfo()
 	if params.stubs != "" {
-		linttest.ParseTestFile(t, "stubs.php", params.stubs)
-		meta.Info.InitStubs()
+		linter.InitStubs(func(ch chan linter.FileInfo) {
+			ch <- linter.FileInfo{
+				Filename: "stubs.php",
+				Contents: []byte(params.stubs),
+			}
+		})
 	}
 	linttest.ParseTestFile(t, "exprtype.php", params.code)
 

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -14,6 +14,7 @@ var (
 	internalClasses           ClassesMap
 
 	indexingComplete bool
+	loadingStubs     bool
 
 	// Info contains global meta information for all classes, functions, etc.
 	Info info
@@ -430,6 +431,18 @@ func OnIndexingComplete(cb func()) {
 	} else {
 		onCompleteCallbacks = append(onCompleteCallbacks, cb)
 	}
+}
+
+// SetLoadingStubs changes IsLoadingStubs() return value.
+//
+// Should be only called from linter.InitStubs() function.
+func SetLoadingStubs(loading bool) {
+	loadingStubs = loading
+}
+
+// IsLoadingStubs reports whether we're parsing stub files right now.
+func IsLoadingStubs() bool {
+	return loadingStubs
 }
 
 func SetIndexingComplete(complete bool) {


### PR DESCRIPTION
meta.InitStubs() sets stubs loading flag to true in the beginning
and to false before it returns.

Minor issue fix: git_main now uses embedded stubs when
executed with gitFullDiff=true.

Fixes #493

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>