### PR TITLE
Solving issue #324 and #325

### DIFF
--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -79,6 +79,12 @@ func init() {
 		},
 
 		{
+			Name:    "illegalArrayKeys",
+			Default: true,
+			Comment: `Report illegal keys in array literals.`,
+		},
+
+		{
 			Name:    "dupArrayKeys",
 			Default: true,
 			Comment: `Report duplicated keys in array literals.`,

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -1127,6 +1127,28 @@ func TestDuplicateArrayKey(t *testing.T) {
 	test.RunAndMatch()
 }
 
+func TestIllegalArrayKeys(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+class A{}
+$arr = [
+    new A() => 1,
+    function () {
+
+} => 2,
+    [1, 2, 3] => 3,
+];
+`)
+	test.Expect = []string{
+		`Illegal array key new A()`,
+		`Illegal array key function () {
+
+}`,
+		`Illegal array key [1, 2, 3]`,
+	}
+	test.RunAndMatch()
+}
+
 func TestMixedArrayKeys(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
#325
Added diagnostics duplication of non-literal keys added. Now the following keys are checked:
```
scalar.Dnumber,
node.SimpleVar,
expr.ConstFetch,
binary.Concat,
expr.ClassConstFetch,
expr.PropertyFetch,
expr.ArrayDimFetch,
expr.StaticPropertyFetch,
expr.Ternary,
expr.FunctionCall,
expr.MethodCall,
expr.StaticCall,
expr.InstanceOf 
```
and everyone `node.Node` that satisfying `sideEffectFree`.

Improved node.Lnumber checking. Now the same numbers in different number systems are considered the same. For example: 
```
$array = [
    1234 => 7,
    02322 => 8,  // 02322 = 1234 duplicate
    0x4D2 => 9,  // 0x4D2 = 1234 duplicate
    0b10011010010 => 10,// 0b10011010010 = 1234 duplicate
    1_234 => 11, // 1_234 = 1234 duplicate
];
```
Added new type of warnings - `illegalArrayKeys`. Example: 
```
class A{}

$arr = [
    new A() => 1,  // Illegal array key new A(), 
    [1, 2, 3] => 2,// Illegal array key [1, 2, 3]
    function () {} => 3, // Illegal array key function () {}
];
```

#324 
Added analysis of the following class-scoped:
`stmt.PropertyList:`
> `expr.ClassConstFetch`
> `expr.Array`
> `expr.Ternary`
> `expr.ConstFetch`

`stmt.ClassConstList:`
> `expr.ClassConstFetch`
> `expr.Array`
> `expr.Ternary`
> `expr.ConstFetch`

Example: 

```
class T
{
    const C = 1;

    const C1 = self::UNDEFCONST;              // undefined class constant
    const C2 = self::C ? "var" : "var";       // then/else operands are identical

    public $var1 = self::UNDEFCONST;          // undefined class constant
    public $var2 = self::C ? "var1" : "var1"; // then/else operands are identical

    public $publicArray = [
        'key1' => 'somethingInPublic',
        'key2' => 'other_thingInPublic',
        'key1' => 'third_thingInPublic', // duplicate key 'key1'
    ];

    const constArray = [
        'key1' => 'somethingInConst',
        'key2' => 'other_thingInConst',
        'key1' => 'third_thingInConst', // duplicate key 'key1'
    ];

    public static $staticArray = [
        'key1' => 'somethingInStatic',
        'key2' => 'other_thingInStatic',
        'key1' => 'third_thingInStatic', // duplicate key 'key1'
    ];

    public $mixArrayKeys = [
        1 => 1,
	2,
	3,
    ];
}
```

### Behavior before
No warnings.

### Actual behavior
```
const C1 = self::UNDEFCONST; - undefined class constant
const C2 = self::C ? "var" : "var"; - then/else operands are identical

public $var1 = self::UNDEFCONST; - undefined class constant
public $var2 = self::C ? "var1" : "var1"; - then/else operands are identical

'key1' => 'third_thingInPublic', - duplicate key 'key1'
'key1' => 'third_thingInConst', - duplicate key 'key1'
'key1' => 'third_thingInStatic', - duplicate key 'key1'

    public $mixArrayKeys = [
        1 => 1,
	2,
	3,
    ]; - Mixing implicit and explicit array keys
```

Thank you for the attention :)