### PR TITLE
solver: improve `self` handling in traits

### DIFF
--- a/src/linttest/exprtype_test.go
+++ b/src/linttest/exprtype_test.go
@@ -47,6 +47,100 @@ func init() {
 	})
 }
 
+func TestExprTypeTraitSelfStatic1(t *testing.T) {
+	// Tests for WStaticMethodCall.
+	code := `<?php
+trait NewSelf {
+  public static function instance() { return new self(); }
+}
+
+class FooSelf { use NewSelf; }
+class BarSelf extends FooSelf {}
+class BazSelf extends BarSelf { use NewSelf; }
+
+exprtype(FooSelf::instance(), '\FooSelf');
+exprtype(BarSelf::instance(), '\FooSelf');
+exprtype(BazSelf::instance(), '\BazSelf');
+
+trait NewStatic {
+  public static function instance() { return new static(); }
+}
+
+class FooStatic { use NewStatic; }
+class BarStatic extends FooStatic {}
+class BazStatic extends BarStatic { use NewStatic; }
+
+exprtype(FooStatic::instance(), '\FooStatic');
+exprtype(BarStatic::instance(), '\BarStatic');
+exprtype(BazStatic::instance(), '\BazStatic');
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
+func TestExprTypeTraitSelfStatic2(t *testing.T) {
+	// Tests for WStaticPropertyFetch.
+	code := `<?php
+trait NewSelf {
+  /** @var self */
+  public static $v = null;
+}
+
+class FooSelf {
+  use NewSelf;
+  private static function f() {
+    exprtype(self::$v, '\FooSelf|null');
+  }
+}
+
+class BarSelf extends FooSelf {
+  private static function f() {
+    exprtype(self::$v, '\FooSelf|null');
+  }
+}
+
+class BazSelf {
+  use NewSelf;
+  private static function f() {
+    exprtype(self::$v, '\BazSelf|null');
+  }
+}
+
+exprtype(FooSelf::$v, '\FooSelf|null');
+exprtype(BarSelf::$v, '\FooSelf|null');
+exprtype(BazSelf::$v, '\BazSelf|null');
+
+trait NewStatic {
+  /** @var static */
+  public static $v = null;
+}
+
+class FooStatic {
+  use NewStatic;
+  private static function f() {
+    exprtype(self::$v, '\FooStatic|null');
+  }
+}
+
+class BarStatic extends FooStatic {
+  private static function f() {
+    exprtype(self::$v, '\BarStatic|null');
+  }
+}
+
+class BazStatic {
+  use NewStatic;
+  private static function f() {
+    exprtype(self::$v, '\BazStatic|null');
+  }
+}
+
+exprtype(FooStatic::$v, '\FooStatic|null');
+exprtype(BarStatic::$v, '\BarStatic|null');
+exprtype(BazStatic::$v, '\BazStatic|null');
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func TestExprTypeIssue497(t *testing.T) {
 	code := `<?php
 /**

--- a/src/linttest/trait_test.go
+++ b/src/linttest/trait_test.go
@@ -1,1 +1,39 @@
 package linttest_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestTraitSingleton(t *testing.T) {
+	// See #533.
+	linttest.SimpleNegativeTest(t, `<?php
+trait Singleton {
+  /**
+   * @var self
+   */
+  private static $instance = null;
+
+  /**
+   * @return self
+   */
+  public static function instance() {
+    if (!self::$instance) {
+      self::$instance = new self();
+    }
+
+    return self::$instance;
+  }
+}
+
+class Foo {
+  use Singleton;
+
+  /** @return int */
+  public function f() { return 42; }
+}
+
+Foo::instance()->f();
+`)
+}


### PR DESCRIPTION
When `self` is used inside a trait T, we expand that `self` to T
during the indexing phase (so metadata contains T instead of `self`).

This is not correct as T can't be a valid type on its own and `self`
always refers to a class C that embeds T.

Since T is not a valid type name, but it's known to be a trait name,
we can safely replace T with C during the types solving.

In contrast to the late static bindings resolution, we do that
replacement right away using the current scope className.

I also fixed a bug in WStaticPropertyFetch case. It was passing
class variable instead of className down the resolution chain
which led to invalid late static binding results.

Fixes #533

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>