### PR TITLE
linttest: add e2e layer to golden tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 phplinter.sh
 phplinter
+phplinter-output.json
 err.log
 src/cmd/stubs/phpstorm-stubs/
 y.output

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -40,6 +40,7 @@ type cmdlineArguments struct {
 
 	unusedVarPattern string
 
+	allowAll     bool
 	allowChecks  string
 	allowDisable string
 
@@ -143,6 +144,8 @@ func bindFlags(ruleSets []*rules.Set, args *cmdlineArguments) {
 	flag.StringVar(&args.allowDisable, "allow-disable", "", "Regexp for filenames where '@linter disable' is allowed")
 	flag.StringVar(&args.allowChecks, "allow-checks", strings.Join(enabledByDefault, ","),
 		"Comma-separated list of check names to be enabled")
+	flag.BoolVar(&args.allowAll, "allow-all-checks", false,
+		"Has the same effect as passing all check names to the -allow-checks parameter")
 	flag.StringVar(&args.misspellList, "misspell-list", "Eng",
 		"Comma-separated list of misspelling dicts; predefined sets are Eng, Eng/US and Eng/UK")
 

--- a/src/cmd/linter_runner.go
+++ b/src/cmd/linter_runner.go
@@ -27,7 +27,7 @@ type linterRunner struct {
 }
 
 func (l *linterRunner) IsEnabledByFlags(checkName string) bool {
-	if !l.reportsIncludeChecksSet[checkName] {
+	if !l.args.allowAll && !l.reportsIncludeChecksSet[checkName] {
 		return false // Not enabled by -allow-checks
 	}
 

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/VKCOM/noverify/src/langsrv"
 	"github.com/VKCOM/noverify/src/lintdebug"
 	"github.com/VKCOM/noverify/src/linter"
+	"github.com/VKCOM/noverify/src/linter/lintapi"
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/rules"
 )
@@ -33,13 +34,13 @@ import (
 
 func isCritical(l *linterRunner, r *linter.Report) bool {
 	if len(l.reportsCriticalSet) != 0 {
-		return l.reportsCriticalSet[r.CheckName()]
+		return l.reportsCriticalSet[r.CheckName]
 	}
 	return r.IsCritical()
 }
 
 func isEnabled(l *linterRunner, r *linter.Report) bool {
-	if !l.IsEnabledByFlags(r.CheckName()) {
+	if !l.IsEnabledByFlags(r.CheckName) {
 		return false
 	}
 
@@ -48,7 +49,7 @@ func isEnabled(l *linterRunner, r *linter.Report) bool {
 	}
 
 	// Disabled by a file comment.
-	return !linter.ExcludeRegex.MatchString(r.GetFilename())
+	return !linter.ExcludeRegex.MatchString(r.Filename)
 }
 
 // Run executes linter main function.
@@ -206,17 +207,17 @@ func createBaseline(l *linterRunner, cfg *MainConfig, reports []*linter.Report) 
 		}
 
 		stats.CountTotal++
-		stats.CountPerCheck[r.CheckName()]++
-		filename := filepath.Base(r.GetFilename())
+		stats.CountPerCheck[r.CheckName]++
+		filename := filepath.Base(r.Filename)
 		f, ok := files[filename]
 		if !ok {
 			f.Filename = filename
 			f.Reports = make(map[uint64]baseline.Report)
 		}
-		info := f.Reports[r.Hash()]
+		info := f.Reports[r.Hash]
 		info.Count++
-		info.Hash = r.Hash()
-		f.Reports[r.Hash()] = info
+		info.Hash = r.Hash
+		f.Reports[r.Hash] = info
 		files[filename] = f
 	}
 
@@ -226,6 +227,43 @@ func createBaseline(l *linterRunner, cfg *MainConfig, reports []*linter.Report) 
 		Files:         files,
 	}
 	return baseline.WriteProfile(l.outputFp, profile, &stats)
+}
+
+func FormatReport(r *linter.Report) string {
+	msg := r.Message
+	if r.CheckName != "" {
+		msg = r.CheckName + ": " + msg
+	}
+
+	// No context line for security-level warnings.
+	if r.Level == lintapi.LevelSecurity {
+		// To make output stable between platforms, see #572
+		filename := strings.ReplaceAll(r.Filename, "\\", "/")
+
+		return fmt.Sprintf("%-7s %s at %s:%d", r.Severity(), msg, filename, r.Line)
+	}
+
+	cursor := strings.Builder{}
+	for i, ch := range r.Context {
+		if i == r.StartChar {
+			break
+		}
+		if ch == '\t' {
+			cursor.WriteRune('\t')
+		} else {
+			cursor.WriteByte(' ')
+		}
+	}
+
+	if r.EndChar > r.StartChar {
+		cursor.WriteString(strings.Repeat("^", r.EndChar-r.StartChar))
+	}
+
+	// To make output stable between platforms, see #572
+	filename := strings.ReplaceAll(r.Filename, "\\", "/")
+
+	return fmt.Sprintf("%-7s %s at %s:%d\n%s\n%s",
+		r.Severity(), msg, filename, r.Line, r.Context, cursor.String())
 }
 
 func analyzeReports(l *linterRunner, cfg *MainConfig, diff []*linter.Report) (criticalReports int) {
@@ -262,9 +300,9 @@ func analyzeReports(l *linterRunner, cfg *MainConfig, diff []*linter.Report) (cr
 	} else {
 		for _, r := range filtered {
 			if isCritical(l, r) {
-				fmt.Fprintf(l.outputFp, "<critical> %s\n", r.String())
+				fmt.Fprintf(l.outputFp, "<critical> %s\n", FormatReport(r))
 			} else {
-				fmt.Fprintf(l.outputFp, "%s\n", r.String())
+				fmt.Fprintf(l.outputFp, "%s\n", FormatReport(r))
 			}
 		}
 	}

--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -240,17 +240,6 @@ var vscodeLevelMap = map[int]int{
 	// LevelSyntax is intentionally not included here
 }
 
-var severityNames = map[int]string{
-	LevelError:       "ERROR  ",
-	LevelWarning:     "WARNING",
-	LevelInformation: "INFO   ",
-	LevelHint:        "HINT   ",
-	LevelUnused:      "UNUSED ",
-	LevelDoNotReject: "MAYBE  ",
-	LevelSyntax:      "SYNTAX ",
-	LevelSecurity:    "WARNING",
-}
-
 var (
 	customBlockLinters []BlockCheckerCreateFunc
 	customRootLinters  []RootCheckerCreateFunc

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -493,15 +493,15 @@ func (d *RootWalker) report(n node.Node, lineNumber int, level int, checkName, m
 		}
 
 		d.reports = append(d.reports, &Report{
-			checkName: checkName,
-			startLn:   string(startLn),
-			startChar: startChar,
-			startLine: pos.StartLine,
-			endChar:   endChar,
-			level:     level,
-			filename:  d.ctx.st.CurrentFile,
-			msg:       msg,
-			hash:      hash,
+			CheckName: checkName,
+			Context:   string(startLn),
+			StartChar: startChar,
+			EndChar:   endChar,
+			Line:      pos.StartLine,
+			Level:     level,
+			Filename:  d.ctx.st.CurrentFile,
+			Message:   msg,
+			Hash:      hash,
 		})
 	}
 }

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/VKCOM/noverify/src/cmd"
 	"github.com/VKCOM/noverify/src/linter"
 	"github.com/VKCOM/noverify/src/linttest"
 	"github.com/VKCOM/noverify/src/meta"
@@ -1519,7 +1520,7 @@ func TestFunctionThrowsExceptionsAndReturns(t *testing.T) {
 	}
 
 	for _, r := range reports {
-		log.Printf("%s", r)
+		log.Printf("%s", cmd.FormatReport(r))
 	}
 }
 
@@ -1803,7 +1804,7 @@ func filterReports(names []string, reports []*linter.Report) []*linter.Report {
 
 	var out []*linter.Report
 	for _, r := range reports {
-		if _, ok := set[r.CheckName()]; ok {
+		if _, ok := set[r.CheckName]; ok {
 			out = append(out, r)
 		}
 	}

--- a/src/linttest/golden_test.go
+++ b/src/linttest/golden_test.go
@@ -1,9 +1,11 @@
 package linttest_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -15,6 +17,17 @@ import (
 	"github.com/VKCOM/noverify/src/rules"
 	"github.com/google/go-cmp/cmp"
 )
+
+type goldenTest struct {
+	name    string
+	deps    []string
+	disable []string
+
+	srcDir string
+
+	// want is a golden file contents.
+	want []byte
+}
 
 func TestGolden(t *testing.T) {
 	defer func(rset *rules.Set) {
@@ -28,30 +41,7 @@ func TestGolden(t *testing.T) {
 		t.Fatalf("init embedded rules: %v", err)
 	}
 
-	coreFiles := []string{
-		`stubs/phpstorm-stubs/Core/Core.php`,
-		`stubs/phpstorm-stubs/Core/Core_d.php`,
-		`stubs/phpstorm-stubs/Core/Core_c.php`,
-		`stubs/phpstorm-stubs/gd/gd.php`,
-		`stubs/phpstorm-stubs/pcre/pcre.php`,
-		`stubs/phpstorm-stubs/standard/standard_defines.php`,
-		`stubs/phpstorm-stubs/standard/standard_0.php`,
-		`stubs/phpstorm-stubs/standard/standard_1.php`,
-		`stubs/phpstorm-stubs/standard/standard_2.php`,
-		`stubs/phpstorm-stubs/standard/standard_3.php`,
-		`stubs/phpstorm-stubs/standard/standard_4.php`,
-		`stubs/phpstorm-stubs/standard/standard_5.php`,
-		`stubs/phpstorm-stubs/standard/standard_6.php`,
-		`stubs/phpstorm-stubs/standard/standard_7.php`,
-		`stubs/phpstorm-stubs/standard/standard_8.php`,
-		`stubs/phpstorm-stubs/standard/standard_9.php`,
-	}
-
-	targets := []struct {
-		name    string
-		deps    []string
-		disable []string
-	}{
+	targets := []*goldenTest{
 		{
 			name: "embeddedrules",
 		},
@@ -183,60 +173,180 @@ func TestGolden(t *testing.T) {
 	}
 
 	for _, target := range targets {
-		t.Run(target.name, func(t *testing.T) {
-			phpFiles, err := findPHPFiles(filepath.Join("testdata", target.name))
+		goldenFile := filepath.Join("testdata/", target.name, "golden.txt")
+		want, err := ioutil.ReadFile(goldenFile)
+		if err != nil {
+			t.Fatalf("read golden file: %v", err)
+		}
+		target.want = want
+
+		if target.srcDir == "" {
+			target.srcDir = filepath.Join("testdata", target.name)
+		}
+	}
+
+	// Old-style tests: run tests inside the same process,
+	// using the global state override.
+	// This is simple and fast, makes test coverage collection
+	// easier, but it can't test whether our linter can work from
+	// the command-line in the same way as it does here.
+	for _, target := range targets {
+		runGoldenTest(t, target)
+	}
+
+	// Second pass only happens if none of the tests above have failed.
+	if !t.Failed() {
+		runGoldenTestsE2E(t, targets)
+	}
+}
+
+func runGoldenTestsE2E(t *testing.T, targets []*goldenTest) {
+	if testing.Short() {
+		t.Logf("e2e is skipped in -short mode")
+		return
+	}
+
+	goArgs := []string{
+		"build",
+		"-o", "phplinter",
+		"-race",
+		"../../", // Using relative target to avoid problems with modules/vendor/GOPATH
+	}
+	out, err := exec.Command("go", goArgs...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("build noverify: %v: %s", err, out)
+	}
+
+	defer func() {
+		_ = os.Remove("phplinter")
+		_ = os.Remove("phplinter-output.json")
+	}()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	for _, target := range targets {
+		t.Run(target.name+"/e2e", func(t *testing.T) {
+			args := []string{
+				"--critical", "",
+				"--output-json",
+				"--disable-cache", // TODO: test with cache as well
+				"--allow-all-checks",
+				"--output", "phplinter-output.json",
+			}
+			if len(target.disable) != 0 {
+				args = append(args, "--exclude-checks", strings.Join(target.disable, ","))
+			}
+			args = append(args, target.srcDir)
+
+			out, err := exec.Command("./phplinter", args...).CombinedOutput()
 			if err != nil {
-				t.Fatalf("list files: %v", err)
+				t.Fatalf("%v: %s", err, out)
 			}
 
-			goldenFile := filepath.Join("testdata/", target.name, "golden.txt")
-			want, err := ioutil.ReadFile(goldenFile)
+			output, err := readReportsFile("phplinter-output.json")
 			if err != nil {
-				t.Fatalf("read golden file: %v", err)
+				t.Fatalf("read output file: %v", err)
 			}
 
-			test := linttest.NewSuite(t)
-			deps := target.deps
-			deps = append(deps, coreFiles...)
-			test.LoadStubs = deps
-			for _, f := range phpFiles {
-				code, err := ioutil.ReadFile(f)
-				if err != nil {
-					t.Fatalf("read PHP file: %v", err)
-				}
-				addNamedFile(test, f, string(code))
+			for _, r := range output.Reports {
+				// Turn absolute paths to something that is compatible
+				// with what we get from the testdata-loaded inputs.
+				r.Filename = strings.TrimPrefix(r.Filename, wd)
+				// TODO: make paths absolute in non-e2e tests so we can
+				// remove this "/" prefix trimming.
+				r.Filename = strings.TrimPrefix(r.Filename, "/")
 			}
 
-			disable := map[string]bool{}
-			for _, checkName := range target.disable {
-				disable[checkName] = true
-			}
-
-			var parts []string
-			reports := test.RunLinter()
-			sort.SliceStable(reports, func(i, j int) bool {
-				return reports[i].GetFilename() < reports[j].GetFilename()
-			})
-			for _, r := range reports {
-				if disable[r.CheckName()] {
-					continue
-				}
-				parts = append(parts, strings.Split(strings.ReplaceAll(r.String(), "\r", ""), "\n")...)
-			}
-			parts = append(parts, "") // Trailing EOL
-
-			haveLines := parts
-			wantString := string(want)
-			wantLines := strings.Split(strings.ReplaceAll(wantString, "\r", ""), "\n")
-			if diff := cmp.Diff(wantLines, haveLines); diff != "" {
-				t.Errorf("results mismatch (+ have) (- want): %s", diff)
-				// Use fmt.Printf() instead of t.Logf() to make the output
-				// more copy/paste friendly.
-				fmt.Printf("have:\n%s", strings.Join(haveLines, "\n"))
-				fmt.Printf("want:\n%s", want)
-			}
+			checkGoldenOutput(t, target.want, output.Reports)
 		})
 	}
+}
+
+func formatReportLines(reports []*linter.Report) []string {
+	sort.SliceStable(reports, func(i, j int) bool {
+		return reports[i].Filename < reports[j].Filename
+	})
+	var parts []string
+	for _, r := range reports {
+		part := strings.ReplaceAll(cmd.FormatReport(r), "\r", "")
+		parts = append(parts, strings.Split(part, "\n")...)
+	}
+	parts = append(parts, "") // Trailing EOL
+	return parts
+}
+
+type linterOutput struct {
+	Reports []*linter.Report
+	Errors  []string
+}
+
+func readReportsFile(filename string) (*linterOutput, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var output linterOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+func runGoldenTest(t *testing.T, target *goldenTest) {
+	coreFiles := []string{
+		`stubs/phpstorm-stubs/Core/Core.php`,
+		`stubs/phpstorm-stubs/Core/Core_d.php`,
+		`stubs/phpstorm-stubs/Core/Core_c.php`,
+		`stubs/phpstorm-stubs/gd/gd.php`,
+		`stubs/phpstorm-stubs/pcre/pcre.php`,
+		`stubs/phpstorm-stubs/standard/standard_defines.php`,
+		`stubs/phpstorm-stubs/standard/standard_0.php`,
+		`stubs/phpstorm-stubs/standard/standard_1.php`,
+		`stubs/phpstorm-stubs/standard/standard_2.php`,
+		`stubs/phpstorm-stubs/standard/standard_3.php`,
+		`stubs/phpstorm-stubs/standard/standard_4.php`,
+		`stubs/phpstorm-stubs/standard/standard_5.php`,
+		`stubs/phpstorm-stubs/standard/standard_6.php`,
+		`stubs/phpstorm-stubs/standard/standard_7.php`,
+		`stubs/phpstorm-stubs/standard/standard_8.php`,
+		`stubs/phpstorm-stubs/standard/standard_9.php`,
+	}
+
+	t.Run(target.name, func(t *testing.T) {
+		phpFiles, err := findPHPFiles(target.srcDir)
+		if err != nil {
+			t.Fatalf("list files: %v", err)
+		}
+
+		test := linttest.NewSuite(t)
+		deps := target.deps
+		deps = append(deps, coreFiles...)
+		test.LoadStubs = deps
+		for _, f := range phpFiles {
+			code, err := ioutil.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read PHP file: %v", err)
+			}
+			addNamedFile(test, f, string(code))
+		}
+
+		disable := map[string]bool{}
+		for _, checkName := range target.disable {
+			disable[checkName] = true
+		}
+		reports := test.RunLinter()
+		filteredReports := reports[:0]
+		for _, r := range reports {
+			if !disable[r.CheckName] {
+				filteredReports = append(filteredReports, r)
+			}
+		}
+
+		checkGoldenOutput(t, target.want, filteredReports)
+	})
 }
 
 func findPHPFiles(root string) ([]string, error) {
@@ -252,4 +362,17 @@ func findPHPFiles(root string) ([]string, error) {
 		return nil
 	})
 	return files, err
+}
+
+func checkGoldenOutput(t *testing.T, want []byte, reports []*linter.Report) {
+	haveLines := formatReportLines(reports)
+	wantString := string(want)
+	wantLines := strings.Split(strings.ReplaceAll(wantString, "\r", ""), "\n")
+	if diff := cmp.Diff(wantLines, haveLines); diff != "" {
+		t.Errorf("results mismatch (+ have) (- want): %s", diff)
+		// Use fmt.Printf() instead of t.Logf() to make the output
+		// more copy/paste friendly.
+		fmt.Printf("have:\n%s", strings.Join(haveLines, "\n"))
+		fmt.Printf("want:\n%s", want)
+	}
 }

--- a/src/linttest/linttest.go
+++ b/src/linttest/linttest.go
@@ -127,7 +127,7 @@ func (s *Suite) Match(reports []*linter.Report) {
 	matchedReports := map[*linter.Report]bool{}
 	usedMatchers := map[int]bool{}
 	for _, r := range reports {
-		have := r.String()
+		have := cmd.FormatReport(r)
 		for i, want := range expect {
 			if usedMatchers[i] {
 				continue
@@ -143,7 +143,7 @@ func (s *Suite) Match(reports []*linter.Report) {
 		if matchedReports[r] {
 			continue
 		}
-		t.Errorf("unexpected report %d: %s", i, r.String())
+		t.Errorf("unexpected report %d: %s", i, cmd.FormatReport(r))
 	}
 	for i, want := range expect {
 		if usedMatchers[i] {
@@ -156,7 +156,7 @@ func (s *Suite) Match(reports []*linter.Report) {
 	if t.Failed() {
 		t.Log(">>> issues reported:")
 		for _, r := range reports {
-			t.Log(r.String())
+			t.Log(cmd.FormatReport(r))
 		}
 		t.Log("<<<")
 	}

--- a/src/linttest/rules_test.go
+++ b/src/linttest/rules_test.go
@@ -430,7 +430,7 @@ func runRulesTest(t *testing.T, test *linttest.Suite, rfile string) {
 
 	var filtered []*linter.Report
 	for _, r := range test.RunLinter() {
-		if _, ok := ruleNamesSet[r.CheckName()]; ok {
+		if _, ok := ruleNamesSet[r.CheckName]; ok {
 			filtered = append(filtered, r)
 		}
 	}


### PR DESCRIPTION
Some refactoring was required in order to make the work easier.

linter.Report structure now exports all its fields to
make it possible to write report formatting function
outside of the linter package.

The new flag -allow-all-checks is used in e2e tests to enable
all checkers without a need to enumerate all of them.

How end-to-end tests is implemented:

- If all golden tests pass, we run all of them again,
  but using the NoVerify binary that will be compiled
  as a part of the test.

- When -short flag is specified, e2e tests are skipped
  to reduce the time required to pass all tests.

- NoVerify binary is compiled with -race flag. It makes
  it run noticeably slower, but we get a chance to catch
  some race conditions during the testing.

Plans for the future:
- Test with cache as well.
- Add baseline mode tests.

Fixes #589

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>