### PR TITLE
Fix issue 325: report dupArrayKeys

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1346,7 +1346,7 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 				key = strings.TrimLeft(constName, "\\")
 				constKey = true
 			} else if n, ok := k.Constant.(*name.Name); ok {
-				n := meta.NameToString(n)
+				n := strings.ToLower(meta.NameToString(n))
 				keyName = n
 				if n == "true" {
 					key = "1"
@@ -1359,15 +1359,13 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 		case *expr.ClassConstFetch:
 			constName := k.ConstantName
 			if constName.Value == `class` || constName.Value == `CLASS` {
-				return false
+				continue
 			}
-
 			className, ok := solver.GetClassName(b.r.ctx.st, k.Class)
 			if !ok {
 				continue
 			}
-			className = strings.TrimLeft(className, "\\")
-			key = className + "::" + constName.Value
+			key = strings.TrimLeft(className, "\\") + "::" + constName.Value
 			constKey = true
 		case *expr.ArrayDimFetch:
 			if v, ok := k.Variable.(*node.SimpleVar); ok {
@@ -1377,7 +1375,7 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 				}
 			}
 		case *node.SimpleVar:
-			key = fmt.Sprintf("$%s", k.Name)
+			key = "$" + k.Name
 			constKey = true
 		}
 

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1332,26 +1332,23 @@ func (b *BlockWalker) handleArrayItem(item *expr.ArrayItem) (key string) {
 		if t, ok := k.Expr.(*scalar.Lnumber); ok {
 			key = "-" + t.Value
 		} else if t, ok := k.Expr.(*scalar.Dnumber); ok {
-			tokens := strings.Split(t.Value, ".")
-			if len(tokens) > 0 {
-				key = "-" + tokens[0]
+			if val, err := strconv.ParseFloat(t.Value, 64); err == nil {
+				key = fmt.Sprintf("-%d", int(val))
 			}
 		}
 	case *expr.UnaryPlus:
 		if t, ok := k.Expr.(*scalar.Lnumber); ok {
 			key = t.Value
 		} else if t, ok := k.Expr.(*scalar.Dnumber); ok {
-			tokens := strings.Split(t.Value, ".")
-			if len(tokens) > 0 {
-				key = tokens[0]
+			if val, err := strconv.ParseFloat(t.Value, 64); err == nil {
+				key = fmt.Sprint(int(val))
 			}
 		}
 	case *scalar.Lnumber:
 		key = k.Value
 	case *scalar.Dnumber:
-		tokens := strings.Split(k.Value, ".")
-		if len(tokens) > 0 {
-			key = tokens[0]
+		if val, err := strconv.ParseFloat(k.Value, 64); err == nil {
+			key = fmt.Sprint(int(val))
 		}
 	case *expr.ConstFetch:
 		constName, _, defined := solver.GetConstant(b.r.ctx.st, k.Constant)

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1304,7 +1304,7 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 					break
 				}
 			}
-			key = k.Value
+			key = fmt.Sprintf("\"%s\"", keyName)
 			constKey = true
 		case *expr.UnaryMinus:
 			if t, ok := k.Expr.(*scalar.Lnumber); ok {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -560,6 +560,11 @@ func unquote(s string) string {
 	return s
 }
 
+// quote returns string surrounded with double quotes
+func quote(s string) string {
+	return "\"" + s + "\""
+}
+
 func linterError(filename, format string, args ...interface{}) {
 	log.Printf("error: "+filename+": "+format, args...)
 }

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1356,11 +1356,17 @@ func TestIssue325_Constants(t *testing.T) {
 		const C1 = "key1";
 	}
 	const C2 = "key2";
+	const C3 = "key3";
 	$test = [
 		T::C1 => 1,
 		T::C1 => 2, // duplicate
+		"T::C1" => 3, // ok
+		"\T::C1" => 4, // ok
 		C2 => 1,
 		C2 => 2, // duplicate
+		C3 => 1,
+		'C3' => 2, // ok
+		'\C3' => 3, // ok
 	];?>`)
 	test.Expect = []string{
 		"Duplicate array key 'T::C1'",
@@ -1376,7 +1382,8 @@ func TestIssue325_ArrayDimFetch(t *testing.T) {
 	$test = [
 		$arr[0] => 1,
 		$arr[1] => 2, 
-		$arr[0]=> 3,// duplicate
+		$arr[0] => 3,// duplicate
+		'$arr[0]' => 4, // ok
 	];?>`)
 	test.Expect = []string{
 		"Duplicate array key '$arr[0]'",

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1301,6 +1301,19 @@ func TestIssue325_DNumbers(t *testing.T) {
 	test.RunAndMatch()
 }
 
+func TestIssue325_Strings(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	$test1 = [
+		'key' => 1,
+		"key" => 2, // duplicate
+	];?>`)
+	test.Expect = []string{
+		"Duplicate array key 'key'",
+	}
+	test.RunAndMatch()
+}
+
 // Test throws errors like 'ERROR undefined: Use true instead of true at _file0.php:4'
 /*func TestIssue325_Booleans(t *testing.T) {
 	test := linttest.NewSuite(t)

--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1243,3 +1243,146 @@ function f($x) {
 }
 `)
 }
+
+func TestIssue325_LNumbers(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	$test = [
+		0 => 1,
+		1 => 2, // ok
+		2 => 1,
+		2 => 2, // duplicate
+		3 => 1,
+		'3' => 2, // duplicate
+		4 => 1,
+		'+4' => 2, // ok
+		+5 => 1,
+		'+5' => 2, // ok
+		+6 => 1,
+		'6' => 2, // duplicate
+		-7 => 1,
+		'-7' => 2, // duplicate
+		8 => 1,
+		'08' => 2, // ok
+	];?>`)
+	test.Expect = []string{
+		"Duplicate array key '2'",
+		"Duplicate array key '3'",
+		"Duplicate array key '6'",
+		"Duplicate array key '-7'",
+	}
+	test.RunAndMatch()
+}
+
+func TestIssue325_DNumbers(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	$test = [
+		0.5 => 1,
+		1.5 => 2, // ok
+		2.5 => 1,
+		2.3 => 2, // duplicate
+		3.3 => 1,
+		'3.2' => 2, // ok
+		4.5 => 1,
+		'+4' => 2, // ok
+		+5.5 => 1,
+		'+5' => 2, // ok
+		+6.5 => 1,
+		'6' => 2, // duplicate
+		-7.5 => 1,
+		'-7' => 2, // duplicate
+	];?>`)
+	test.Expect = []string{
+		"Duplicate array key '2.3'",
+		"Duplicate array key '6'",
+		"Duplicate array key '-7'",
+	}
+	test.RunAndMatch()
+}
+
+// Test throws errors like 'ERROR undefined: Use true instead of true at _file0.php:4'
+/*func TestIssue325_Booleans(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	$test1 = [
+		1 => 1,
+		true => 2, // duplicate
+	];
+	$test2 = [
+		1 => 1,
+		false => 2, // ok
+	];
+	$test3 = [
+		0 => 1,
+		true => 2, // ok
+	];
+	$test4 = [
+		0 => 1,
+		false => 2, // duplicate
+	];
+	$test5 = [
+		true => 1,
+		'true' => 2, // ok
+	];
+	$test6 = [
+		false => 1,
+		'false' => 2, // ok
+	];?>`)
+	test.Expect = []string{
+		"Duplicate array key 'true'",
+		"Duplicate array key 'false'",
+	}
+	test.RunAndMatch()
+}*/
+
+func TestIssue325_Constants(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	class T {
+		const C1 = "key1";
+	}
+	const C2 = "key2";
+	$test = [
+		T::C1 => 1,
+		T::C1 => 2, // duplicate
+		C2 => 1,
+		C2 => 2, // duplicate
+	];?>`)
+	test.Expect = []string{
+		"Duplicate array key 'T::C1'",
+		"Duplicate array key 'C2'",
+	}
+	test.RunAndMatch()
+}
+
+func TestIssue325_ArrayDimFetch(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	$arr = [1, 2, 3];
+	$test = [
+		$arr[0] => 1,
+		$arr[1] => 2, 
+		$arr[0]=> 3,// duplicate
+	];?>`)
+	test.Expect = []string{
+		"Duplicate array key '$arr[0]'",
+	}
+	test.RunAndMatch()
+}
+
+func TestIssue325_SimpleVars(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+	$simpleVarA = "keyA";
+	$simpleVarB = "keyB";
+	$test = [
+		$simpleVarA => 1,
+		$simpleVarB => 2, 
+		$simpleVarA => 3,// duplicate
+	];?>`)
+	test.Expect = []string{
+		"Duplicate array key '$simpleVarA'",
+	}
+	test.RunAndMatch()
+}


### PR DESCRIPTION
To detect duplicates I cast all nodes to string names, like php does. E.g. if node type is string, first I check if string begins with '0' or '+', if not, I try to parse it to int, else I save it in keys map with quotes. 

Duplicate array keys detection now works for:
* numbers (integer and float)
* strings
* booleans
* constants and class-constants
* simple variables
* array elements

Some things to improve:
* check if array from last item is not a class that implements ArrayAccess
* simplify handling Lnumber and Dnumber, UnaryMinus and UnaryPlus

Also I noticed, that this code:
```php
<?php 
$test1 = [true => 2];
?>
```
causes error: `ERROR undefined: Use true instead of true at _file0.php:2`. Is this expected behaviour? I can not write test for boolean keys duplicates because of this error, it is commented now.