### PR TITLE
ir: merge type cast expressions into TypeCastExpr

### DIFF
--- a/src/ir/freefloating.go
+++ b/src/ir/freefloating.go
@@ -88,17 +88,7 @@ func (n *SmallerOrEqualExpr) GetFreeFloating() *freefloating.Collection { return
 
 func (n *SpaceshipExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
 
-func (n *ArrayCastExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
-
-func (n *BoolCastExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
-
-func (n *DoubleCastExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
-
-func (n *IntCastExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
-
-func (n *ObjectCastExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
-
-func (n *StringCastExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
+func (n *TypeCastExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
 
 func (n *UnsetCastExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
 

--- a/src/ir/get_node_kind.go
+++ b/src/ir/get_node_kind.go
@@ -49,12 +49,7 @@ const (
 	KindSmallerExpr
 	KindSmallerOrEqualExpr
 	KindSpaceshipExpr
-	KindArrayCastExpr
-	KindBoolCastExpr
-	KindDoubleCastExpr
-	KindIntCastExpr
-	KindObjectCastExpr
-	KindStringCastExpr
+	KindTypeCastExpr
 	KindUnsetCastExpr
 	KindArrayExpr
 	KindArrayDimFetchExpr
@@ -259,18 +254,8 @@ func GetNodeKind(n Node) NodeKind {
 		return KindSmallerOrEqualExpr
 	case *SpaceshipExpr:
 		return KindSpaceshipExpr
-	case *ArrayCastExpr:
-		return KindArrayCastExpr
-	case *BoolCastExpr:
-		return KindBoolCastExpr
-	case *DoubleCastExpr:
-		return KindDoubleCastExpr
-	case *IntCastExpr:
-		return KindIntCastExpr
-	case *ObjectCastExpr:
-		return KindObjectCastExpr
-	case *StringCastExpr:
-		return KindStringCastExpr
+	case *TypeCastExpr:
+		return KindTypeCastExpr
 	case *UnsetCastExpr:
 		return KindUnsetCastExpr
 	case *ArrayExpr:

--- a/src/ir/get_position.go
+++ b/src/ir/get_position.go
@@ -92,17 +92,7 @@ func GetPosition(n Node) *position.Position {
 		return n.Position
 	case *SpaceshipExpr:
 		return n.Position
-	case *ArrayCastExpr:
-		return n.Position
-	case *BoolCastExpr:
-		return n.Position
-	case *DoubleCastExpr:
-		return n.Position
-	case *IntCastExpr:
-		return n.Position
-	case *ObjectCastExpr:
-		return n.Position
-	case *StringCastExpr:
+	case *TypeCastExpr:
 		return n.Position
 	case *UnsetCastExpr:
 		return n.Position

--- a/src/ir/irfmt/printer.go
+++ b/src/ir/irfmt/printer.go
@@ -1,6 +1,7 @@
 package irfmt
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
@@ -209,18 +210,8 @@ func (p *PrettyPrinter) printNode(n ir.Node) {
 
 		// cast
 
-	case *ir.ArrayCastExpr:
-		p.printArray(n)
-	case *ir.BoolCastExpr:
-		p.printBool(n)
-	case *ir.DoubleCastExpr:
-		p.printDouble(n)
-	case *ir.IntCastExpr:
-		p.printInt(n)
-	case *ir.ObjectCastExpr:
-		p.printObject(n)
-	case *ir.StringCastExpr:
-		p.printString(n)
+	case *ir.TypeCastExpr:
+		p.printTypeCastExpr(n)
 	case *ir.UnsetCastExpr:
 		p.printUnset(n)
 
@@ -816,33 +807,8 @@ func (p *PrettyPrinter) printBinarySpaceship(n *ir.SpaceshipExpr) {
 
 // cast
 
-func (p *PrettyPrinter) printArray(n *ir.ArrayCastExpr) {
-	io.WriteString(p.w, "(array)")
-	p.Print(n.Expr)
-}
-
-func (p *PrettyPrinter) printBool(n *ir.BoolCastExpr) {
-	io.WriteString(p.w, "(bool)")
-	p.Print(n.Expr)
-}
-
-func (p *PrettyPrinter) printDouble(n *ir.DoubleCastExpr) {
-	io.WriteString(p.w, "(float)")
-	p.Print(n.Expr)
-}
-
-func (p *PrettyPrinter) printInt(n *ir.IntCastExpr) {
-	io.WriteString(p.w, "(int)")
-	p.Print(n.Expr)
-}
-
-func (p *PrettyPrinter) printObject(n *ir.ObjectCastExpr) {
-	io.WriteString(p.w, "(object)")
-	p.Print(n.Expr)
-}
-
-func (p *PrettyPrinter) printString(n *ir.StringCastExpr) {
-	io.WriteString(p.w, "(string)")
+func (p *PrettyPrinter) printTypeCastExpr(n *ir.TypeCastExpr) {
+	fmt.Fprintf(p.w, "(%s)", n.Type)
 	p.Print(n.Expr)
 }
 

--- a/src/ir/irfmt/printer_test.go
+++ b/src/ir/irfmt/printer_test.go
@@ -1101,7 +1101,8 @@ func TestPrintArray(t *testing.T) {
 	o := bytes.NewBufferString("")
 
 	p := NewPrettyPrinter(o, "    ")
-	p.Print(&ir.ArrayCastExpr{
+	p.Print(&ir.TypeCastExpr{
+		Type: "array",
 		Expr: &ir.SimpleVar{Name: "var"},
 	})
 
@@ -1117,7 +1118,8 @@ func TestPrintBool(t *testing.T) {
 	o := bytes.NewBufferString("")
 
 	p := NewPrettyPrinter(o, "    ")
-	p.Print(&ir.BoolCastExpr{
+	p.Print(&ir.TypeCastExpr{
+		Type: "bool",
 		Expr: &ir.SimpleVar{Name: "var"},
 	})
 
@@ -1133,7 +1135,8 @@ func TestPrintDouble(t *testing.T) {
 	o := bytes.NewBufferString("")
 
 	p := NewPrettyPrinter(o, "    ")
-	p.Print(&ir.DoubleCastExpr{
+	p.Print(&ir.TypeCastExpr{
+		Type: "float",
 		Expr: &ir.SimpleVar{Name: "var"},
 	})
 
@@ -1149,7 +1152,8 @@ func TestPrintInt(t *testing.T) {
 	o := bytes.NewBufferString("")
 
 	p := NewPrettyPrinter(o, "    ")
-	p.Print(&ir.IntCastExpr{
+	p.Print(&ir.TypeCastExpr{
+		Type: "int",
 		Expr: &ir.SimpleVar{Name: "var"},
 	})
 
@@ -1165,7 +1169,8 @@ func TestPrintObject(t *testing.T) {
 	o := bytes.NewBufferString("")
 
 	p := NewPrettyPrinter(o, "    ")
-	p.Print(&ir.ObjectCastExpr{
+	p.Print(&ir.TypeCastExpr{
+		Type: "object",
 		Expr: &ir.SimpleVar{Name: "var"},
 	})
 
@@ -1181,7 +1186,8 @@ func TestPrintString(t *testing.T) {
 	o := bytes.NewBufferString("")
 
 	p := NewPrettyPrinter(o, "    ")
-	p.Print(&ir.StringCastExpr{
+	p.Print(&ir.TypeCastExpr{
+		Type: "string",
 		Expr: &ir.SimpleVar{Name: "var"},
 	})
 

--- a/src/ir/irutil/clone.go
+++ b/src/ir/irutil/clone.go
@@ -27,12 +27,6 @@ func NodeClone(x ir.Node) ir.Node {
 			clone.Arguments = sliceClone
 		}
 		return &clone
-	case *ir.ArrayCastExpr:
-		clone := *x
-		if x.Expr != nil {
-			clone.Expr = NodeClone(x.Expr).(ir.Node)
-		}
-		return &clone
 	case *ir.ArrayDimFetchExpr:
 		clone := *x
 		if x.Variable != nil {
@@ -243,12 +237,6 @@ func NodeClone(x ir.Node) ir.Node {
 		}
 		if x.Right != nil {
 			clone.Right = NodeClone(x.Right).(ir.Node)
-		}
-		return &clone
-	case *ir.BoolCastExpr:
-		clone := *x
-		if x.Expr != nil {
-			clone.Expr = NodeClone(x.Expr).(ir.Node)
 		}
 		return &clone
 	case *ir.BooleanAndExpr:
@@ -553,12 +541,6 @@ func NodeClone(x ir.Node) ir.Node {
 			clone.Cond = NodeClone(x.Cond).(ir.Node)
 		}
 		return &clone
-	case *ir.DoubleCastExpr:
-		clone := *x
-		if x.Expr != nil {
-			clone.Expr = NodeClone(x.Expr).(ir.Node)
-		}
-		return &clone
 	case *ir.EchoStmt:
 		clone := *x
 		{
@@ -848,12 +830,6 @@ func NodeClone(x ir.Node) ir.Node {
 			clone.Class = NodeClone(x.Class).(ir.Node)
 		}
 		return &clone
-	case *ir.IntCastExpr:
-		clone := *x
-		if x.Expr != nil {
-			clone.Expr = NodeClone(x.Expr).(ir.Node)
-		}
-		return &clone
 	case *ir.InterfaceExtendsStmt:
 		clone := *x
 		{
@@ -1035,12 +1011,6 @@ func NodeClone(x ir.Node) ir.Node {
 		}
 		return &clone
 	case *ir.Nullable:
-		clone := *x
-		if x.Expr != nil {
-			clone.Expr = NodeClone(x.Expr).(ir.Node)
-		}
-		return &clone
-	case *ir.ObjectCastExpr:
 		clone := *x
 		if x.Expr != nil {
 			clone.Expr = NodeClone(x.Expr).(ir.Node)
@@ -1305,12 +1275,6 @@ func NodeClone(x ir.Node) ir.Node {
 	case *ir.String:
 		clone := *x
 		return &clone
-	case *ir.StringCastExpr:
-		clone := *x
-		if x.Expr != nil {
-			clone.Expr = NodeClone(x.Expr).(ir.Node)
-		}
-		return &clone
 	case *ir.SwitchStmt:
 		clone := *x
 		if x.Cond != nil {
@@ -1426,6 +1390,12 @@ func NodeClone(x ir.Node) ir.Node {
 		}
 		if x.Finally != nil {
 			clone.Finally = NodeClone(x.Finally).(ir.Node)
+		}
+		return &clone
+	case *ir.TypeCastExpr:
+		clone := *x
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr).(ir.Node)
 		}
 		return &clone
 	case *ir.UnaryMinusExpr:

--- a/src/ir/irutil/equal.go
+++ b/src/ir/irutil/equal.go
@@ -40,15 +40,6 @@ func NodeEqual(x, y ir.Node) bool {
 			}
 		}
 		return true
-	case *ir.ArrayCastExpr:
-		y, ok := y.(*ir.ArrayCastExpr)
-		if !ok || x == nil || y == nil {
-			return x == y
-		}
-		if !NodeEqual(x.Expr, y.Expr) {
-			return false
-		}
-		return true
 	case *ir.ArrayDimFetchExpr:
 		y, ok := y.(*ir.ArrayDimFetchExpr)
 		if !ok || x == nil || y == nil {
@@ -344,15 +335,6 @@ func NodeEqual(x, y ir.Node) bool {
 			return false
 		}
 		if !NodeEqual(x.Right, y.Right) {
-			return false
-		}
-		return true
-	case *ir.BoolCastExpr:
-		y, ok := y.(*ir.BoolCastExpr)
-		if !ok || x == nil || y == nil {
-			return x == y
-		}
-		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -780,15 +762,6 @@ func NodeEqual(x, y ir.Node) bool {
 			return false
 		}
 		if !NodeEqual(x.Cond, y.Cond) {
-			return false
-		}
-		return true
-	case *ir.DoubleCastExpr:
-		y, ok := y.(*ir.DoubleCastExpr)
-		if !ok || x == nil || y == nil {
-			return x == y
-		}
-		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -1226,15 +1199,6 @@ func NodeEqual(x, y ir.Node) bool {
 			return false
 		}
 		return true
-	case *ir.IntCastExpr:
-		y, ok := y.(*ir.IntCastExpr)
-		if !ok || x == nil || y == nil {
-			return x == y
-		}
-		if !NodeEqual(x.Expr, y.Expr) {
-			return false
-		}
-		return true
 	case *ir.InterfaceExtendsStmt:
 		y, ok := y.(*ir.InterfaceExtendsStmt)
 		if !ok || x == nil || y == nil {
@@ -1501,15 +1465,6 @@ func NodeEqual(x, y ir.Node) bool {
 		return true
 	case *ir.Nullable:
 		y, ok := y.(*ir.Nullable)
-		if !ok || x == nil || y == nil {
-			return x == y
-		}
-		if !NodeEqual(x.Expr, y.Expr) {
-			return false
-		}
-		return true
-	case *ir.ObjectCastExpr:
-		y, ok := y.(*ir.ObjectCastExpr)
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
@@ -1891,15 +1846,6 @@ func NodeEqual(x, y ir.Node) bool {
 			return false
 		}
 		return true
-	case *ir.StringCastExpr:
-		y, ok := y.(*ir.StringCastExpr)
-		if !ok || x == nil || y == nil {
-			return x == y
-		}
-		if !NodeEqual(x.Expr, y.Expr) {
-			return false
-		}
-		return true
 	case *ir.SwitchStmt:
 		y, ok := y.(*ir.SwitchStmt)
 		if !ok || x == nil || y == nil {
@@ -2056,6 +2002,18 @@ func NodeEqual(x, y ir.Node) bool {
 			}
 		}
 		if !NodeEqual(x.Finally, y.Finally) {
+			return false
+		}
+		return true
+	case *ir.TypeCastExpr:
+		y, ok := y.(*ir.TypeCastExpr)
+		if !ok || x == nil || y == nil {
+			return x == y
+		}
+		if x.Type != y.Type {
+			return false
+		}
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true

--- a/src/ir/types.go
+++ b/src/ir/types.go
@@ -309,39 +309,10 @@ type SpaceshipExpr struct {
 	Right        Node
 }
 
-type ArrayCastExpr struct {
+type TypeCastExpr struct {
 	FreeFloating freefloating.Collection
 	Position     *position.Position
-	Expr         Node
-}
-
-type BoolCastExpr struct {
-	FreeFloating freefloating.Collection
-	Position     *position.Position
-	Expr         Node
-}
-
-type DoubleCastExpr struct {
-	FreeFloating freefloating.Collection
-	Position     *position.Position
-	Expr         Node
-}
-
-type IntCastExpr struct {
-	FreeFloating freefloating.Collection
-	Position     *position.Position
-	Expr         Node
-}
-
-type ObjectCastExpr struct {
-	FreeFloating freefloating.Collection
-	Position     *position.Position
-	Expr         Node
-}
-
-type StringCastExpr struct {
-	FreeFloating freefloating.Collection
-	Position     *position.Position
+	Type         string // "array" "bool" "int" "float" "object" "string"
 	Expr         Node
 }
 

--- a/src/ir/walk.go
+++ b/src/ir/walk.go
@@ -546,57 +546,7 @@ func (n *SpaceshipExpr) Walk(v Visitor) {
 	v.LeaveNode(n)
 }
 
-func (n *ArrayCastExpr) Walk(v Visitor) {
-	if !v.EnterNode(n) {
-		return
-	}
-	if n.Expr != nil {
-		n.Expr.Walk(v)
-	}
-	v.LeaveNode(n)
-}
-
-func (n *BoolCastExpr) Walk(v Visitor) {
-	if !v.EnterNode(n) {
-		return
-	}
-	if n.Expr != nil {
-		n.Expr.Walk(v)
-	}
-	v.LeaveNode(n)
-}
-
-func (n *DoubleCastExpr) Walk(v Visitor) {
-	if !v.EnterNode(n) {
-		return
-	}
-	if n.Expr != nil {
-		n.Expr.Walk(v)
-	}
-	v.LeaveNode(n)
-}
-
-func (n *IntCastExpr) Walk(v Visitor) {
-	if !v.EnterNode(n) {
-		return
-	}
-	if n.Expr != nil {
-		n.Expr.Walk(v)
-	}
-	v.LeaveNode(n)
-}
-
-func (n *ObjectCastExpr) Walk(v Visitor) {
-	if !v.EnterNode(n) {
-		return
-	}
-	if n.Expr != nil {
-		n.Expr.Walk(v)
-	}
-	v.LeaveNode(n)
-}
-
-func (n *StringCastExpr) Walk(v Visitor) {
+func (n *TypeCastExpr) Walk(v Visitor) {
 	if !v.EnterNode(n) {
 		return
 	}

--- a/src/irgen/irgen.go
+++ b/src/irgen/irgen.go
@@ -495,66 +495,20 @@ func ConvertNode(n node.Node) ir.Node {
 		return out
 
 	case *cast.Array:
-		if n == nil {
-			return (*ir.ArrayCastExpr)(nil)
-		}
-		out := &ir.ArrayCastExpr{}
-		out.FreeFloating = n.FreeFloating
-		out.Position = n.Position
-		out.Expr = ConvertNode(n.Expr)
-		return out
-
+		return convCastExpr(n, n.Expr, "array")
 	case *cast.Bool:
-		if n == nil {
-			return (*ir.BoolCastExpr)(nil)
-		}
-		out := &ir.BoolCastExpr{}
-		out.FreeFloating = n.FreeFloating
-		out.Position = n.Position
-		out.Expr = ConvertNode(n.Expr)
-		return out
-
-	case *cast.Double:
-		if n == nil {
-			return (*ir.DoubleCastExpr)(nil)
-		}
-		out := &ir.DoubleCastExpr{}
-		out.FreeFloating = n.FreeFloating
-		out.Position = n.Position
-		out.Expr = ConvertNode(n.Expr)
-		return out
-
+		return convCastExpr(n, n.Expr, "bool")
 	case *cast.Int:
-		if n == nil {
-			return (*ir.IntCastExpr)(nil)
-		}
-		out := &ir.IntCastExpr{}
-		out.FreeFloating = n.FreeFloating
-		out.Position = n.Position
-		out.Expr = ConvertNode(n.Expr)
-		return out
-
+		return convCastExpr(n, n.Expr, "int")
+	case *cast.Double:
+		return convCastExpr(n, n.Expr, "float")
 	case *cast.Object:
-		if n == nil {
-			return (*ir.ObjectCastExpr)(nil)
-		}
-		out := &ir.ObjectCastExpr{}
-		out.FreeFloating = n.FreeFloating
-		out.Position = n.Position
-		out.Expr = ConvertNode(n.Expr)
-		return out
-
+		return convCastExpr(n, n.Expr, "object")
 	case *cast.String:
-		if n == nil {
-			return (*ir.StringCastExpr)(nil)
-		}
-		out := &ir.StringCastExpr{}
-		out.FreeFloating = n.FreeFloating
-		out.Position = n.Position
-		out.Expr = ConvertNode(n.Expr)
-		return out
+		return convCastExpr(n, n.Expr, "string")
 
 	case *cast.Unset:
+		// We dont convert (unset)$x into CastExpr deliberately.
 		if n == nil {
 			return (*ir.UnsetCastExpr)(nil)
 		}
@@ -1848,4 +1802,13 @@ func ConvertNode(n node.Node) ir.Node {
 	}
 
 	panic(fmt.Sprintf("unhandled type %T", n))
+}
+
+func convCastExpr(n, e node.Node, typ string) *ir.TypeCastExpr {
+	return &ir.TypeCastExpr{
+		FreeFloating: *n.GetFreeFloating(),
+		Position:     n.GetPosition(),
+		Type:         typ,
+		Expr:         ConvertNode(e),
+	}
 }

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -114,16 +114,12 @@ func (b *blockLinter) enterNode(n ir.Node) {
 		b.checkBinaryVoidType(n.Left, n.Right)
 		b.checkBinaryDupArgsNoFloat(n, n.Left, n.Right)
 
-	case *ir.DoubleCastExpr:
-		b.checkRedundantCast(n.Expr, "float")
-	case *ir.IntCastExpr:
-		b.checkRedundantCast(n.Expr, "int")
-	case *ir.BoolCastExpr:
-		b.checkRedundantCast(n.Expr, "bool")
-	case *ir.StringCastExpr:
-		b.checkRedundantCast(n.Expr, "string")
-	case *ir.ArrayCastExpr:
-		b.checkRedundantCastArray(n.Expr)
+	case *ir.TypeCastExpr:
+		if n.Type == "array" {
+			b.checkRedundantCastArray(n.Expr)
+		} else {
+			b.checkRedundantCast(n.Expr, n.Type)
+		}
 
 	case *ir.CloneExpr:
 		b.walker.r.checkKeywordCase(n, "clone")

--- a/src/phpgrep/matcher.go
+++ b/src/phpgrep/matcher.go
@@ -646,24 +646,9 @@ func (m *matcher) eqNode(state *matcherState, x, y ir.Node) bool {
 			m.eqNode(state, x.Method, y.Method) &&
 			m.eqNodeSlice(state, x.ArgumentList.Arguments, y.ArgumentList.Arguments)
 
-	case *ir.DoubleCastExpr:
-		y, ok := y.(*ir.DoubleCastExpr)
-		return ok && m.eqNode(state, x.Expr, y.Expr)
-	case *ir.ArrayCastExpr:
-		y, ok := y.(*ir.ArrayCastExpr)
-		return ok && m.eqNode(state, x.Expr, y.Expr)
-	case *ir.BoolCastExpr:
-		y, ok := y.(*ir.BoolCastExpr)
-		return ok && m.eqNode(state, x.Expr, y.Expr)
-	case *ir.IntCastExpr:
-		y, ok := y.(*ir.IntCastExpr)
-		return ok && m.eqNode(state, x.Expr, y.Expr)
-	case *ir.ObjectCastExpr:
-		y, ok := y.(*ir.ObjectCastExpr)
-		return ok && m.eqNode(state, x.Expr, y.Expr)
-	case *ir.StringCastExpr:
-		y, ok := y.(*ir.StringCastExpr)
-		return ok && m.eqNode(state, x.Expr, y.Expr)
+	case *ir.TypeCastExpr:
+		y, ok := y.(*ir.TypeCastExpr)
+		return ok && x.Type == y.Type && m.eqNode(state, x.Expr, y.Expr)
 
 	case *ir.Root:
 		return false

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -327,16 +327,21 @@ func exprTypeLocalCustom(sc *meta.Scope, cs *meta.ClassParseState, n ir.Node, cu
 		return unaryMathOpType(sc, cs, n.Variable, custom)
 	case *ir.PreDecExpr:
 		return unaryMathOpType(sc, cs, n.Variable, custom)
-	case *ir.ArrayCastExpr:
-		return meta.NewTypesMap("mixed[]")
-	case *ir.BoolCastExpr:
-		return meta.PreciseBoolType
-	case *ir.DoubleCastExpr:
-		return meta.PreciseFloatType
-	case *ir.IntCastExpr, *ir.ShiftLeftExpr, *ir.ShiftRightExpr:
+	case *ir.TypeCastExpr:
+		switch n.Type {
+		case "array":
+			return meta.NewTypesMap("mixed[]")
+		case "int":
+			return meta.PreciseIntType
+		case "string":
+			return meta.PreciseStringType
+		case "float":
+			return meta.PreciseFloatType
+		case "bool":
+			return meta.PreciseBoolType
+		}
+	case *ir.ShiftLeftExpr, *ir.ShiftRightExpr:
 		return meta.PreciseIntType
-	case *ir.StringCastExpr:
-		return meta.PreciseStringType
 	case *ir.ClassConstFetchExpr:
 		className, ok := GetClassName(cs, n.Class)
 		if !ok {


### PR DESCRIPTION
It seems like this is a worthwhile simplification.

Only one place becomes more complex (solver exprtype) while
all other usages become better.

Unset cast is not merged into TypeCastExpr as it's very special
and should not be handled in combination with type casts.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>