### PR TITLE
cmd: fix linter init order

### DIFF
--- a/src/cmd/linter_runner.go
+++ b/src/cmd/linter_runner.go
@@ -64,11 +64,11 @@ func (l *linterRunner) Init(args *cmdlineArguments) error {
 		}
 	}
 
+	l.initCheckMappings()
+
 	if err := l.initRules(); err != nil {
 		return fmt.Errorf("init rules: %v", err)
 	}
-
-	l.initCheckMappings()
 
 	return nil
 }


### PR DESCRIPTION
initCheckMappings() should be called before initRules().

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>