### PR TITLE
cmd: add MainConfig.BeforeReport hook

### DIFF
--- a/src/cmd/conf.go
+++ b/src/cmd/conf.go
@@ -1,5 +1,9 @@
 package cmd
 
+import (
+	"github.com/VKCOM/noverify/src/linter"
+)
+
 // MainConfig describes optional main function config.
 // All zero field values have some defined behavior.
 type MainConfig struct {
@@ -8,4 +12,9 @@ type MainConfig struct {
 	//
 	// If nil, behaves as a no-op function.
 	AfterFlagParse func()
+
+	// BeforeReport acts as both an on-report action and a filter.
+	//
+	// If false is returned, the given report will not be reported.
+	BeforeReport func(*linter.Report) bool
 }

--- a/src/cmd/git_main.go
+++ b/src/cmd/git_main.go
@@ -154,7 +154,7 @@ func gitRepoComputeReportsFromLocalChanges() (oldReports, reports []*linter.Repo
 	return oldReports, reports, changes, true
 }
 
-func gitMain() (int, error) {
+func gitMain(cfg *MainConfig) (int, error) {
 	var (
 		oldReports, reports []*linter.Report
 		diffArgs            []string
@@ -184,7 +184,7 @@ func gitMain() (int, error) {
 	}
 	log.Printf("Computed reports diff for %s", time.Since(start))
 
-	criticalReports := analyzeReports(diff)
+	criticalReports := analyzeReports(cfg, diff)
 
 	if criticalReports > 0 {
 		log.Printf("Found %d critical issues, please fix them.", criticalReports)

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -310,6 +310,9 @@ func (r *Report) MarshalJSON() ([]byte, error) {
 	return b, err
 }
 
+// Message returns report message.
+func (r *Report) Message() string { return r.msg }
+
 func (r *Report) String() string {
 	msg := r.msg
 	if r.checkName != "" {


### PR DESCRIPTION
This allows a custom NoVerify-based tool to examine all
reports before they are printed.

Another use case is a custom reports filtering.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>