### PR TITLE
linter: move sideEffectFree function to solver package

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -2466,7 +2466,7 @@ func (b *BlockWalker) caseHasFallthroughComment(n node.Node) bool {
 }
 
 func (b *BlockWalker) sideEffectFree(n node.Node) bool {
-	return sideEffectFree(b.ctx.sc, b.r.ctx.st, b.ctx.customTypes, n)
+	return solver.SideEffectFree(b.ctx.sc, b.r.ctx.st, b.ctx.customTypes, n)
 }
 
 func (b *BlockWalker) isVoid(n node.Node) bool {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1024,7 +1024,7 @@ func (d *RootWalker) enterClassMethod(meth *stmt.ClassMethod) bool {
 	if modif.final {
 		funcFlags |= meta.FuncFinal
 	}
-	if !insideInterface && !modif.abstract && sideEffectFreeFunc(d.scope(), d.ctx.st, nil, stmts) {
+	if !insideInterface && !modif.abstract && solver.SideEffectFreeFunc(d.scope(), d.ctx.st, nil, stmts) {
 		funcFlags |= meta.FuncPure
 	}
 	class.Methods.Set(nm, meta.FuncInfo{
@@ -1469,7 +1469,7 @@ func (d *RootWalker) enterFunction(fun *stmt.Function) bool {
 	}
 
 	var funcFlags meta.FuncFlags
-	if sideEffectFreeFunc(d.scope(), d.ctx.st, nil, fun.Stmts) {
+	if solver.SideEffectFreeFunc(d.scope(), d.ctx.st, nil, fun.Stmts) {
 		funcFlags |= meta.FuncPure
 	}
 	d.meta.Functions.Set(nm, meta.FuncInfo{
@@ -1767,7 +1767,7 @@ func (d *RootWalker) checkFilterSet(m *phpgrep.MatchData, sc *meta.Scope, filter
 		if !d.checkTypeFilter(filter.Type, sc, nn) {
 			return false
 		}
-		if filter.Pure && !sideEffectFree(d.scope(), d.ctx.st, nil, nn) {
+		if filter.Pure && !solver.SideEffectFree(d.scope(), d.ctx.st, nil, nn) {
 			return false
 		}
 	}


### PR DESCRIPTION
This way it's easier to reuse this code.

sideEffectFree function was unexported in linter package.
Since linter package already contains too much symbols, it's probably better to move it to solver package (at least for now).