### PR TITLE
Partial solution of the duplicate array keys issue 325

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1275,7 +1275,7 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 		switch k := item.Key.(type) {
 		case *scalar.String:
 			keyString = unquote(k.Value)
-			warningKeyString = k.Value
+			warningKeyString = keyString
 		case *scalar.Lnumber:
 			keyString = numStringToDecimal(k.Value)
 			warningKeyString = k.Value

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1282,6 +1282,13 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 		case *scalar.Dnumber:
 			keyString = numStringToDecimal(k.Value)
 			warningKeyString = k.Value
+		case *expr.ConstFetch:
+			if name, _, defined := solver.GetConstant(b.r.ctx.st, k.Constant); !defined {
+				continue
+			} else {
+				keyString = name
+				warningKeyString = astutil.FmtNode(k.Constant)
+			}
 		default:
 			keyString = astutil.FmtNode(item.Key)
 			warningKeyString = keyString

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -399,3 +399,12 @@ func numStringToDecimal(str string) string {
 	}
 	return strconv.FormatInt(value, 10)
 }
+
+func isValidArrayKey(key node.Node) bool {
+	switch key.(type) {
+	case *expr.Array, *expr.New:
+		return false
+	}
+
+	return true
+}

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -2,6 +2,7 @@ package linter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -356,4 +357,45 @@ var phpKeywords = map[string]bool{
 	"die":          true,
 	"self":         true,
 	"parent":       true,
+}
+
+func intStringToDecimal(str string) (int64, error) {
+	if len(str) == 1 {
+		return strconv.ParseInt(str, 10, 64)
+	}
+
+	switch str[1] {
+	case 'b':
+		return strconv.ParseInt(str[2:], 2, 64)
+	case 'x':
+		return strconv.ParseInt(str[2:], 16, 64)
+	}
+
+	if str[0] == '0' {
+		return strconv.ParseInt(str, 8, 64)
+	}
+
+	return strconv.ParseInt(str, 10, 64)
+}
+
+func numStringToDecimal(str string) string {
+	var sign bool = str[0] == '-'
+	var value int64
+
+	if sign {
+		str = str[1:]
+	}
+	str = strings.ReplaceAll(str, "_", "")
+
+	if strings.ContainsRune(str, '.') {
+		floatValue, _ := strconv.ParseFloat(str, 64)
+		value = int64(floatValue)
+	} else {
+		value, _ = intStringToDecimal(str)
+	}
+
+	if sign {
+		value *= -1
+	}
+	return strconv.FormatInt(value, 10)
 }

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1342,7 +1342,7 @@ func TestDupArrayKeys_Nums(t *testing.T) {
 		`Duplicate array key '0x49'`,
 		`Duplicate array key '7_3'`,
 		`Duplicate array key '0111'`,
-		`Duplicate array key '"73"'`,
+		`Duplicate array key '73'`,
 		`Duplicate array key '0.73e2'`,
 	}
 
@@ -1381,7 +1381,7 @@ EOT => 3,
   `)
 
 	test.Expect = []string{
-		`Duplicate array key '"first"'`,
+		`Duplicate array key 'first'`,
 		`Duplicate array key '<<<EOT
 1
 EOT'`,

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1450,6 +1450,16 @@ func TestDupArrayKeys_Expressions(t *testing.T) {
     'b' . $s => 2,
     'a' . $s => 3, // Duplicate key 'a'.$s
   ];
+
+  $a = 1;
+  $b = 2;
+  $expressions_7 = [
+    $a => 1,
+    $a + 1 => 2,
+    $a + 1 => 3, // Duplicate key $a + 1
+    $a + $b => 4,
+    $a + $b => 5, // Duplicate key $a + $b
+  ];
   ?>
   `)
 
@@ -1459,6 +1469,8 @@ func TestDupArrayKeys_Expressions(t *testing.T) {
 		`Duplicate array key 'isset($k)'`,
 		`Duplicate array key '$k instanceof T'`,
 		`Duplicate array key ''a' . $s'`,
+		`Duplicate array key '$a + 1'`,
+		`Duplicate array key '$a + $b'`,
 	}
 
 	test.RunAndMatch()

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1259,6 +1259,13 @@ func TestDupArrayKeys_ToSkip(t *testing.T) {
   $skips_2 = [
     [1, 2] => 1,
     [1, 2] => 2,
+    [1, 2,] => 3,
+    [1, 2,] => 4,
+  ];
+
+  $skips_3 = [
+    function() {} => 1,
+    function() {} => 2,
   ];
   ?>
   `)
@@ -1271,6 +1278,8 @@ func TestDupArrayKeys_Consts(t *testing.T) {
   <?php
   $C1 = 1;
   $C2 = 2;
+  const c1 = 1;
+  const c2 = 2;
 
   class T {
     const C1 = 1;
@@ -1288,12 +1297,19 @@ func TestDupArrayKeys_Consts(t *testing.T) {
     T::C2 => 2, 
     T::C1 => 3, // Duplicate key T1::C1
   ];
+
+  $constants_3 = [
+    c1 => 1,
+    c2 => 2,
+    c1 => 3, // Duplicate key c1
+  ];
   ?>
   `)
 
 	test.Expect = []string{
 		`Duplicate key C1`,
 		`Duplicate key T1::C1`,
+		`Duplicate key c1`,
 	}
 
 	test.RunAndMatch()
@@ -1338,10 +1354,15 @@ func TestDupArrayKeys_Strings(t *testing.T) {
 
 	test.AddFile(`
   <?php
+  $first = "a";
+  const first = "b";
+
   $strings_1 = [
     "first" => 1,
     "second" => 2,
     "first" => 3, // Duplicate key first
+    $first => 4,
+    first => 5,
   ];
 
   // Heredocs

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1307,9 +1307,9 @@ func TestDupArrayKeys_Consts(t *testing.T) {
   `)
 
 	test.Expect = []string{
-		`Duplicate key C1`,
-		`Duplicate key T1::C1`,
-		`Duplicate key c1`,
+		`Duplicate array key '$C1'`,
+		`Duplicate array key 'T::C1'`,
+		`Duplicate array key 'c1'`,
 	}
 
 	test.RunAndMatch()
@@ -1336,14 +1336,14 @@ func TestDupArrayKeys_Nums(t *testing.T) {
   `)
 
 	test.Expect = []string{
-		`Duplicate key 73`,
-		`Duplicate key 73.0`,
-		`Duplicate key 0b1001001`,
-		`Duplicate key 0x49`,
-		`Duplicate key 7_3`,
-		`Duplicate key 0111`,
-		`Duplicate key 73`,
-		`Duplicate key 0.73e2`,
+		`Duplicate array key '73'`,
+		`Duplicate array key '73.0'`,
+		`Duplicate array key '0b1001001'`,
+		`Duplicate array key '0x49'`,
+		`Duplicate array key '7_3'`,
+		`Duplicate array key '0111'`,
+		`Duplicate array key '"73"'`,
+		`Duplicate array key '0.73e2'`,
 	}
 
 	test.RunAndMatch()
@@ -1381,7 +1381,7 @@ EOT => 3,
   `)
 
 	test.Expect = []string{
-		`Duplicate key first`,
+		`Duplicate array key '"first"'`,
 		`Duplicate array key '<<<EOT
 1
 EOT'`,
@@ -1454,11 +1454,11 @@ func TestDupArrayKeys_Expressions(t *testing.T) {
   `)
 
 	test.Expect = []string{
-		`Duplicate key $k[0]`,
-		`Duplicate key getX(1)`,
-		`Duplicate key isset($k)`,
-		`Duplicate key $k instanceof T`,
-		`Duplicate key 'a'.$s`,
+		`Duplicate array key '$k[0]'`,
+		`Duplicate array key 'getX(1)'`,
+		`Duplicate array key 'isset($k)'`,
+		`Duplicate array key '$k instanceof T'`,
+		`Duplicate array key ''a' . $s'`,
 	}
 
 	test.RunAndMatch()

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1271,6 +1271,17 @@ func TestDupArrayKeys(t *testing.T) {
 
   $k = [11, 22];
 
+  // 0. Tests to skip
+  $skips_1 = [
+    new T() => 1,
+    new T() => 2,
+  ];
+
+  $skips_2 = [
+    [1, 2] => 1,
+    [1, 2] => 2,
+  ];
+
   // 1. Constants
   $constants_1 = [
     $C1 => 1, 


### PR DESCRIPTION
Partially fixed the problem. Duplicates of array keys can now be: numbers in any format, strings, variables, constants, return values of functions, etc. Also, the `dupArrayKeys` does not check situations that are not related to its problem.

However, more complex expressions, such as binary operations, are not checked:
```php
$arr = [
    -($a + $b) => 1,
    -$b - $a => 2,
];
```
and many others, in which the use of nodes included in the expression differs only in order.

The solution to this, it seems to me, cannot be reduced to calculating the value of a number or to comparing a string representation. But the solution, I think, is a comparison of AST or the use of standardized reduction of term strings. For example:
```go
"-($b + $a)" ~> "-$b - $a" ~> "-$a - $b" ~> "-$a-$b"
```
It seems to me that the use of memory and computing resources in this case will not be too critical, but still greater than at the moment.

_Test task for admission to the VK internship._