### PR TITLE
Adding a check for some class fields

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -726,16 +726,9 @@ func (d *RootWalker) enterPropertyList(pl *stmt.PropertyList) bool {
 	for _, pNode := range pl.Properties {
 		p := pNode.(*stmt.Property)
 
-		switch exprProperty := p.Expr.(type) {
-		case *expr.Array:
-			if exprProperty.ShortSyntax {
-				b.handleArray(exprProperty)
-			}
-		case *expr.ClassConstFetch:
-			b.handleClassConstFetch(exprProperty)
-		case *expr.Ternary:
-			b.handleTernary(exprProperty)
-		}
+		b.addVar(p.Variable, meta.MixedType, "property", meta.VarAlwaysDefined)
+		b.addStatement(p)
+		p.Walk(b)
 
 		nm := p.Variable.Name
 
@@ -848,7 +841,6 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 	}
 	d.checkCommentMisspellings(meth.MethodName, meth.PhpDocComment)
 	d.checkIdentMisspellings(meth.MethodName)
-
 	for _, p := range meth.Params {
 		d.checkFuncParam(p.(*node.Parameter))
 		d.checkVarnameMisspellings(p, p.(*node.Parameter).Variable.Name)

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1288,6 +1288,10 @@ class T
         2,
         3,
     ];
+
+	public function __construct($array = array(1, 2, 3))
+    {}
+
 }
 `)
 
@@ -1301,6 +1305,7 @@ class T
 		`Duplicate array key 'key1'`,
 		`Use of old array syntax (use short form instead)`,
 		`Mixing implicit and explicit array keys`,
+		`Use of old array syntax (use short form instead)`,
 	}
 	test.RunAndMatch()
 }

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1231,6 +1231,19 @@ Base::staticProtMethod();
 	test.RunAndMatch()
 }
 
+func TestIssue497(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+/**
+ * @param shape(a:int) $x
+ * @return T<int>
+ */
+function f($x) {
+  $v = $x['a'];
+  return [$v];
+}
+`)
+}
+
 func TestIssue324(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php

--- a/src/linttest/testdata/idn/golden.txt
+++ b/src/linttest/testdata/idn/golden.txt
@@ -1,12 +1,18 @@
 MAYBE   phpdoc: Missing PHPDoc for "idn_to_ascii" public method at testdata/idn/idn.php:64
     public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
                            ^^^^^^^^^^^^
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/idn/idn.php:64
+    public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
+                                                                                   ^^^^^^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/idn/idn.php:87
         $idna_info = array(
                      
 MAYBE   phpdoc: Missing PHPDoc for "idn_to_utf8" public method at testdata/idn/idn.php:96
     public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
                            ^^^^^^^^^^^
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/idn/idn.php:96
+    public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
+                                                                                  ^^^^^^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/idn/idn.php:119
         $idna_info = array(
                      

--- a/src/linttest/testdata/idn/golden.txt
+++ b/src/linttest/testdata/idn/golden.txt
@@ -1,3 +1,9 @@
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/idn/idn.php:49
+    private static $encodeTable = array(
+                                  
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/idn/idn.php:55
+    private static $decodeTable = array(
+                                  
 MAYBE   phpdoc: Missing PHPDoc for "idn_to_ascii" public method at testdata/idn/idn.php:64
     public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
                            ^^^^^^^^^^^^

--- a/src/linttest/testdata/underscore/golden.txt
+++ b/src/linttest/testdata/underscore/golden.txt
@@ -127,6 +127,9 @@ ERROR   undefined: Property {mixed}->_uniqueId does not exist at testdata/unders
 ERROR   undefined: Property {mixed}->_uniqueId does not exist at testdata/underscore/underscore.php:824
     return (is_null($prefix)) ? self::_wrap($_instance->_uniqueId) : self::_wrap($prefix . $_instance->_uniqueId);
                                                                                                        ^^^^^^^^^
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:839
+  private $_mixins = array();
+                     ^^^^^^^
 ERROR   undefined: Property {mixed}->_mixins does not exist at testdata/underscore/underscore.php:843
     $mixins =& self::getInstance()->_mixins;
                                     ^^^^^^^
@@ -136,6 +139,9 @@ ERROR   undefined: Property {mixed}->_mixins does not exist at testdata/undersco
 ERROR   undefined: Property {mixed}->_mixins does not exist at testdata/underscore/underscore.php:859
     $mixins =& self::getInstance()->_mixins;
                                     ^^^^^^^
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:874
+  public $_template_settings = array(
+                               
 ERROR   undefined: Property {mixed}->_template_settings does not exist at testdata/underscore/underscore.php:882
     $_template_settings =& self::getInstance()->_template_settings;
                                                 ^^^^^^^^^^^^^^^^^^
@@ -148,15 +154,27 @@ ERROR   undefined: Property {mixed}->_template_settings does not exist at testda
 MAYBE   deprecated: Call to deprecated function create_function (7.2 Use anonymous functions instead.) at testdata/underscore/underscore.php:940
       $func = create_function('$context', $code);
               ^^^^^^^^^^^^^^^
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:957
+  public $_memoized = array();
+                      ^^^^^^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:970
         return md5(join('_', array(
                              
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:986
+  public $_throttled = array();
+                       ^^^^^^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:995
       $key = md5(join('', array(
                           
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:1012
+  public $_onced = array();
+                   ^^^^^^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:1036
       $args = array_merge(array($function), func_get_args());
                           ^^^^^^^^^^^^^^^^
+MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:1057
+  public $_aftered = array();
+                     ^^^^^^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:1102
     $filled_args = array();
                    ^^^^^^^


### PR DESCRIPTION
#324 
Added analysis of the following class-scoped:
* `stmt.PropertyList:`
for example
> `expr.ClassConstFetch`
> `expr.Array`
> `expr.Ternary`

* `stmt.ClassConstList:`
for example
> `expr.ClassConstFetch`
> `expr.Array`
> `expr.Ternary`


* Arguments of methods and constructors

Example: 

```
class T
{
    const C = 1;

    const C1 = self::UNDEFCONST;              // undefined class constant
    const C2 = self::C ? "var" : "var";       // then/else operands are identical

    public $var1 = self::UNDEFCONST;          // undefined class constant
    public $var2 = self::C ? "var1" : "var1"; // then/else operands are identical

    public $publicArray = [
        'key1' => 'somethingInPublic',
        'key2' => 'other_thingInPublic',
        'key1' => 'third_thingInPublic', // duplicate key 'key1'
    ];

    const constArray = [
        'key1' => 'somethingInConst',
        'key2' => 'other_thingInConst',
        'key1' => 'third_thingInConst', // duplicate key 'key1'
    ];

    public static $staticArray = [
        'key1' => 'somethingInStatic',
        'key2' => 'other_thingInStatic',
        'key1' => 'third_thingInStatic', // duplicate key 'key1'
    ];

    public $mixArrayKeys = [
        1 => 1,
	2,
	3,
    ];

    /**
     * @return int
     */
    public function foo($array = array(1, 2, 3)): int // old array syntax
    {
        return $array[0];
    }

    public function __construct($array = array(1, 2, 3)) // old array syntax
    {}
}
```

### Behavior before
No warnings.

### Actual behavior
```
const C1 = self::UNDEFCONST; - undefined class constant
const C2 = self::C ? "var" : "var"; - then/else operands are identical

public $var1 = self::UNDEFCONST; - undefined class constant
public $var2 = self::C ? "var1" : "var1"; - then/else operands are identical

'key1' => 'third_thingInPublic', - duplicate key 'key1'
'key1' => 'third_thingInConst',  - duplicate key 'key1'
'key1' => 'third_thingInStatic', - duplicate key 'key1'

public $mixArrayKeys = [
    1 => 1,
	 2,
	 3,
]; - Mixing implicit and explicit array keys

public function foo($array = array(1, 2, 3)): int - Use of old array syntax (use short form instead)

public function __construct($array = array(1, 2, 3)) - Use of old array syntax (use short form instead)
```

These changes do not pass the old tests, as they reveal new 'maybe' in the tests, namely 
`src/linttest/testdata/idn/idn.php`

`src/linttest/testdata/idn/idn.php` - was changed

PS: This PR is not related to the test assignment for the internship.