### PR TITLE
irgen: rename to ir/irconv

### DIFF
--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -1,4 +1,4 @@
-package irgen
+package irconv
 
 import (
 	"fmt"

--- a/src/ir/irconv/utils.go
+++ b/src/ir/irconv/utils.go
@@ -1,4 +1,4 @@
-package irgen
+package irconv
 
 import (
 	"strings"

--- a/src/langsrv/langsrv.go
+++ b/src/langsrv/langsrv.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/VKCOM/noverify/src/ir"
-	"github.com/VKCOM/noverify/src/irgen"
+	"github.com/VKCOM/noverify/src/ir/irconv"
 	"github.com/VKCOM/noverify/src/lintdebug"
 	"github.com/VKCOM/noverify/src/linter"
 	"github.com/VKCOM/noverify/src/meta"
@@ -831,7 +831,7 @@ func getMethodCompletionItems(st *meta.ClassParseState, str string, sc *meta.Sco
 		lintdebug.Send("Could not parse %s", strTemp)
 		return nil
 	}
-	rootIR := irgen.ConvertRoot(tempNode)
+	rootIR := irconv.ConvertRoot(tempNode)
 
 	stmtLst := rootIR.Stmts
 	if len(stmtLst) == 0 {

--- a/src/langsrv/refs.go
+++ b/src/langsrv/refs.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/VKCOM/noverify/src/ir"
-	"github.com/VKCOM/noverify/src/irgen"
+	"github.com/VKCOM/noverify/src/ir/irconv"
 	"github.com/VKCOM/noverify/src/lintdebug"
 	"github.com/VKCOM/noverify/src/linter"
 	"github.com/VKCOM/noverify/src/meta"
@@ -223,7 +223,7 @@ func findReferences(substr string, parse parseFn) []vscode.Location {
 						parser.Parse()
 
 						rootNode := parser.GetRootNode()
-						rootIR := irgen.ConvertRoot(rootNode)
+						rootIR := irconv.ConvertRoot(rootNode)
 						if rootNode != nil {
 							var found []vscode.Location
 							func() {

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -22,7 +22,7 @@ import (
 	"github.com/VKCOM/noverify/src/git"
 	"github.com/VKCOM/noverify/src/inputs"
 	"github.com/VKCOM/noverify/src/ir"
-	"github.com/VKCOM/noverify/src/irgen"
+	"github.com/VKCOM/noverify/src/ir/irconv"
 	"github.com/VKCOM/noverify/src/lintdebug"
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/php/parser/php7"
@@ -147,7 +147,7 @@ func analyzeFile(filename string, contents []byte, parser *php7.Parser, lineRang
 		return nil, nil, errors.New("Empty root node")
 	}
 
-	rootIR := irgen.ConvertRoot(rootNode)
+	rootIR := irconv.ConvertRoot(rootNode)
 
 	st := &meta.ClassParseState{CurrentFile: filename}
 	w := &RootWalker{

--- a/src/phpgrep/compile.go
+++ b/src/phpgrep/compile.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/VKCOM/noverify/src/ir"
-	"github.com/VKCOM/noverify/src/irgen"
+	"github.com/VKCOM/noverify/src/ir/irconv"
 	"github.com/VKCOM/noverify/src/php/parseutil"
 )
 
@@ -18,7 +18,7 @@ func compile(opts *Compiler, pattern []byte) (*Matcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	rootIR := irgen.ConvertNode(root)
+	rootIR := irconv.ConvertNode(root)
 
 	if st, ok := rootIR.(*ir.ExpressionStmt); ok {
 		rootIR = st.Expr

--- a/src/phpgrep/matcher_test.go
+++ b/src/phpgrep/matcher_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/VKCOM/noverify/src/ir"
+	"github.com/VKCOM/noverify/src/ir/irconv"
 	"github.com/VKCOM/noverify/src/ir/irutil"
-	"github.com/VKCOM/noverify/src/irgen"
 	"github.com/VKCOM/noverify/src/php/parseutil"
 )
 
@@ -16,7 +16,7 @@ func mustParse(t testing.TB, code string) ir.Node {
 	if err != nil {
 		t.Fatalf("parse `%s`: %v", code, err)
 	}
-	irnode := irgen.ConvertNode(n)
+	irnode := irconv.ConvertNode(n)
 	if n, ok := irnode.(*ir.ExpressionStmt); ok {
 		return n.Expr
 	}

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/VKCOM/noverify/src/ir"
-	"github.com/VKCOM/noverify/src/irgen"
+	"github.com/VKCOM/noverify/src/ir/irconv"
 	"github.com/VKCOM/noverify/src/linter/lintapi"
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/php/parser/freefloating"
@@ -59,7 +59,7 @@ func (p *parser) parse(filename string, r io.Reader) (*Set, error) {
 	if err != nil {
 		return res, err
 	}
-	rootIR := irgen.ConvertRoot(root)
+	rootIR := irconv.ConvertRoot(root)
 
 	// Convert PHP file into the rule set.
 	p.filename = filename


### PR DESCRIPTION
We may have irgen package later that generates IR-related code.

The ir/irconv package does not generate anything, it converts
php-parser AST into our own IR.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>