### PR TITLE
phpdoc: fix phpdoc.Parse()

### DIFF
--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -47,6 +47,21 @@ func init() {
 	})
 }
 
+func TestExprTypeIssue497(t *testing.T) {
+	code := `<?php
+/**
+ * @param shape(a:int) $x
+ *
+ * @return T<int>
+ */
+function f($x) {
+  exprtype($x, '\shape$exprtype.php$0$');
+  return [$v];
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func TestExprTypePrecise2(t *testing.T) {
 	code := `<?php
 function test1($data) {

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1230,3 +1230,16 @@ Base::staticProtMethod();
 	}
 	test.RunAndMatch()
 }
+
+func TestIssue497(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+/**
+ * @param shape(a:int) $x
+ * @return T<int>
+ */
+function f($x) {
+  $v = $x['a'];
+  return [$v];
+}
+`)
+}

--- a/src/phpdoc/parser.go
+++ b/src/phpdoc/parser.go
@@ -155,6 +155,6 @@ func nextField(s string) (field, rest string) {
 }
 
 func nextTypeField(parser *TypeParser, s string) (field Type, rest string) {
-	typ := parser.Parse(s)
+	typ := parser.Parse(s).Clone()
 	return typ, strings.TrimLeft(s[typ.Expr.End:], " ")
 }

--- a/src/phpdoc/parser_test.go
+++ b/src/phpdoc/parser_test.go
@@ -9,12 +9,15 @@ import (
 
 func TestParseSimple(t *testing.T) {
 	p := NewTypeParser()
+	parseType := func(s string) Type {
+		return p.Parse(s).Clone()
+	}
 	want := []CommentPart{
 		&TypeVarCommentPart{
 			line:       4,
 			name:       "param",
 			VarIsFirst: true,
-			Type:       p.Parse(`int  Here goes the description`),
+			Type:       parseType(`int  Here goes the description`),
 			Var:        "$param",
 			Rest:       "Here goes the description",
 		},
@@ -22,21 +25,21 @@ func TestParseSimple(t *testing.T) {
 			line: 5,
 			name: "param",
 			Var:  "$arr",
-			Type: p.Parse(`array<int, string> $arr  Array of int to string`),
+			Type: parseType(`array<int, string> $arr  Array of int to string`),
 			Rest: "Array of int to string",
 		},
 		&TypeVarCommentPart{
 			line: 6,
 			name: "param",
 			Var:  "$arr_nested",
-			Type: p.Parse(`array<int, array<string, stdclass> > $arr_nested  Array of nested arrays`),
+			Type: parseType(`array<int, array<string, stdclass> > $arr_nested  Array of nested arrays`),
 			Rest: `Array of nested arrays`,
 		},
 		&TypeVarCommentPart{
 			line:       7,
 			name:       "param",
 			VarIsFirst: true,
-			Type:       p.Parse(`array<int, array<string, stdclass> >  Array of nested arrays`),
+			Type:       parseType(`array<int, array<string, stdclass> >  Array of nested arrays`),
 			Var:        "$arr_nested",
 			Rest:       "Array of nested arrays",
 		},
@@ -44,13 +47,13 @@ func TestParseSimple(t *testing.T) {
 			line: 8,
 			name: "var",
 			Var:  "",
-			Type: p.Parse(`int`),
+			Type: parseType(`int`),
 		},
 		&TypeVarCommentPart{
 			line: 9,
 			name: "var",
 			Var:  "$foo1",
-			Type: p.Parse(`array<int> $foo1  var comment`),
+			Type: parseType(`array<int> $foo1  var comment`),
 			Rest: "var comment",
 		},
 		&TypeVarCommentPart{
@@ -58,22 +61,22 @@ func TestParseSimple(t *testing.T) {
 			name:       "var",
 			VarIsFirst: true,
 			Var:        "$foo2",
-			Type:       p.Parse(`array<int,string>`),
+			Type:       parseType(`array<int,string>`),
 		},
 		&TypeVarCommentPart{
 			line: 11,
 			name: "var",
-			Type: p.Parse(`array< int, string >`),
+			Type: parseType(`array< int, string >`),
 		},
 		&TypeVarCommentPart{
 			line: 12,
 			name: "var",
-			Type: p.Parse("array<int, array<string, stdclass>	>"),
+			Type: parseType("array<int, array<string, stdclass>	>"),
 		},
 		&TypeCommentPart{
 			line: 13,
 			name: "return",
-			Type: p.Parse(`int   some    result`),
+			Type: parseType(`int   some    result`),
 			Rest: `some    result`,
 		},
 		&RawCommentPart{


### PR DESCRIPTION
Since there can be multiple type annotations in a phpdoc
block, we need to do a Type.Clone() to avoid previously
parsed types corruption.

We could avoid that if we were processing phpdoc
directives one-by-one in a stream fashion, but since
we're eagerly converting all directives to a slice,
we can't avoid these allocations.

Fixes #497

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>