### PR TITLE
meta: handle class and trait collisions

### DIFF
--- a/src/linttest/indexing_order_test.go
+++ b/src/linttest/indexing_order_test.go
@@ -1,0 +1,96 @@
+package linttest_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestIndexingOrderClasses(t *testing.T) {
+	// This test introduces conflicting declarations.
+	//
+	// No matter which file traversal order we get, if we simply
+	// override the metadata, we'll get warnings in either case.
+	//
+	// If foo/A class is recorded, the second file will have troubles
+	// accessing $v->field. If bar/A is recorded, the first file will
+	// have troubles creating A with 0 constructor arguments.
+
+	test := linttest.NewSuite(t)
+	addNamedFile(test, "/foo/A.php", `<?php
+class A {}
+
+$v = new A();
+`)
+	addNamedFile(test, "/bar/A.php", `<?php
+class A {
+  public $field;
+  public function __construct($x) { $this->field = $x; }
+}
+
+$v = new A(1);
+echo $v->field;
+`)
+
+	// TODO: this test should give no warnings.
+	// Right now we ensure that the linter output doesn't depend
+	// on the file traversal order, but this warnings is still out of place.
+	test.Expect = []string{
+		`argCount: Too few arguments for \A constructor`,
+	}
+	test.RunAndMatch()
+}
+
+func TestIndexingOrderTraits(t *testing.T) {
+	test := linttest.NewSuite(t)
+	addNamedFile(test, "/foo/A.php", `<?php
+trait TA {}
+
+class A { use TA; }
+
+$v = new A();
+`)
+	addNamedFile(test, "/bar/A.php", `<?php
+trait TA {
+  public $field;
+  public function __construct($x) { $this->field = $x; }
+}
+
+class B {
+  use TA;
+}
+
+$v = new B(1);
+echo $v->field;
+`)
+
+	// TODO: this test should give no warnings.
+	// Right now we ensure that the linter output doesn't depend
+	// on the file traversal order, but this warnings is still out of place.
+	test.Expect = []string{
+		`argCount: Too few arguments for \A constructor`,
+	}
+	test.RunAndMatch()
+}
+
+func TestIndexingOrderFuncs(t *testing.T) {
+	test := linttest.NewSuite(t)
+	addNamedFile(test, "/foo/A.php", `<?php
+function a() {}
+
+a();
+`)
+	addNamedFile(test, "/bar/A.php", `<?php
+function a($x) {}
+
+a(1);
+`)
+
+	// TODO: this test should give no warnings.
+	// Right now we ensure that the linter output doesn't depend
+	// on the file traversal order, but this warnings is still out of place.
+	test.Expect = []string{
+		`Too few arguments for a`,
+	}
+	test.RunAndMatch()
+}

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -228,17 +228,25 @@ func (i *info) DeleteMetaForFileNonLocked(filename string) {
 
 func (i *info) AddClassesNonLocked(filename string, m ClassesMap) {
 	i.perFileClasses[filename] = m
+
+	allClasses := i.allClasses.H
 	for k, v := range m.H {
-		// TODO: resolve duplicate class conflicts
-		i.allClasses.H[k] = v
+		prevClass, ok := allClasses[k]
+		if !ok || v.Pos.Length > prevClass.Pos.Length {
+			allClasses[k] = v
+		}
 	}
 }
 
 func (i *info) AddTraitsNonLocked(filename string, m ClassesMap) {
 	i.perFileTraits[filename] = m
+
+	allTraits := i.allTraits.H
 	for k, v := range m.H {
-		// TODO: resolve duplicate trait conflicts
-		i.allTraits.H[k] = v
+		prevTrait, ok := allTraits[k]
+		if !ok || v.Pos.Length > prevTrait.Pos.Length {
+			allTraits[k] = v
+		}
 	}
 }
 
@@ -266,6 +274,10 @@ func (i *info) AddConstantsNonLocked(filename string, m ConstantsMap) {
 	i.perFileConstants[filename] = m
 
 	for k, v := range m {
+		// This may cause a name conflict if we have several
+		// constants with the same name inside the project.
+		// When we'll store a list of symbols for the every name,
+		// it won't be a problem anymore.
 		i.allConstants[k] = v
 	}
 }


### PR DESCRIPTION
Like with functions, choose a "larger" definition.

This makes the linter output more stable as traversal
order will not influence indexing results.

We still may want to store slices of entries instead of only
one, but that's a bigger task and would require much more changes.

Output stability is required to make the baseline mode usable.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>