### PR TITLE
Handling non-literal key duplicates in dupArrayKeys diagnostic

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1273,10 +1273,9 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 		case *scalar.Lnumber:
 			key = k.Value
 		case *scalar.Dnumber:
-			key = k.Value // (WIP) What is considered a duplicate? (1.234 or round_down(1.234))
+			key = k.Value
 		case *node.SimpleVar:
 			key = "$" + k.Name
-		// case *node.Var:
 		case *expr.ConstFetch:
 			var defined bool
 			if key, _, defined = solver.GetConstant(b.r.ctx.st, k.Constant); !defined {
@@ -1289,13 +1288,8 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 				continue
 			}
 			key = className + "::" + k.ConstantName.Value
-		// default:  // expressions
-		// 	if !b.sideEffectFree(k) {
-		// 		continue
-		// 	}
 		}
 
-		// (WIP) How about putting this condition before the "switch-case"?
 		if !nodeSet.Add(item.Key) {
 			b.r.Report(item.Key, LevelWarning, "dupArrayKeys", "Duplicate array key '%s'", key)
 		}

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -1113,7 +1113,7 @@ $valid_quotes = [
 `)
 }
 
-func TestDuplicateArrayKey(t *testing.T) {
+func TestDuplicateLiteralArrayKey(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 	function test() {
@@ -1124,6 +1124,23 @@ func TestDuplicateArrayKey(t *testing.T) {
 	  ];
 	}`)
 	test.Expect = []string{"Duplicate array key 'key1'"}
+	test.RunAndMatch()
+}
+
+func TestDuplicateNonLiteralArrayKey(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	function test() {
+	  $key1 = 'key1';
+	  $key2 = 'key2';
+
+	  return [
+		   $key1 => 'something',
+           $key2 => 'other_thing',
+           $key1 => 'third_thing', // duplicate
+	  ];
+	}`)
+	test.Expect = []string{"Duplicate array key '$key1'"}
 	test.RunAndMatch()
 }
 

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -8,8 +8,6 @@ import (
 
 func TestIssue325_1(t *testing.T) {
 	// Tests for basic literal array key types (int, string)
-	// TODO(qypec): add tests for different numeral system for `int` (necessary???)
-	// TODO(qypec): some other kinds of strings? (heredoc, nowdoc)
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 	$example1 = [
@@ -40,7 +38,6 @@ func TestIssue325_1(t *testing.T) {
 
 func TestIssue325_2(t *testing.T) {
 	// Tests for cast literal array key types (float)
-	// TODO(qypec): add tests for different numeral system for `float` (necessary???)
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 	$example1 = [
@@ -111,25 +108,6 @@ func TestIssue325_3(t *testing.T) {
 	}
 	test.RunAndMatch()
 }
-
-// func TestIssue325_4(t *testing.T) {
-// 	// Test for expressions duplicate keys
-// 	test := linttest.NewSuite(t)
-// 	test.AddFile(`<?php
-// 	$k = [
-//     	'key1',
-//     	'key2',
-//     ];
-
-// 	$example3 = [
-// 		$k[0] => 1,
-// 		$k[1] => 2,
-// 		$k[0] => 3, // Duplicate key $k[0]
-// 	];
-// 	`)
-// 	test.Expect = []string{"Duplicate array key $k[0]"}
-// 	test.RunAndMatch()
-// }
 
 func TestIssue327(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php


### PR DESCRIPTION
**Solving #325**

Handling for the most nodes without side effect.
Tests for cases with this nodes.

Tracked various numeral systems for `Lnumber`:
```
6464 => 1,
014500 => 2, // Duplicate key '6464'
0x1940 => 3, // Duplicate key '6464'
```

Illegal types:
- `expr.New`
- `expr.FunctionCall`
