### PR TITLE
Add handling non-literal array keys

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1275,6 +1275,25 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 		case *scalar.Lnumber:
 			key = k.Value
 			constKey = true
+		case *scalar.Dnumber:
+			key = k.Value
+			constKey = true
+		case *expr.ConstFetch:
+			if constName, _, ok := solver.GetConstant(b.r.ctx.st, k.Constant); ok {
+				key = constName
+				constKey = true
+			}
+		case *expr.ClassConstFetch:
+			constName := k.ConstantName.Value
+			if className, ok := solver.GetClassName(b.r.ctx.st, k.Class); ok {
+				key = className + "::" + constName
+				constKey = true
+			}
+		default:
+			if nodeView, ok := getArrayKeyRepresentation(k); ok && b.sideEffectFree(k) {
+				key = nodeView
+				constKey = true
+			}
 		}
 
 		if !constKey {

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -2,6 +2,8 @@ package linter
 
 import (
 	"fmt"
+	"github.com/VKCOM/noverify/src/php/parser/node/name"
+	"github.com/VKCOM/noverify/src/php/parser/printer"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -287,6 +289,49 @@ func findFreeFloatingToken(n node.Node, pos freefloating.Position, s string) boo
 			return true
 		}
 	}
+	return false
+}
+
+// Returns Node string representation if it's legal for array key.
+// Illegal keys have to be processed with individual warning.
+func getArrayKeyRepresentation(n node.Node) (view string, ok bool) {
+	b := strings.Builder{}
+	p := printer.NewPrinter(&b)
+
+	ok = isLegalKey(n)
+	p.Print(n)
+
+	return b.String(), ok
+}
+
+// Checks if Node type is legal for array key.
+func isLegalKey(n node.Node) (ok bool){
+	switch n.(type){
+	case *binary.BitwiseAnd, *binary.BitwiseOr, *binary.BitwiseXor,
+		*binary.BooleanAnd, *binary.BooleanOr, *binary.Coalesce,
+		*binary.Concat, *binary.Div, *binary.Equal, *binary.Greater,
+		*binary.GreaterOrEqual, *binary.Identical, *binary.LogicalAnd,
+		*binary.LogicalOr, *binary.LogicalXor, *binary.Minus, *binary.Mod,
+		*binary.Mul, *binary.NotEqual, *binary.NotIdentical, *binary.Plus,
+		*binary.Pow, *binary.ShiftLeft, *binary.ShiftRight,
+		*binary.SmallerOrEqual, *binary.Smaller, *binary.Spaceship,
+
+		*expr.ArrayDimFetch, *expr.ArrayItem, *expr.BitwiseNot,
+		*expr.BooleanNot, *expr.ClassConstFetch, *expr.ConstFetch,
+		*expr.Empty, *expr.FunctionCall, *expr.InstanceOf, *expr.Isset,
+		*expr.MethodCall, *expr.PostDec, *expr.PostInc, *expr.PreDec,
+		*expr.PreInc, *expr.PropertyFetch, *expr.StaticCall,
+		*expr.StaticPropertyFetch, *expr.Ternary, *expr.UnaryMinus, *expr.UnaryPlus,
+
+		*node.Var, *node.SimpleVar, *node.Identifier,
+
+		*name.Name, *name.NamePart, *name.FullyQualified, *name.Relative,
+
+		*scalar.Lnumber, *scalar.Dnumber, *scalar.String, *scalar.Heredoc:
+
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
Solving #325 . Now `handleArrayItems` handles not only `Lnumber` and `String`, but `ConstFetch`, `ClassConstFetch` (processed individually in case of having convenient functions to deal with namespaces) and a lot of other legal keys that satisfy `sideEffectFree` (processed by `printer`).
I suppose debatable cases like: `$example = [new T() => 1, new T() => 2,];`
should be reported by some "IllegalArrayKeys", so my `isLegalKey` function returns false if key type is `expr.New` or `expr.Array` or other illegal type (suppose this function isn't ideal and I missed some cases or included extra, but all reasonable tests were passed).
One more issue is the fact I understand we can't determine variable (like `node.Var`) type when it's array key. So "dupArrayKeys" will find duplicate `$k` also if it's array: `$k = [1, 2, 3];`. I think it can be fixed somewhere in `parser`, but it's a task for "IllegalArrayKeys". But I also can be mistaken whether linter needs this check.