### PR TITLE
solver: return prev solving result for recursive cases

### DIFF
--- a/src/langsrv/langsrv.go
+++ b/src/langsrv/langsrv.go
@@ -439,7 +439,7 @@ func handleTextDocumentReferences(req *baseRequest) error {
 	})
 }
 
-func resolveTypesSafe(curStaticClass string, m meta.TypesMap, visitedMap map[string]struct{}) (res map[string]struct{}) {
+func resolveTypesSafe(curStaticClass string, m meta.TypesMap, visitedMap solver.ResolverMap) (res map[string]struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
 			res = make(map[string]struct{})
@@ -540,7 +540,7 @@ func getHoverForNode(n node.Node, sc *meta.Scope, cs *meta.ClassParseState) stri
 
 func getHoverForVariable(v *node.SimpleVar, sc *meta.Scope, cs *meta.ClassParseState) string {
 	typ, _ := sc.GetVarNameType(v.Name)
-	newM := meta.NewTypesMapFromMap(resolveTypesSafe(cs.CurrentClass, typ, make(map[string]struct{})))
+	newM := meta.NewTypesMapFromMap(resolveTypesSafe(cs.CurrentClass, typ, make(solver.ResolverMap)))
 	return newM.String() + " $" + v.Name
 }
 

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -65,7 +65,7 @@ func ExprTypeCustom(sc *meta.Scope, cs *meta.ClassParseState, n node.Node, custo
 		return m
 	}
 
-	visitedMap := make(map[string]struct{})
+	visitedMap := make(ResolverMap)
 	resolvedTypes := ResolveTypes(cs.CurrentClass, m, visitedMap)
 	return meta.NewTypesMapFromMap(resolvedTypes)
 }

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -20,20 +20,22 @@ func mixedType() map[string]struct{} {
 
 // ResolveType resolves function calls, method calls and global variables.
 //   curStaticClass is current class name (if inside the class, otherwise "")
-func resolveType(curStaticClass, typ string, visitedMap map[string]struct{}) (result map[string]struct{}) {
+func resolveType(curStaticClass, typ string, visitedMap ResolverMap) (result map[string]struct{}) {
 	r := resolver{visited: visitedMap}
 	return r.resolveType(curStaticClass, typ)
 }
 
 // ResolveTypes resolves function calls, method calls and global variables.
 //   curStaticClass is current class name (if inside the class, otherwise "")
-func ResolveTypes(curStaticClass string, m meta.TypesMap, visitedMap map[string]struct{}) map[string]struct{} {
+func ResolveTypes(curStaticClass string, m meta.TypesMap, visitedMap ResolverMap) map[string]struct{} {
 	r := resolver{visited: visitedMap}
 	return r.resolveTypes(curStaticClass, m)
 }
 
+type ResolverMap map[string]map[string]struct{}
+
 type resolver struct {
-	visited map[string]struct{}
+	visited ResolverMap
 }
 
 func (r *resolver) collectMethodCallTypes(out, possibleTypes map[string]struct{}, methodName string) map[string]struct{} {
@@ -50,6 +52,7 @@ func (r *resolver) collectMethodCallTypes(out, possibleTypes map[string]struct{}
 
 func (r *resolver) resolveType(class, typ string) map[string]struct{} {
 	res := r.resolveTypeNoLateStaticBinding(class, typ)
+	r.visited[typ] = res
 
 	if _, ok := res["static"]; ok {
 		delete(res, "static")
@@ -62,8 +65,8 @@ func (r *resolver) resolveType(class, typ string) map[string]struct{} {
 func (r *resolver) resolveTypeNoLateStaticBinding(class, typ string) map[string]struct{} {
 	visitedMap := r.visited
 
-	if _, ok := visitedMap[typ]; ok {
-		return nil
+	if result, ok := visitedMap[typ]; ok {
+		return result
 	}
 
 	if len(typ) == 0 || typ[0] >= meta.WMax {
@@ -71,7 +74,7 @@ func (r *resolver) resolveTypeNoLateStaticBinding(class, typ string) map[string]
 	}
 
 	res := make(map[string]struct{})
-	visitedMap[typ] = struct{}{}
+	visitedMap[typ] = nil // Nil guards against unbound recursion
 
 	switch typ[0] {
 	case meta.WGlobal:
@@ -187,7 +190,7 @@ func (r *resolver) resolveTypeNoLateStaticBinding(class, typ string) map[string]
 	return res
 }
 
-func solveBaseMethodParam(curStaticClass, typ string, visitedMap, res map[string]struct{}) map[string]struct{} {
+func solveBaseMethodParam(curStaticClass, typ string, visitedMap ResolverMap, res map[string]struct{}) map[string]struct{} {
 	index, className, methodName := meta.UnwrapBaseMethodParam(typ)
 	class, ok := meta.Info.GetClass(className)
 	if ok {

--- a/src/solver/solver_test.go
+++ b/src/solver/solver_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func resolve(typ string) map[string]struct{} {
-	return resolveType("", typ, make(map[string]struct{}))
+	return resolveType("", typ, make(ResolverMap))
 }
 
 func makeTyp(typ string) map[string]struct{} {


### PR DESCRIPTION
We achieve this by using map[string]map[string]struct{} instead of
map[string]struct{}. The nested maps are the resolveType results for
a given type.

We start by assigning a nil map so we don't fall into the infinite
recursion. When resolveTypeNoLateStaticBinding returns we record
resolving results into the same map key. If we hit the resolving loop,
we return previously computed value (if any).

This does affect the performance by a ~5%:

	name                     old time/op    new time/op    delta
	ExprType/simplevar-8       2.15µs ± 2%    2.27µs ± 1%  +5.43%  (p=0.008 n=5+5)
	ExprType/f1call-8          5.06µs ± 1%    5.22µs ± 1%  +3.23%  (p=0.008 n=5+5)
	ExprType/f3call-8          3.78µs ± 1%    3.92µs ± 2%  +3.49%  (p=0.008 n=5+5)
	ExprType/m4call-8          7.22µs ± 2%    7.52µs ± 1%  +4.19%  (p=0.008 n=5+5)
	ExprType/newpropfetch-8    5.88µs ± 1%    6.04µs ± 0%  +2.66%  (p=0.016 n=5+4)

(Benchmarks are from the linttest bench_test.go suite.)

Fixes #553

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>