### PR TITLE
cmd: fix git mode for the gitRepoComputeReportsFromCommits() case

### DIFF
--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -51,7 +51,7 @@ type cmdlineArguments struct {
 	gitFullDiff                bool
 	gitIncludeUntracked        bool
 	gitRepo                    string
-	gitRef                     string
+	gitRef                     string // TODO: remove? It looks unused
 	gitCommitFrom              string
 	gitCommitTo                string
 

--- a/src/cmd/git_main.go
+++ b/src/cmd/git_main.go
@@ -213,19 +213,18 @@ func analyzeGitAuthorsWhiteList(l *linterRunner, changeLog []git.Commit) (should
 }
 
 func prepareGitArgs(l *linterRunner) (logArgs, diffArgs []string, err error) {
-	l.gitRef = l.args.gitRef
-	l.gitCommitFrom = l.args.gitCommitFrom
-	l.gitCommitTo = l.args.gitCommitTo
+	gitCommitFrom := l.args.gitCommitFrom
+	gitCommitTo := l.args.gitCommitTo
 	if l.args.gitPushArg != "" {
 		args := strings.Fields(l.args.gitPushArg)
 		if len(args) != 3 {
 			return nil, nil, fmt.Errorf("Unexpected format of push arguments, expected only 3 columns: %s", l.args.gitPushArg)
 		}
-		l.gitCommitFrom, l.gitCommitTo, l.gitRef = args[0], args[1], args[2]
+		// args[2] is a git ref (branch name), but its unused.
+		gitCommitFrom, gitCommitTo = args[0], args[1]
 	}
-
 	if l.args.gitCommitFrom == git.Zero {
-		l.args.gitCommitFrom = "master"
+		gitCommitFrom = "master"
 	}
 
 	if !l.args.gitSkipFetch {
@@ -250,12 +249,12 @@ func prepareGitArgs(l *linterRunner) (logArgs, diffArgs []string, err error) {
 
 		// check if master was merged in between the commits
 		if fromAndMaster != toAndMaster {
-			l.gitCommitFrom = toAndMaster
+			gitCommitFrom = toAndMaster
 		}
 	}
 
-	logArgs = []string{l.gitCommitFrom + ".." + l.gitCommitTo}
-	diffArgs = []string{l.gitCommitFrom + ".." + l.gitCommitTo}
+	logArgs = []string{gitCommitFrom + ".." + gitCommitTo}
+	diffArgs = []string{gitCommitFrom + ".." + gitCommitTo}
 
 	return logArgs, diffArgs, nil
 }

--- a/src/cmd/linter_runner.go
+++ b/src/cmd/linter_runner.go
@@ -21,10 +21,6 @@ type linterRunner struct {
 	reportsIncludeChecksSet map[string]bool
 	reportsCriticalSet      map[string]bool
 
-	gitRef        string
-	gitCommitFrom string
-	gitCommitTo   string
-
 	allowDisableRegex *regexp.Regexp
 }
 


### PR DESCRIPTION
Code was assigning to a wrong field so git.Zero was not replaced
by the "master" string. This led to a panic that is quite hard to
reproduce outside of the real-world environment.

To make this mistake less likely in future, I removed fields
from the struct and store these values as local values as they're
only needed inside that function scope.

gitRef looks unused. It was unused before the refactoring as well.
Maybe it was used before but we broke something a long time ago?
This calls for another investigation.

Refs #513

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>