### PR TITLE
ir/irfmt: print new expr without () if Args==nil

### DIFF
--- a/src/ir/irfmt/printer.go
+++ b/src/ir/irfmt/printer.go
@@ -948,7 +948,7 @@ func (p *PrettyPrinter) printExprNew(n *ir.NewExpr) {
 	io.WriteString(p.w, "new ")
 	p.Print(n.Class)
 
-	if len(n.Args) != 0 {
+	if n.Args != nil {
 		io.WriteString(p.w, "(")
 		p.joinPrint(", ", n.Args)
 		io.WriteString(p.w, ")")

--- a/src/ir/irfmt/printer_test.go
+++ b/src/ir/irfmt/printer_test.go
@@ -1600,6 +1600,37 @@ func TestPrintNew(t *testing.T) {
 	}
 }
 
+func TestPrintNewNoParens(t *testing.T) {
+	o := bytes.NewBufferString("")
+
+	p := NewPrettyPrinter(o, "    ")
+	p.Print(&ir.NewExpr{Class: &ir.Name{Value: "Foo"}})
+
+	expected := `new Foo`
+	actual := o.String()
+
+	if expected != actual {
+		t.Errorf("\nexpected: %s\ngot: %s\n", expected, actual)
+	}
+}
+
+func TestPrintNewWithParens(t *testing.T) {
+	o := bytes.NewBufferString("")
+
+	p := NewPrettyPrinter(o, "    ")
+	p.Print(&ir.NewExpr{
+		Class: &ir.Name{Value: "Foo"},
+		Args:  []ir.Node{},
+	})
+
+	expected := `new Foo()`
+	actual := o.String()
+
+	if expected != actual {
+		t.Errorf("\nexpected: %s\ngot: %s\n", expected, actual)
+	}
+}
+
 func TestPrintPostDec(t *testing.T) {
 	o := bytes.NewBufferString("")
 


### PR DESCRIPTION
This is consistent with what we had before the IR transition.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>