### PR TITLE
linttest: check for <?php tag in SimpleNegativeTest arg

### DIFF
--- a/src/linttest/linttest.go
+++ b/src/linttest/linttest.go
@@ -38,6 +38,9 @@ func init() {
 //
 // For positive testing, use Suite type directly.
 func SimpleNegativeTest(t *testing.T, contents string) {
+	if !strings.HasPrefix(contents, `<?php`) {
+		t.Fatalf("PHP script doesn't start with <?php")
+	}
 	s := NewSuite(t)
 	s.AddFile(contents)
 	s.RunAndMatch()


### PR DESCRIPTION
If <?php tag was forgotten, test will never result in any
warnings as it will be parsed as inline HTML.

This change adds a sanity check that helps to detect such mistakes
as early as possible.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>