### PR TITLE
solver: handle interfaces in Implements()

### DIFF
--- a/src/linttest/regression_test.go
+++ b/src/linttest/regression_test.go
@@ -1384,3 +1384,35 @@ class A {
   }
 }`)
 }
+
+func TestIssue556(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{`stubs/phpstorm-stubs/Core/Core_c.php`}
+	test.AddFile(`<?php
+/**
+ * @param \ArrayAccess|array $v
+ */
+function f1($v) {
+  return $v[10];
+}
+
+interface MyArrayAccess extends ArrayAccess {}
+
+/**
+ * @param MyArrayAccess|array $v
+ */
+function f2($v) {
+  return $v[10];
+}
+
+interface MyArrayAccess2 extends MyArrayAccess {}
+
+/**
+ * @param MyArrayAccess2 $v
+ */
+function f3($v) {
+  return $v[10];
+}
+`)
+	test.RunAndMatch()
+}

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -466,6 +466,13 @@ func findProperty(className string, propertyName string, visitedMap map[string]s
 // Does not perform the actual method set comparison.
 func Implements(className string, interfaceName string) bool {
 	visited := make(map[string]struct{}, 8)
+	return implements(className, interfaceName, visited)
+}
+
+func implements(className string, interfaceName string, visited map[string]struct{}) bool {
+	if className == interfaceName {
+		return true
+	}
 
 	for {
 		class, ok := meta.Info.GetClass(className)
@@ -480,6 +487,12 @@ func Implements(className string, interfaceName string) bool {
 
 		for iface := range class.Interfaces {
 			if interfaceExtends(iface, interfaceName, visited) {
+				return true
+			}
+		}
+
+		for _, iface := range class.ParentInterfaces {
+			if implements(iface, interfaceName, visited) {
 				return true
 			}
 		}


### PR DESCRIPTION
Added 2 cases:
- Implements(I, I) => true
- Implements(I1 extends I2, I2) => true

We could separate the loop for class-only and interface-only paths,
but it seems we can't tell whether a ClassInfo represents
a class or an interface.

Fixes #556

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>