### PR TITLE
linter: fix function name resolving in side effects finder

### DIFF
--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1243,3 +1243,13 @@ function f($x) {
 }
 `)
 }
+
+func TestIssue547(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{`stubs/phpstorm-stubs/standard/standard_3.php`}
+	test.AddFile(`<?php
+putenv("A=1");
+\putenv("B=2");
+`)
+	test.RunAndMatch()
+}


### PR DESCRIPTION
Since we can get both FQN and relative names, it's more
reliable to do a proper function name resolving in
side effects finder.

We only handled relative names before which led to false
positives in discardExpr when FQN was used.

Fixes #547

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>