### PR TITLE
Added non-literal key duplication report

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1320,14 +1320,7 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 
 		if b.sideEffectFree(item.Key) {
 			key = b.getKeyValue(item.Key)
-
-			// as we want to delete double `'` or `"` around single string
-			switch k := item.Key.(type) {
-			case *scalar.String:
-				reportKeyStr = unquote(k.Value)
-			default:
-				reportKeyStr = astutil.FmtNode(k)
-			}
+			reportKeyStr = astutil.FmtNode(item.Key)
 		} else {
 			continue
 		}

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -1123,7 +1123,7 @@ func TestDuplicateArrayKey(t *testing.T) {
 		  'key1' => 'third_thing', // duplicate
 	  ];
 	}`)
-	test.Expect = []string{"Duplicate array key 'key1'"}
+	test.Expect = []string{"Duplicate array key ''key1''"}
 	test.RunAndMatch()
 }
 


### PR DESCRIPTION
This pull request solves #325. I have used sideEffectFree() function for detection of const keys and then format some of nodes to special format to handle PHP rules of array keys converting. As I think it is to complex for this task to implement the whole node tree switch, I have tried to simplify it maximally. As a result features of array last comma and different string quotes are implemented as tricks. I can't find the example which will destroy my trick. If you can, please, tell me about it. Also I have added test for this issue.

PS: This PR is a test task for the internship in VK in the backend-infrastructure team.