### PR TITLE
linttest: use t.Helper() to skip irrelevant funcs

### DIFF
--- a/src/linttest/linttest.go
+++ b/src/linttest/linttest.go
@@ -129,6 +129,7 @@ func AddNamedFile(test *Suite, name, code string) {
 // This is a recommended way to use the Suite, but if
 // reports slice is needed, one can use RunLinter directly.
 func (s *Suite) RunAndMatch() {
+	s.t.Helper()
 	s.Match(s.RunLinter())
 }
 
@@ -139,6 +140,8 @@ func (s *Suite) RunAndMatch() {
 func (s *Suite) Match(reports []*linter.Report) {
 	expect := s.Expect
 	t := s.t
+
+	t.Helper()
 
 	if len(reports) != len(expect) {
 		t.Errorf("unexpected number of reports: expected %d, got %d",
@@ -186,6 +189,7 @@ func (s *Suite) Match(reports []*linter.Report) {
 // RunLinter executes linter over s Files and returns all issue reports
 // that were produced during that.
 func (s *Suite) RunLinter() []*linter.Report {
+	s.t.Helper()
 	meta.ResetInfo()
 
 	for _, stub := range s.LoadStubs {


### PR DESCRIPTION
With this, we can finally see the corrent filename in
failed test output.

Instead of this:

	--- FAIL: TestVoidResultUsedInAssignment (0.01s)
	    linttest.go:144: unexpected number of reports: expected 1, got 0
	    linttest.go:173: pattern 0 matched nothing: void function result used
	    linttest.go:178: >>> issues reported:
	    linttest.go:182: <<<

We get this:

	--- FAIL: TestVoidResultUsedInAssignment (0.01s)
	    basic_test.go:489: unexpected number of reports: expected 1, got 0
	    basic_test.go:489: pattern 0 matched nothing: void function result used
	    basic_test.go:489: >>> issues reported:
	    basic_test.go:489: <<<

basic_test.go is an actual file with the test and line=489 is a
line that executed the test itself.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>