### PR TITLE
cmd: pass InitEnvironment object to AfterFlagsParse

### DIFF
--- a/example/custom/main.go
+++ b/example/custom/main.go
@@ -39,7 +39,7 @@ func main() {
 	})
 }
 
-func useCustomFlags() {
+func useCustomFlags(env cmd.InitEnvironment) {
 	if *customFlag != "" {
 		log.Println("custom flag value:", *customFlag)
 	}

--- a/src/cmd/conf.go
+++ b/src/cmd/conf.go
@@ -2,7 +2,14 @@ package cmd
 
 import (
 	"github.com/VKCOM/noverify/src/linter"
+	"github.com/VKCOM/noverify/src/rules"
 )
+
+// InitEnvironment passes the state that may be required to finish
+// custom linters initialization.
+type InitEnvironment struct {
+	RuleSets []*rules.Set
+}
 
 // MainConfig describes optional main function config.
 // All zero field values have some defined behavior.
@@ -11,7 +18,7 @@ type MainConfig struct {
 	// Can be used to examine flags that were bound prior to the Main() call.
 	//
 	// If nil, behaves as a no-op function.
-	AfterFlagParse func()
+	AfterFlagParse func(InitEnvironment)
 
 	// BeforeReport acts as both an on-report action and a filter.
 	//

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -83,7 +83,9 @@ func Run(cfg *MainConfig) (int, error) {
 		linter.CacheDir = ""
 	}
 	if cfg.AfterFlagParse != nil {
-		cfg.AfterFlagParse()
+		cfg.AfterFlagParse(InitEnvironment{
+			RuleSets: ruleSets,
+		})
 	}
 
 	return mainNoExit(ruleSets, &args, cfg)

--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -79,6 +79,7 @@ func parseEmbeddedRules(p *rules.Parser) ([]*rules.Set, error) {
 		if err != nil {
 			return nil, err
 		}
+		rset.Builtin = true
 		ruleSets = append(ruleSets, rset)
 	}
 	return ruleSets, nil

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -29,9 +29,10 @@ func NewSet() *Set {
 
 // Set is a result of rule file parsing.
 type Set struct {
-	Any   *ScopedSet // Anywhere
-	Root  *ScopedSet // Only outside of functions
-	Local *ScopedSet // Only inside functions
+	Any     *ScopedSet // Anywhere
+	Root    *ScopedSet // Only outside of functions
+	Local   *ScopedSet // Only inside functions
+	Builtin bool       // Whether this is a NoVerify builtin rule set
 
 	Names []string // All rule names
 }


### PR DESCRIPTION
To avoid doing the double work, pass some information
to the custom linters explicitly.

Right now I only need rule sets, but we may need something
else in the future.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>