### PR TITLE
linter: save shape type props types as immutable type maps

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1913,7 +1913,7 @@ func (d *RootWalker) afterLeaveFile() {
 			props := make(meta.PropertiesMap)
 			for _, p := range shape.props {
 				props[p.key] = meta.PropertyInfo{
-					Typ:         newTypesMap(&d.ctx, p.types),
+					Typ:         newTypesMap(&d.ctx, p.types).Immutable(),
 					AccessLevel: meta.Public,
 				}
 			}


### PR DESCRIPTION
This helps to avoid races in #614

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>