### PR TITLE
linter: added checks for functions

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -558,6 +558,7 @@ func (b *BlockWalker) handleReturn(ret *stmt.Return) {
 		currentClass := b.r.ctx.st.CurrentClass
 		currentMethod := b.r.ctx.st.CurrentMethod
 
+		var isBareReturnError bool
 		if len(currentClass) != 0 {
 			funcName = currentMethod
 
@@ -571,7 +572,7 @@ func (b *BlockWalker) handleReturn(ret *stmt.Return) {
 			}
 
 			if !fun.Typ.Is("void") {
-				b.r.Report(ret, LevelWarning, "bareReturn", "Replace 'return' with 'return null'")
+				isBareReturnError = true
 			}
 		} else {
 			fun, ok := meta.Info.GetFunction(funcName)
@@ -580,13 +581,13 @@ func (b *BlockWalker) handleReturn(ret *stmt.Return) {
 			}
 
 			if !fun.Typ.Is("void") {
-				b.r.Report(ret, LevelWarning, "bareReturn", "Replace 'return' with 'return null'")
+				isBareReturnError = true
 			}
 		}
 
-		// for _, el := range meta.Info.allFunctions.H {
-		// 	fmt.Println(el.Name)
-		// }
+		if isBareReturnError {
+			b.r.Report(ret, LevelWarning, "bareReturn", "Replace 'return' with 'return null'. The '%s' function has @return annotation with non-'void' value, so 'return null' is preferred.", funcName)
+		}
 
 		return
 	}

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -455,6 +455,12 @@ function performance_test() {}`,
 			Default: true,
 			Comment: `Report linter error.`,
 		},
+
+		{
+			Name:    "bareReturn",
+			Default: true,
+			Comment: `Report when function has bare return and non-void return type.`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -460,6 +460,61 @@ function performance_test() {}`,
 			Name:    "bareReturn",
 			Default: true,
 			Comment: `Report when function has bare return and non-void return type.`,
+			Before: `/**
+ * @param string $x
+ * @return string|null
+ */
+function f($x) {
+    if ($x === "0") {
+        return; // Better to write as "return null"
+    }
+    if ($x === "1") {
+        return; // Better to write as "return null"
+    }
+    return "q";
+}`,
+			After: `/**
+ * @param string $x
+ * @return string|null
+ */
+function f($x) {
+    if ($x === "0") {
+        return null; // Ok
+    }
+    if ($x === "1") {
+        return null; // Ok
+    }
+    return "q";
+}`,
+		},
+
+		{
+			Name:    "mismatchingReturn",
+			Default: true,
+			Comment: `Report when function has @return annotation with non-void value, but the function does not contain return statements.`,
+			Before: `/**
+ * @param int $x
+ * @return string|null
+ */
+function f($x) {
+  echo $x;
+}`,
+			After: `/**
+ * @param int $x
+ * @return string|null
+ */
+function f($x) {
+  echo $x;
+  return $x; // Ok
+}
+// or
+/**
+ * @param int $x
+ * @return void
+ */
+function f($x) {
+  echo $x; // Ok
+}`,
 		},
 	}
 

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -529,8 +529,8 @@ func (d *RootWalker) reportHash(pos *position.Position, startLine []byte, checkN
 	// want such methods to be considered as a single "scope".
 	scope := "file"
 	switch {
-	case d.ctx.st.CurrentClass != "" && d.ctx.st.CurrentFunction != "":
-		scope = d.ctx.st.CurrentClass + "::" + d.ctx.st.CurrentFunction
+	case d.ctx.st.CurrentClass != "" && d.ctx.st.CurrentMethod != "":
+		scope = d.ctx.st.CurrentClass + "::" + d.ctx.st.CurrentMethod
 	case d.ctx.st.CurrentFunction != "":
 		scope = d.ctx.st.CurrentFunction
 	}

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -530,9 +530,10 @@ func (d *RootWalker) reportHash(pos *position.Position, startLine []byte, checkN
 	scope := "file"
 	switch {
 	case d.ctx.st.CurrentClass != "" && d.ctx.st.CurrentMethod != "":
-		scope = d.ctx.st.CurrentClass + "::" + d.ctx.st.CurrentMethod
+		scope = d.ctx.st.CurrentClass + "::" + strings.TrimPrefix(d.ctx.st.CurrentMethod, "\\")
 	case d.ctx.st.CurrentFunction != "":
-		scope = d.ctx.st.CurrentFunction
+		parts := strings.Split(d.ctx.st.CurrentFunction, "\\")
+		scope = parts[len(parts)-1]
 	}
 
 	var prevLine []byte

--- a/src/linttest/basic_test.go
+++ b/src/linttest/basic_test.go
@@ -1785,6 +1785,29 @@ echo UNDEFINED_CONST;
 	test.RunAndMatch()
 }
 
+func TestBareReturnInNonVoidFunction(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+/**
+ * @return string|null
+ */
+function f($x) {
+    if ($x === "0") {
+        return; // Better to write as "return null"
+    }
+    if ($x === "1") {
+        return; // Better to write as "return null"
+    }
+    return "saf";
+}
+`)
+	test.Expect = []string{
+		`Replace 'return' with 'return null'`,
+		`Replace 'return' with 'return null'`,
+	}
+	test.RunAndMatch()
+}
+
 func addNamedFile(test *linttest.Suite, name, code string) {
 	test.Files = append(test.Files, linttest.TestFile{
 		Name: name,

--- a/src/linttest/testdata/baseline-test/baseline.json
+++ b/src/linttest/testdata/baseline-test/baseline.json
@@ -1,6 +1,6 @@
 {
 	"LinterVersion": "",
-	"CreatedAt": 1595281530,
+	"CreatedAt": 1595422854,
 	"Version": 3,
 	"Stats": {
 		"CountTotal": 3,
@@ -13,13 +13,13 @@
 		{
 			"File": "file1.php",
 			"Hashes": [
-				"2nv24v5g6ukxh,oh8k7otr41kw"
+				"efcp28m3d934,zvj1i6sv1mkt"
 			]
 		},
 		{
 			"File": "file2.php",
 			"Hashes": [
-				"2bbim48w63elq"
+				"1g5qsg7oziw8q"
 			]
 		}
 	]

--- a/src/linttest/testdata/baseline-test/baseline.json
+++ b/src/linttest/testdata/baseline-test/baseline.json
@@ -1,6 +1,6 @@
 {
 	"LinterVersion": "",
-	"CreatedAt": 1595422854,
+	"CreatedAt": 1595281530,
 	"Version": 3,
 	"Stats": {
 		"CountTotal": 3,
@@ -13,13 +13,13 @@
 		{
 			"File": "file1.php",
 			"Hashes": [
-				"efcp28m3d934,zvj1i6sv1mkt"
+				"2nv24v5g6ukxh,oh8k7otr41kw"
 			]
 		},
 		{
 			"File": "file2.php",
 			"Hashes": [
-				"1g5qsg7oziw8q"
+				"2bbim48w63elq"
 			]
 		}
 	]

--- a/src/linttest/testdata/baseline-test/baseline.json
+++ b/src/linttest/testdata/baseline-test/baseline.json
@@ -1,6 +1,6 @@
 {
 	"LinterVersion": "",
-	"CreatedAt": 1595281530,
+	"CreatedAt": 1595446792,
 	"Version": 3,
 	"Stats": {
 		"CountTotal": 3,
@@ -13,7 +13,7 @@
 		{
 			"File": "file1.php",
 			"Hashes": [
-				"2nv24v5g6ukxh,oh8k7otr41kw"
+				"2nv24v5g6ukxh,3dmy6ef8t9s62"
 			]
 		},
 		{

--- a/src/linttest/testdata/mustache/golden.txt
+++ b/src/linttest/testdata/mustache/golden.txt
@@ -52,6 +52,21 @@ MAYBE   phpdoc: Missing PHPDoc for "getHelperName" public method at testdata/mus
 MAYBE   phpdoc: Missing PHPDoc for "getTemplateName" public method at testdata/mustache/src/Mustache/Exception/UnknownTemplateException.php:34
     public function getTemplateName()
                     ^^^^^^^^^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:207
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:216
+                    return;
+                    ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:224
+                return;
+                ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:229
+                return;
+                ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:236
+                    return;
+                    ^^^^^^^
 INFO    unused: Variable v is unused (use $_ to ignore this inspection) at testdata/mustache/src/Mustache/Template.php:122
                 foreach ($value as $k => $v) {
                                          ^^

--- a/src/linttest/testdata/mustache/golden.txt
+++ b/src/linttest/testdata/mustache/golden.txt
@@ -52,19 +52,19 @@ MAYBE   phpdoc: Missing PHPDoc for "getHelperName" public method at testdata/mus
 MAYBE   phpdoc: Missing PHPDoc for "getTemplateName" public method at testdata/mustache/src/Mustache/Exception/UnknownTemplateException.php:34
     public function getTemplateName()
                     ^^^^^^^^^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:207
+WARNING bareReturn: Replace 'return' with 'return null'. The 'clearStandaloneLines' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/mustache/src/Mustache/Parser.php:207
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:216
+WARNING bareReturn: Replace 'return' with 'return null'. The 'clearStandaloneLines' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/mustache/src/Mustache/Parser.php:216
                     return;
                     ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:224
+WARNING bareReturn: Replace 'return' with 'return null'. The 'clearStandaloneLines' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/mustache/src/Mustache/Parser.php:224
                 return;
                 ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:229
+WARNING bareReturn: Replace 'return' with 'return null'. The 'clearStandaloneLines' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/mustache/src/Mustache/Parser.php:229
                 return;
                 ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/mustache/src/Mustache/Parser.php:236
+WARNING bareReturn: Replace 'return' with 'return null'. The 'clearStandaloneLines' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/mustache/src/Mustache/Parser.php:236
                     return;
                     ^^^^^^^
 INFO    unused: Variable v is unused (use $_ to ignore this inspection) at testdata/mustache/src/Mustache/Template.php:122

--- a/src/linttest/testdata/parsedown/golden.txt
+++ b/src/linttest/testdata/parsedown/golden.txt
@@ -1,28 +1,28 @@
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:353
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockCode' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:353
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:407
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockComment' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:407
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:432
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockCommentContinue' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:432
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:456
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockFencedCode' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:456
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:463
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockFencedCode' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:463
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:506
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockFencedCodeContinue' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:506
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:545
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockHeader' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:545
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:552
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockHeader' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:552
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:621
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockList' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:621
                         return;
                         ^^^^^^^
 MAYBE   ternarySimplify: could rewrite as `$matches[1] ?? ''` at testdata/parsedown/parsedown.php:674
@@ -31,22 +31,22 @@ MAYBE   ternarySimplify: could rewrite as `$matches[1] ?? ''` at testdata/parsed
 MAYBE   regexpSimplify: May re-write '/^>[ ]?+(.*+)/' as '/^> ?+(.*+)/' at testdata/parsedown/parsedown.php:750
         if (preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
                        ^^^^^^^^^^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:771
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockQuoteContinue' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:771
             return;
             ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^>[ ]?+(.*+)/' as '/^> ?+(.*+)/' at testdata/parsedown/parsedown.php:774
         if ($Line['text'][0] === '>' and preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
                                                     ^^^^^^^^^^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:815
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockSetextHeader' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:815
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:833
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockMarkup' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:833
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:842
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockMarkup' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:842
                 return;
                 ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:861
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockMarkupContinue' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:861
             return;
             ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/' as '/^\[(.+?)\]: *+<?(\S+?)>?(?: +["'(](.+)["')])? *+$/' at testdata/parsedown/parsedown.php:875
@@ -55,64 +55,64 @@ MAYBE   regexpSimplify: May re-write '/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.
 MAYBE   ternarySimplify: could rewrite as `$matches[3] ?? null` at testdata/parsedown/parsedown.php:881
                 'title' => isset($matches[3]) ? $matches[3] : null,
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:901
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockTable' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:901
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:910
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockTable' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:910
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:915
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockTable' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:915
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:933
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockTable' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:933
                 return;
                 ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:964
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockTable' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:964
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1024
+WARNING bareReturn: Replace 'return' with 'return null'. The 'blockTableContinue' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1024
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1097
+WARNING bareReturn: Replace 'return' with 'return null'. The 'paragraphContinue' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1097
             return;
             ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/[ ]*+\n/' as '/ *+\n/' at testdata/parsedown/parsedown.php:1265
             $text = preg_replace('/[ ]*+\n/', ' ', $text);
                                  ^^^^^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1311
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineEmphasis' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1311
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1326
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineEmphasis' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1326
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1357
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineImage' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1357
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1366
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineImage' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1366
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1418
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineLink' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1418
             return;
             ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/' as '/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?: +("[^"]*+"|'[^']*+'))?\s*+[)]/' at testdata/parsedown/parsedown.php:1421
         if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/', $remainder, $matches))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1448
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineLink' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1448
                 return;
                 ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1467
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineMarkup' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1467
             return;
             ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^<\/\w[\w-]*+[ ]*+>/s' as '/^<\/\w[\w-]*+ *+>/s' at testdata/parsedown/parsedown.php:1470
         if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*+[ ]*+>/s', $Excerpt['text'], $matches))
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1506
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineSpecialCharacter' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1506
         return;
         ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1513
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineStrikethrough' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1513
             return;
             ^^^^^^^
-WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1536
+WARNING bareReturn: Replace 'return' with 'return null'. The 'inlineUrl' function has @return annotation with non-'void' value, so 'return null' is preferred. at testdata/parsedown/parsedown.php:1536
             return;
             ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui' as '~\bhttps?+:/{2}[^\s<]+\b/*+~ui' at testdata/parsedown/parsedown.php:1540

--- a/src/linttest/testdata/parsedown/golden.txt
+++ b/src/linttest/testdata/parsedown/golden.txt
@@ -1,27 +1,120 @@
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:353
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:407
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:432
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:456
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:463
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:506
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:545
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:552
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:621
+                        return;
+                        ^^^^^^^
 MAYBE   ternarySimplify: could rewrite as `$matches[1] ?? ''` at testdata/parsedown/parsedown.php:674
             $text = isset($matches[1]) ? $matches[1] : '';
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^>[ ]?+(.*+)/' as '/^> ?+(.*+)/' at testdata/parsedown/parsedown.php:750
         if (preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
                        ^^^^^^^^^^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:771
+            return;
+            ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^>[ ]?+(.*+)/' as '/^> ?+(.*+)/' at testdata/parsedown/parsedown.php:774
         if ($Line['text'][0] === '>' and preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
                                                     ^^^^^^^^^^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:815
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:833
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:842
+                return;
+                ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:861
+            return;
+            ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/' as '/^\[(.+?)\]: *+<?(\S+?)>?(?: +["'(](.+)["')])? *+$/' at testdata/parsedown/parsedown.php:875
             and preg_match('/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/', $Line['text'], $matches)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   ternarySimplify: could rewrite as `$matches[3] ?? null` at testdata/parsedown/parsedown.php:881
                 'title' => isset($matches[3]) ? $matches[3] : null,
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:901
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:910
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:915
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:933
+                return;
+                ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:964
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1024
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1097
+            return;
+            ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/[ ]*+\n/' as '/ *+\n/' at testdata/parsedown/parsedown.php:1265
             $text = preg_replace('/[ ]*+\n/', ' ', $text);
                                  ^^^^^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1311
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1326
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1357
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1366
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1418
+            return;
+            ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/' as '/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?: +("[^"]*+"|'[^']*+'))?\s*+[)]/' at testdata/parsedown/parsedown.php:1421
         if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/', $remainder, $matches))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1448
+                return;
+                ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1467
+            return;
+            ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^<\/\w[\w-]*+[ ]*+>/s' as '/^<\/\w[\w-]*+ *+>/s' at testdata/parsedown/parsedown.php:1470
         if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*+[ ]*+>/s', $Excerpt['text'], $matches))
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1506
+        return;
+        ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1513
+            return;
+            ^^^^^^^
+WARNING bareReturn: Replace 'return' with 'return null' at testdata/parsedown/parsedown.php:1536
+            return;
+            ^^^^^^^
 MAYBE   regexpSimplify: May re-write '/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui' as '~\bhttps?+:/{2}[^\s<]+\b/*+~ui' at testdata/parsedown/parsedown.php:1540
             and preg_match('/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -517,8 +517,8 @@ type ClassParseState struct {
 	CurrentClass            string
 	CurrentParentClass      string
 	CurrentParentInterfaces []string // interfaces allow for multiple inheritance...
-	CurrentFunction         string   // current method or function name
-	CurrentMethod           string   // current method
+	CurrentFunction         string   // current function or method fully qualified name
+	CurrentMethod           string   // current method (only name)
 }
 
 type FunctionsOverrideMap map[string]FuncInfoOverride

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -518,6 +518,7 @@ type ClassParseState struct {
 	CurrentParentClass      string
 	CurrentParentInterfaces []string // interfaces allow for multiple inheritance...
 	CurrentFunction         string   // current method or function name
+	CurrentMethod           string   // current method
 }
 
 type FunctionsOverrideMap map[string]FuncInfoOverride

--- a/src/state/update.go
+++ b/src/state/update.go
@@ -13,9 +13,11 @@ import (
 func EnterNode(st *meta.ClassParseState, n walker.Walkable) {
 	switch n := n.(type) {
 	case *stmt.Function:
-		st.CurrentFunction = n.FunctionName.Value
+		st.CurrentFunction = st.Namespace + "\\" + n.FunctionName.Value
+
 	case *stmt.ClassMethod:
-		st.CurrentFunction = n.MethodName.Value
+		st.CurrentFunction = st.CurrentClass + "\\" + n.MethodName.Value
+		st.CurrentMethod = n.MethodName.Value
 
 	case *stmt.Namespace:
 		// TODO: handle another namespace syntax:
@@ -109,7 +111,11 @@ func handleUseFunction(st *meta.ClassParseState, n *stmt.Use) {
 // LeaveNode must be called upon leaving a node to update current state.
 func LeaveNode(st *meta.ClassParseState, n walker.Walkable) {
 	switch n.(type) {
-	case *stmt.ClassMethod, *stmt.Function:
+	case *stmt.ClassMethod:
+		st.CurrentFunction = ""
+		st.CurrentMethod = ""
+
+	case *stmt.Function:
 		st.CurrentFunction = ""
 
 	case *stmt.Class, *stmt.Interface, *stmt.Trait:


### PR DESCRIPTION
1. Added check for bare returns for functions with non-void return types. #563
2. Added check for the absence of return statement in function with `@return` annotation, which is not equal to void. #561

For this, the storage of `CurrentFunction` has been improved.
`CurrentFunction` now stores the fully qualified name of the function with its class and namespace. A separate `CurrentMethod` field was created to store the names of the methods. #597 

Fixes #561 
Fixes #563 
Fixes #597 