### PR TITLE
tests/golden: use GORACE to increase history_size

### DIFF
--- a/src/tests/golden/golden_test.go
+++ b/src/tests/golden/golden_test.go
@@ -268,7 +268,12 @@ func runGoldenTestsE2E(t *testing.T, targets []*goldenTest) {
 			}
 			args = append(args, target.srcDir)
 
-			out, err := exec.Command("./phplinter.exe", args...).CombinedOutput()
+			// Use GORACE=history_size to increase the stacktrace limit.
+			// See https://github.com/golang/go/issues/10661
+			phplinterCmd := exec.Command("./phplinter.exe", args...)
+			phplinterCmd.Env = append([]string{}, os.Environ()...)
+			phplinterCmd.Env = append(phplinterCmd.Env, "GORACE=history_size=7")
+			out, err := phplinterCmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("%v: %s", err, out)
 			}


### PR DESCRIPTION
From docs:

> The per-goroutine memory access history is 32K * 2**history_size elements.
  Increasing this value can avoid a "failed to restore the stack"
  error in reports, at the cost of increased memory usage.

We have "failed to restore the stack" in #614 so it's useful for us already
to reveal the full stack trace.

See https://github.com/golang/go/issues/10661

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>