### PR TITLE
linter: don't stop at the first method/prop match

### DIFF
--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1253,3 +1253,134 @@ putenv("A=1");
 `)
 	test.RunAndMatch()
 }
+
+func TestIssue548_1(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class A {
+  private $value;
+  private function method() {}
+}
+
+class B {
+  private $value;
+  private function method() {}
+}
+
+class C extends B {
+  private $value;
+  private function method() {}
+
+  /**
+   * @param A|B|C $x
+   */
+  private function foo($x) {
+    if ($x instanceof C) {
+      echo $x->value;
+      echo $x->method();
+    }
+  }
+}`)
+}
+
+func TestIssue548_2(t *testing.T) {
+	// Like TestIssue548, but with different names and types order.
+	linttest.SimpleNegativeTest(t, `<?php
+class C {
+  private $value;
+  private function method() {}
+}
+
+class B {
+  private $value;
+  private function method() {}
+}
+
+class A extends B {
+  private $value;
+  private function method() {}
+
+  /**
+   * @param A|B|C $x
+   */
+  private function foo($x) {
+    if ($x instanceof A) {
+      echo $x->value;
+      echo $x->method();
+    }
+  }
+}`)
+}
+
+func TestIssue548_Magic(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class A {
+  public function __call($method, $args) {}
+  public function __get($prop) {}
+}
+
+class B extends A {
+  /**
+   * @param A|B $x
+   */
+  private function foo($x) {
+    if ($x instanceof B) {
+      echo $x->value;
+      echo $x->method();
+    }
+  }
+}`)
+}
+
+func TestIssue548_Trait1(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class A {
+  private $value;
+  private function method() {}
+}
+
+trait T {
+  private $value;
+  private function method() {}
+}
+
+class B {
+  use T;
+
+  /**
+   * @param A|B $x
+   */
+  private function foo($x) {
+    if ($x instanceof B) {
+      echo $x->value;
+      echo $x->method();
+    }
+  }
+}`)
+}
+
+func TestIssue548_Trait2(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class B {
+  private $value;
+  private function method() {}
+}
+
+trait T {
+  private $value;
+  private function method() {}
+}
+
+class A {
+  use T;
+
+  /**
+   * @param A|B $x
+   */
+  private function foo($x) {
+    if ($x instanceof A) {
+      echo $x->value;
+      echo $x->method();
+    }
+  }
+}`)
+}


### PR DESCRIPTION
When doing a method/property lookup to see whether it's defined,
don't stop at the first name match. We may find a more accessible
version of the symbol. Right now we prioritize own symbols over
base class symbols over everything else.

Fixes #548

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>