### PR TITLE
linter: add dupGlobal checker

### DIFF
--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -207,7 +207,7 @@ func AnalyzeFileRootLevel(rootNode node.Node, d *RootWalker) {
 		ctx:                  &blockContext{sc: sc},
 		r:                    d,
 		unusedVars:           make(map[string][]node.Node),
-		nonLocalVars:         make(map[string]struct{}),
+		nonLocalVars:         make(map[string]variableKind),
 		ignoreFunctionBodies: true,
 		rootLevel:            true,
 		path:                 newNodePath(),

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -101,6 +101,14 @@ func init() {
 		},
 
 		{
+			Name:    "dupGlobal",
+			Default: true,
+			Comment: `Report repeated global statements over variables.`,
+			Before:  `global $x, $y, $x;`,
+			After:   `global $x, $y;`,
+		},
+
+		{
 			Name:    "dupArrayKeys",
 			Default: true,
 			Comment: `Report duplicated keys in array literals.`,

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -646,7 +646,7 @@ func (d *RootWalker) handleFuncStmts(params []meta.FuncParam, uses, stmts []node
 		ctx:          &blockContext{sc: sc},
 		r:            d,
 		unusedVars:   make(map[string][]node.Node),
-		nonLocalVars: make(map[string]struct{}),
+		nonLocalVars: make(map[string]variableKind),
 		path:         newNodePath(),
 	}
 	for _, createFn := range d.customBlock {
@@ -674,13 +674,13 @@ func (d *RootWalker) handleFuncStmts(params []meta.FuncParam, uses, stmts []node
 		if !byRef {
 			b.unusedVars[v.Name] = append(b.unusedVars[v.Name], v)
 		} else {
-			b.nonLocalVars[v.Name] = struct{}{}
+			b.nonLocalVars[v.Name] = varRef
 		}
 	}
 
 	for _, p := range params {
 		if p.IsRef {
-			b.nonLocalVars[p.Name] = struct{}{}
+			b.nonLocalVars[p.Name] = varRef
 		}
 	}
 	for _, s := range stmts {


### PR DESCRIPTION
Finds global statements over repeated variables.

Using the same name inside one statement emits a warning-level report.
Redundant global between statements produces maybe-level report.

We only track unconditional global statements for inter-statement analysis.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>