### PR TITLE
linter: add intOverflow check

### DIFF
--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -17,6 +17,14 @@ const (
 func init() {
 	allChecks := []CheckInfo{
 		{
+			Name:    "intOverflow",
+			Default: true,
+			Comment: `Report potential integer overflows that may result in unexpected behavior.`,
+			Before:  `return -9223372036854775808;`,
+			After:   `return PHP_INT_MIN;`,
+		},
+
+		{
 			Name:    "discardExpr",
 			Default: true,
 			Comment: `Report expressions that are evaluated but not used.`,

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -12,6 +12,35 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestIntOverflow(t *testing.T) {
+	// See https://bugs.php.net/bug.php?id=53934
+
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+// Overflow cases.
+echo -9223372036854775808;
+echo 9223372036854775808;
+echo 9223372036854775807000;
+
+// Valid cases.
+echo 9223372036854775807;
+echo -9223372036854775807;
+echo 123;
+echo -9223372036854775807 - 1;
+
+// Explicit float literals are OK.
+echo 9223372036854775807000.0;
+echo -9223372036854775807000.0;
+echo -9.2233720368548E+18;
+`)
+	test.Expect = []string{
+		`9223372036854775808 will be interpreted as float due to the overflow`,
+		`9223372036854775808 will be interpreted as float due to the overflow`,
+		`9223372036854775807000 will be interpreted as float due to the overflow`,
+	}
+	test.RunAndMatch()
+}
+
 func TestDupGlobalRoot(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 global $x;


### PR DESCRIPTION
Reports potential integer overflows that may result in unexpected behavior.

See https://bugs.php.net/bug.php?id=53934

Fixes #623

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>