### PR TITLE
linttest: removed unnecessary definitions of functions and constants in tests

### DIFF
--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -1838,9 +1838,6 @@ func TestArrayUnion(t *testing.T) {
 
 func TestCompactImpliesUsage(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
-function define($_, $_) {}
-define('null', 0);
-
 // Declaration from phpstorm-stubs
 function compact ($varname, $_ = null) {}
 
@@ -1861,9 +1858,6 @@ function g() {
 func TestCompactWithUndefined(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
-function define($_, $_) {}
-define('null', 0);
-
 // Declaration from phpstorm-stubs
 function compact ($varname, $_ = null) {}
 

--- a/src/tests/checkers/regression_test.go
+++ b/src/tests/checkers/regression_test.go
@@ -849,10 +849,6 @@ function error() {}
 
 func TestIssue182(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
-define('null', 0);
-
-function define($name, $v) {}
-
 trait SingletonSelf {
     /** @var self */
     private static $instance = null;

--- a/src/tests/checkers/rules_test.go
+++ b/src/tests/checkers/rules_test.go
@@ -151,12 +151,8 @@ $x === false;
 function stripos($haystack, $needle, $offset = 0) { return 0; }
 function explode($delimeter, $s, $limit = 0) { return []; }
 function in_array($needle, $haystack, $strict = false) { return true; }
-function define($name, $value) {}
 function array_key_exists($needle, $haystack) { return false; }
 function implode($glue, $pieces) { return ''; }
-
-define('true', 1 == 1);
-define('false', 1 == 0);
 
 function stringCond(string $s) {
   if ($s !== '') { // Good

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -1399,9 +1399,6 @@ function test() {
 
 func TestExprTypeFunction(t *testing.T) {
 	code := `<?php
-function define($name, $value) {}
-define('null', 0);
-
 class Foo {}
 
 function mixed_array($x) {


### PR DESCRIPTION
Due to the introduction of default stubs