### PR TITLE
cmd: handle index-only-files flag in non-git mode as well

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -175,6 +175,7 @@ func mainNoExit(ruleSets []*rules.Set, args *cmdlineArguments, cfg *MainConfig) 
 
 	log.Printf("Indexing %+v", flag.Args())
 	linter.ParseFilenames(linter.ReadFilenames(flag.Args(), nil))
+	parseIndexOnlyFiles(&l)
 	meta.SetIndexingComplete(true)
 	log.Printf("Linting")
 


### PR DESCRIPTION
Suppose we have 2 source folders: `www` and `cron`. They use classes from `vendor`. We want to check `www` and `cron`, but we also need definitions from the `vendor`.

It can be simple with index-only-files:

	noverify -index-only-files ./vendor ./www ./cron

If we don't have -index-only-files, then we have to do this:

	noverify -exclude vendor ./www ./cron ./vendor

Or this (a better way, but requires arguments duplication):

	noverify -full-analysis-files ./www,./cron ./www ./cron ./vendor

With index-only-files we can specify source directories that are
required for the indexing phase, but should not be visited during the
linting phase.