### PR TITLE
Added checks for constant, property and method duplicates in classes

### DIFF
--- a/src/linter/phpdoc_util.go
+++ b/src/linter/phpdoc_util.go
@@ -68,6 +68,7 @@ func parseClassPHPDocMethod(ctx *rootContext, result *classPhpDocParseResult, pa
 		Flags:        funcFlags,
 		MinParamsCnt: 0, // TODO: parse signature and assign a proper value
 		AccessLevel:  meta.Public,
+		FromDoc:      true,
 	})
 }
 
@@ -98,5 +99,6 @@ func parseClassPHPDocProperty(ctx *rootContext, result *classPhpDocParseResult, 
 	result.properties[part.Var[len("$"):]] = meta.PropertyInfo{
 		Typ:         newTypesMap(ctx, types),
 		AccessLevel: meta.Public,
+		FromDoc:     true,
 	}
 }

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -257,6 +257,24 @@ func init() {
 			Default: true,
 			Comment: `Report commonly misspelled words in comments.`,
 		},
+
+		{
+			Name:    "classConstantRedefinition",
+			Default: true,
+			Comment: `Report redefinition of class constant.`,
+		},
+
+		{
+			Name:    "classPropertyRedeclaration",
+			Default: true,
+			Comment: `Report redeclaration of class property.`,
+		},
+
+		{
+			Name:    "classMethodRedeclaration",
+			Default: true,
+			Comment: `Report redeclaration of class method`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -725,6 +725,25 @@ func (d *RootWalker) enterPropertyList(pl *stmt.PropertyList) bool {
 			typ = typ.Append(solver.ExprTypeLocal(d.scope(), d.ctx.st, p.Expr))
 		}
 
+		propFromDoc := false
+		contains := false
+
+		if prop, ok := cl.Properties[nm]; ok {
+			contains = true
+			propFromDoc = prop.FromDoc
+		} else {
+			if prop, ok := cl.Properties["$"+nm]; ok {
+				contains = true
+				propFromDoc = prop.FromDoc
+			}
+		}
+
+		if contains && !propFromDoc {
+			className := strings.TrimPrefix(cl.Name, "\\")
+			d.Report(pNode, LevelError, "classPropertyRedeclaration", "Property %s::$%s cannot be redeclare", className, nm)
+			continue
+		}
+
 		if isStatic {
 			nm = "$" + nm
 		}
@@ -734,6 +753,7 @@ func (d *RootWalker) enterPropertyList(pl *stmt.PropertyList) bool {
 			Pos:         d.getElementPos(p),
 			Typ:         typ.Immutable(),
 			AccessLevel: accessLevel,
+			FromDoc:     false,
 		}
 	}
 
@@ -762,7 +782,11 @@ func (d *RootWalker) enterClassConstList(s *stmt.ClassConstList) bool {
 		d.checkCommentMisspellings(c, c.PhpDocComment)
 		typ := solver.ExprTypeLocal(d.scope(), d.ctx.st, c.Expr)
 
-		// TODO: handle duplicate constant
+		if _, ok := cl.Constants[nm]; ok {
+			className := strings.TrimPrefix(cl.Name, "\\")
+			d.Report(cNode, LevelError, "classConstantRedefinition", "Constant %s::%s cannot be redefine", className, nm)
+		}
+
 		cl.Constants[nm] = meta.ConstantInfo{
 			Pos:         d.getElementPos(c),
 			Typ:         typ.Immutable(),
@@ -874,7 +898,11 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 
 	d.addScope(meth, sc)
 
-	// TODO: handle duplicate method
+	if method, ok := class.Methods.Get(nm); ok && !method.FromDoc {
+		className := strings.TrimPrefix(class.Name, "\\")
+		d.Report(meth, LevelError, "classMethodRedeclaration", "Method %s::%s cannot be redeclare", className, nm)
+	}
+
 	returnType := meta.MergeTypeMaps(phpdocReturnType, actualReturnTypes, specifiedReturnType)
 	if returnType.IsEmpty() {
 		returnType = meta.VoidType

--- a/src/linttest/phpdoc_test.go
+++ b/src/linttest/phpdoc_test.go
@@ -305,7 +305,7 @@ class Foo {
   public $x;
 
   /** @var real */
-  public $x;
+  public $y;
 }
 `)
 	test.Expect = []string{

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -306,6 +306,7 @@ type FuncInfo struct {
 	Flags        FuncFlags
 	ExitFlags    int // if function has exit/die/throw, then ExitFlags will be <> 0
 	Doc          PhpDocInfo
+	FromDoc      bool
 }
 
 func (info *FuncInfo) IsStatic() bool   { return info.Flags&FuncStatic != 0 }
@@ -353,6 +354,7 @@ type PropertyInfo struct {
 	Pos         ElementPosition
 	Typ         TypesMap
 	AccessLevel AccessLevel
+	FromDoc     bool
 }
 
 type ConstantInfo struct {


### PR DESCRIPTION
Added warnings if the class contains duplicate:

1. Constants
2. Properties
3. Methods

## Example:
```php
/**
 * @property int $d Just property
 * @method static void foo() Just method
 * @method void boo() Just method
 */
class B {

public const b = 100;
private const b = 100;
protected const b = 100; // Constant B::b cannot be redefine


public $d;
public static $d = 100;
protected static $d = 100; // Property B::$d cannot be redeclare

/**
 * Some method foo()
 */
public static function foo() {}
/**
 * Some method foo()
 */
private function foo() {}
/**
 * Some method foo()
 */
protected function foo() {} // Method B::foo cannot be redeclare


/**
 * Some method boo()
 */
public function boo() {}

/**
 * Some method boo()
 */
protected function boo() {} // Method B::boo cannot be redeclare
}
```

## Behavior before
No warnings.

## Actual Behavior:
```
<critical> ERROR   classConstantRedefinition: Constant B::b cannot be redefine at G:\Programming\noverify\example\index.php:22
private const b = 100;
              ^^^^^^^
<critical> ERROR   classConstantRedefinition: Constant B::b cannot be redefine at G:\Programming\noverify\example\index.php:23
protected const b = 100; // Constant B::b cannot be redefine
                ^^^^^^^
<critical> ERROR   classPropertyRedeclaration: Property B::$d cannot be redeclare at G:\Programming\noverify\example\index.php:27
public static $d = 100;
              ^^^^^^^^
<critical> ERROR   classPropertyRedeclaration: Property B::$d cannot be redeclare at G:\Programming\noverify\example\index.php:28
protected static $d = 100; // Property B::$d cannot be redeclare
                 ^^^^^^^^
<critical> ERROR   classMethodRedeclaration: Method B::foo cannot be redeclare at G:\Programming\noverify\example\index.php:37
private function foo() {}
^^^^^^^^^^^^^^^^^^^^^^^^^
<critical> ERROR   classMethodRedeclaration: Method B::foo cannot be redeclare at G:\Programming\noverify\example\index.php:41
protected function foo() {} // Method B::foo cannot be redeclare
^^^^^^^^^^^^^^^^^^^^^^^^^^^
<critical> ERROR   classMethodRedeclaration: Method B::boo cannot be redeclare at G:\Programming\noverify\example\index.php:52
protected function boo() {} // Method B::boo cannot be redeclare
^^^^^^^^^^^^^^^^^^^^^^^^^^^
2020/06/23 02:45:11.324557 Found 7 critical reports

Process finished with exit code 2

```

> To distinguish between properties and methods from PHPDoc and real ones, the FromDoc property of FuncInfo and PropertyInfo was added.