### PR TITLE
Improved storage of the value of constants

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/VKCOM/noverify/src/meta"
@@ -1377,15 +1376,22 @@ func (b *BlockWalker) handleArrayItems(arr node.Node, items []*expr.ArrayItem) b
 				continue
 			}
 
-			key = info.Value.Value
+			value := info.Value.Value
 
-			if info.Value.Type == meta.Float {
-				val, err := strconv.ParseFloat(key, 64)
-				if err != nil {
+			switch info.Value.Type {
+			case meta.Float:
+				val, ok := value.(float64)
+				if !ok {
 					continue
 				}
 				value := int64(val)
 				key = fmt.Sprint(value)
+
+			case meta.Integer:
+				key = fmt.Sprint(value)
+
+			case meta.String:
+				key = value.(string)
 			}
 
 			constKey = true

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -111,7 +111,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 4109
+		wantLen := 4078
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -120,7 +120,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "f5c3f410fd821309de4eaf6bc68ca6aee07dcb904edeaa7b8cb6798291103f9036dbc5ffbff87dc01f04d26f0483a623caf5511f60d4b66a60952870a516c11c"
+		wantStrings := "5229b096d5a9f0ed73cea28dce9677760e620ed5fd33ccda12355159735e181b09ef152b4d518af886f13b1c7bebd2f1ca274b5485b91d0f23813d05ee646382"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/meta/encoding_test.go
+++ b/src/meta/encoding_test.go
@@ -94,3 +94,59 @@ func TestTypeEncoding(t *testing.T) {
 		}
 	}
 }
+
+func TestConstantValueDecodeEncode(t *testing.T) {
+	// encode test
+	v := ConstantValue{
+		Type:  Integer,
+		Value: int64(54),
+	}
+	b, err := v.GobEncode()
+	if err != nil {
+		t.Errorf("unexpected error \"%s\"", err)
+	}
+
+	if b[0] != byte(Integer) || b[1] != 53 || b[2] != 52 {
+		t.Error("error encode")
+	}
+
+	// decode test
+	vb := ConstantValue{}
+	err = vb.GobDecode(b)
+	if err != nil {
+		t.Errorf("unexpected error \"%s\"", err)
+	}
+
+	if vb.Type != v.Type || vb.Value != v.Value {
+		t.Error("error decode, objects not equal")
+	}
+
+	// decode test #2
+	v2 := ConstantValue{
+		Type:  Integer,
+		Value: "hello",
+	}
+
+	b2, err := v2.GobEncode()
+	if err == nil {
+		t.Error("expected error \"corrupted integer\"")
+	}
+
+	vb2 := ConstantValue{}
+	err = vb2.GobDecode(b2)
+	if err == nil {
+		t.Error("expected error \"data corrupted\"")
+	}
+
+	// error type
+	vv := ConstantValue{
+		Type:  100,
+		Value: int64(54),
+	}
+	_, err = vv.GobEncode()
+
+	if err == nil {
+		t.Error("expected error \"unhandled type\"")
+	}
+
+}

--- a/src/meta/encoding_test.go
+++ b/src/meta/encoding_test.go
@@ -96,57 +96,32 @@ func TestTypeEncoding(t *testing.T) {
 }
 
 func TestConstantValueDecodeEncode(t *testing.T) {
-	// encode test
-	v := ConstantValue{
-		Type:  Integer,
-		Value: int64(54),
-	}
-	b, err := v.GobEncode()
-	if err != nil {
-		t.Errorf("unexpected error \"%s\"", err)
-	}
-
-	if b[0] != byte(Integer) || b[1] != 53 || b[2] != 52 {
-		t.Error("error encode")
+	testCases := []ConstantValue{
+		{Type: String, Value: "world"},
+		{Type: Integer, Value: int64(5)},
+		{Type: Float, Value: 5.56},
+		{Type: String, Value: "hello"},
+		{Type: Float, Value: 124.67},
+		{Type: Integer, Value: int64(50000000)},
 	}
 
-	// decode test
-	vb := ConstantValue{}
-	err = vb.GobDecode(b)
-	if err != nil {
-		t.Errorf("unexpected error \"%s\"", err)
-	}
+	for _, testCase := range testCases {
+		// encode this
+		encoded, err := testCase.GobEncode()
+		if err != nil {
+			t.Errorf("unexpected error \"%s\"", err)
+		}
 
-	if vb.Type != v.Type || vb.Value != v.Value {
-		t.Error("error decode, objects not equal")
-	}
+		// decode this
+		decoded := ConstantValue{}
+		err = decoded.GobDecode(encoded)
+		if err != nil {
+			t.Errorf("unexpected error \"%s\"", err)
+		}
 
-	// decode test #2
-	v2 := ConstantValue{
-		Type:  Integer,
-		Value: "hello",
+		// compare
+		if decoded.Type != testCase.Type || decoded.Value != testCase.Value {
+			t.Error("error decode, objects not equal")
+		}
 	}
-
-	b2, err := v2.GobEncode()
-	if err == nil {
-		t.Error("expected error \"corrupted integer\"")
-	}
-
-	vb2 := ConstantValue{}
-	err = vb2.GobDecode(b2)
-	if err == nil {
-		t.Error("expected error \"data corrupted\"")
-	}
-
-	// error type
-	vv := ConstantValue{
-		Type:  100,
-		Value: int64(54),
-	}
-	_, err = vv.GobEncode()
-
-	if err == nil {
-		t.Error("expected error \"unhandled type\"")
-	}
-
 }


### PR DESCRIPTION
The way of storing values for constants has been changed. Now interface{} is used for this, which avoids unnecessary conversions from a string to a certain type and back.

Since the data is not stored in a string, methods for decoding and encoding and tests for them were written for caching.

Solve #594 