### PR TITLE
Added report for illegal non-public interface methods and constants

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -503,7 +503,7 @@ func (b *BlockWalker) handleInterface(int *stmt.Interface) bool {
 		switch x := st.(type) {
 		case *stmt.ClassMethod:
 			for _, modifier := range x.Modifiers {
-				if modifier.Value != "public" {
+				if strings.ToLower(modifier.Value) != "public" {
 					interfaceName := int.InterfaceName.Value
 					methodName := x.MethodName.Value
 					b.r.Report(x, LevelWarning, "nonPublicInterfaceMethod", "Non-public method '%s' in the interface '%s'", methodName, interfaceName)
@@ -511,7 +511,7 @@ func (b *BlockWalker) handleInterface(int *stmt.Interface) bool {
 			}
 		case *stmt.ClassConstList:
 			for _, modifier := range x.Modifiers {
-				if modifier.Value != "public" {
+				if strings.ToLower(modifier.Value) != "public" {
 					interfaceName := int.InterfaceName.Value
 					for _, constant := range x.Consts {
 						constantName := constant.(*stmt.Constant).ConstantName.Value

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -503,26 +503,24 @@ func (b *BlockWalker) handleInterface(int *stmt.Interface) bool {
 		switch x := st.(type) {
 		case *stmt.ClassMethod:
 			for _, modifier := range x.Modifiers {
-				if strings.ToLower(modifier.Value) != "public" {
-					interfaceName := int.InterfaceName.Value
+				if strings.EqualFold(modifier.Value, "private") || strings.EqualFold(modifier.Value, "protected") {
 					methodName := x.MethodName.Value
-					b.r.Report(x, LevelWarning, "nonPublicInterfaceMethod", "Non-public method '%s' in the interface '%s'", methodName, interfaceName)
+					b.r.Report(x, LevelWarning, "nonPublicInterfaceMember", "'%s' can't be %s", methodName, modifier.Value)
 				}
 			}
 		case *stmt.ClassConstList:
 			for _, modifier := range x.Modifiers {
-				if strings.ToLower(modifier.Value) != "public" {
-					interfaceName := int.InterfaceName.Value
+				if strings.EqualFold(modifier.Value, "private") || strings.EqualFold(modifier.Value, "protected") {
 					for _, constant := range x.Consts {
 						constantName := constant.(*stmt.Constant).ConstantName.Value
-						b.r.Report(x, LevelWarning, "nonPublicInterfaceMethod", "Non-public constant '%s' in the interface '%s'", constantName, interfaceName)
+						b.r.Report(x, LevelWarning, "nonPublicInterfaceMember", "'%s' can't be %s", constantName, modifier.Value)
 					}
 				}
 			}
 		}
 	}
 
-	return false
+	return !b.ignoreFunctionBodies
 }
 
 func (b *BlockWalker) handleFunction(fun *stmt.Function) bool {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -257,6 +257,18 @@ func init() {
 			Default: true,
 			Comment: `Report commonly misspelled words in comments.`,
 		},
+
+		{
+			Name:    "nonPublicInterfaceMethod",
+			Default: true,
+			Comment: `Report illegal non-public access level for methods in interfaces.`,
+		},
+
+		{
+			Name:    "nonPublicInterfaceConstant",
+			Default: true,
+			Comment: `Report illegal non-public access level for constants in interfaces.`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -259,15 +259,9 @@ func init() {
 		},
 
 		{
-			Name:    "nonPublicInterfaceMethod",
+			Name:    "nonPublicInterfaceMember",
 			Default: true,
-			Comment: `Report illegal non-public access level for methods in interfaces.`,
-		},
-
-		{
-			Name:    "nonPublicInterfaceConstant",
-			Default: true,
-			Comment: `Report illegal non-public access level for constants in interfaces.`,
+			Comment: `Report illegal non-public access level in interfaces.`,
 		},
 	}
 

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1243,31 +1243,3 @@ function f($x) {
 }
 `)
 }
-
-func TestIssue406(t *testing.T) {
-	test := linttest.NewSuite(t)
-	test.AddFile(`<?php
-
-interface A {
-  private const b = 100, c1 = 1000; // constant list
-  private const c = 100; // lone constant
-
-  public function f(); // ok
-
-  private function b(); // Non-public method 'b' in the interface 'A'
-}
-
-interface B {
-  protected function f(); // Non-public method 'f' in the interface 'A'
-}
-
-`)
-	test.Expect = []string{
-		`Non-public constant 'b' in the interface 'A'`,
-		`Non-public constant 'c1' in the interface 'A'`,
-		`Non-public constant 'c' in the interface 'A'`,
-		`Non-public method 'b' in the interface 'A'`,
-		`Non-public method 'f' in the interface 'B'`,
-	}
-	test.RunAndMatch()
-}

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1243,3 +1243,31 @@ function f($x) {
 }
 `)
 }
+
+func TestIssue406(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+
+interface A {
+  private const b = 100, c1 = 1000; // constant list
+  private const c = 100; // lone constant
+
+  public function f(); // ok
+
+  private function b(); // Non-public method 'b' in the interface 'A'
+}
+
+interface B {
+  protected function f(); // Non-public method 'f' in the interface 'A'
+}
+
+`)
+	test.Expect = []string{
+		`Non-public constant 'b' in the interface 'A'`,
+		`Non-public constant 'c1' in the interface 'A'`,
+		`Non-public constant 'c' in the interface 'A'`,
+		`Non-public method 'b' in the interface 'A'`,
+		`Non-public method 'f' in the interface 'B'`,
+	}
+	test.RunAndMatch()
+}

--- a/src/linttest/rules_test.go
+++ b/src/linttest/rules_test.go
@@ -358,6 +358,47 @@ function bad(string $x) {
 	runRulesTest(t, test, rfile)
 }
 
+func TestInterfaceRules(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+
+interface WithConstants {
+  const r = 10000; // ok
+  public const v = 1; // ok
+  private const b = 100, c1 = 1000; // 'b' can't be private, 'c1' can't be private
+  protected const c = 100; // 'c' can't be protected
+}
+
+interface WithMethods {
+  public function c(); // ok
+  private function b(); // 'b' can't be private
+  protected function f(); // 'f' can't be protected
+}
+
+interface WithStaticMethods {
+  static function f1(); // ok
+  public static function f2(); // ok
+  private static function bad1(); // 'bad1' can't be private
+  static protected function bad2(); // 'bad2' can't be protected
+}
+
+interface WithoutAnyModifier {
+    function f(); // Ok,
+}
+
+`)
+	test.Expect = []string{
+		`'b' can't be private`,
+		`'c1' can't be private`,
+		`'c' can't be protected`,
+		`'b' can't be private`,
+		`'f' can't be protected`,
+		`'bad1' can't be private`,
+		`'bad2' can't be protected`,
+	}
+	test.RunAndMatch()
+}
+
 func runRulesTest(t *testing.T, test *linttest.Suite, rfile string) {
 	rparser := rules.NewParser()
 	rset, err := rparser.Parse("<test>", strings.NewReader(rfile))


### PR DESCRIPTION
#406

Added checks for non-public methods and constants in interfaces.

Example:

```php
interface WithConstants {
  const r = 10000; // ok
  public const v = 1; // ok
  private const b = 100, c1 = 1000; // 'b' can't be private, 'c1' can't be private
  protected const c = 100; // 'c' can't be protected
}

interface WithMethods {
  public function c(); // ok
  private function b(); // 'b' can't be private
  protected function f(); // 'f' can't be protected
}

interface WithStaticMethods {
  static function f1(); // ok
  public static function f2(); // ok
  private static function bad1(); // 'bad1' can't be private
  static protected function bad2(); // 'bad2' can't be protected
}

interface WithoutAnyModifier {
    function f(); // Ok,
}
```

### Behavior before
No warnings.

### Actual behavior
```
<critical> WARNING nonPublicInterfaceMember: 'b' can't be private at G:\Programming\noverify\example\index.php:19
  private const b = 100, c1 = 1000; // 'b' can't be private, 'c1' can't be private
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<critical> WARNING nonPublicInterfaceMember: 'c1' can't be private at G:\Programming\noverify\example\index.php:19
  private const b = 100, c1 = 1000; // 'b' can't be private, 'c1' can't be private
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<critical> WARNING nonPublicInterfaceMember: 'c' can't be protected at G:\Programming\noverify\example\index.php:20
  protected const c = 100; // 'c' can't be protected
  ^^^^^^^^^^^^^^^^^^^^^^^^
<critical> WARNING nonPublicInterfaceMember: 'b' can't be private at G:\Programming\noverify\example\index.php:25
  private function b(); // 'b' can't be private
  ^^^^^^^^^^^^^^^^^^^^^
<critical> WARNING nonPublicInterfaceMember: 'f' can't be protected at G:\Programming\noverify\example\index.php:26
  protected function f(); // 'f' can't be protected
  ^^^^^^^^^^^^^^^^^^^^^^^
<critical> WARNING nonPublicInterfaceMember: 'bad1' can't be private at G:\Programming\noverify\example\index.php:32
  private static function bad1(); // 'bad1' can't be private
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<critical> WARNING nonPublicInterfaceMember: 'bad2' can't be protected at G:\Programming\noverify\example\index.php:33
  static protected function bad2(); // 'bad2' can't be protected
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```