### PR TITLE
linttest: shuffle PHP input files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ install:
 
 check:
 	@go vet $(go list ./src/... | grep -v vendor)
-	@go test -race -v ./src/...
+	@go test -count 3 -race -v ./src/...
 
 .PHONY: check

--- a/src/linttest/golden_test.go
+++ b/src/linttest/golden_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -180,7 +181,11 @@ func TestGolden(t *testing.T) {
 			}
 
 			var parts []string
-			for _, r := range test.RunLinter() {
+			reports := test.RunLinter()
+			sort.SliceStable(reports, func(i, j int) bool {
+				return reports[i].GetFilename() < reports[j].GetFilename()
+			})
+			for _, r := range reports {
 				if disable[r.CheckName()] {
 					continue
 				}

--- a/src/linttest/testdata/flysystem/golden.txt
+++ b/src/linttest/testdata/flysystem/golden.txt
@@ -52,12 +52,6 @@ MAYBE   phpdoc: Missing PHPDoc for "retrieveSafely" public method at testdata/fl
 MAYBE   phpdoc: Missing PHPDoc for "forFileInfo" public method at testdata/flysystem/src/UnreadableFileException.php:9
     public static function forFileInfo(SplFileInfo $fileInfo)
                            ^^^^^^^^^^^
-INFO    unused: Variable e is unused (use $_ to ignore this inspection) at testdata/flysystem/src/Util/MimeType.php:208
-        } catch (ErrorException $e) {
-                                ^^
-MAYBE   ternarySimplify: could rewrite as `static::$extensionToMimeTypeMap[$extension] ?? 'text/plain'` at testdata/flysystem/src/Util/MimeType.php:222
-        return isset(static::$extensionToMimeTypeMap[$extension])
-               ^^^^^^^^^^^
 MAYBE   phpdoc: Missing PHPDoc for "isSeekableStream" public method at testdata/flysystem/src/Util.php:258
     public static function isSeekableStream($resource)
                            ^^^^^^^^^^^^^^^^
@@ -67,3 +61,9 @@ MAYBE   regexpSimplify: May re-write '#^[a-zA-Z]{1}:[^\\\/]#' as '#^[a-zA-Z]:[^\
 MAYBE   regexpSimplify: May re-write '#^[a-zA-Z]{1}:$#' as '#^[a-zA-Z]:$#' at testdata/flysystem/src/Util.php:346
         if (preg_match('#^[a-zA-Z]{1}:$#', $basename)) {
                        ^^^^^^^^^^^^^^^^^^
+INFO    unused: Variable e is unused (use $_ to ignore this inspection) at testdata/flysystem/src/Util/MimeType.php:208
+        } catch (ErrorException $e) {
+                                ^^
+MAYBE   ternarySimplify: could rewrite as `static::$extensionToMimeTypeMap[$extension] ?? 'text/plain'` at testdata/flysystem/src/Util/MimeType.php:222
+        return isset(static::$extensionToMimeTypeMap[$extension])
+               ^^^^^^^^^^^


### PR DESCRIPTION
In our tests we don't do concurrent indexing/linting which
makes it harder to catch undesired processing order dependencies.

With randomized indexing/linting we're getting closer to the
real world cases where order of parsing is not guaranteed to
be the same between executions.

Test failure prints a seed that was used.
Using that value with `$TEST_SEED` environment variable
makes it possible to easily reproduce the failing state.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>