### PR TITLE
irutil: add Inspect function

### DIFF
--- a/src/ir/irutil/inspect.go
+++ b/src/ir/irutil/inspect.go
@@ -1,0 +1,20 @@
+package irutil
+
+import (
+	"github.com/VKCOM/noverify/src/ir"
+)
+
+func Inspect(root ir.Node, visit func(ir.Node) bool) {
+	w := inspectWalker{visit: visit}
+	root.Walk(w)
+}
+
+type inspectWalker struct {
+	visit func(n ir.Node) bool
+}
+
+func (w inspectWalker) EnterNode(n ir.Node) bool {
+	return w.visit(n)
+}
+
+func (w inspectWalker) LeaveNode(n ir.Node) {}


### PR DESCRIPTION
Works in the same way as go/ast.Inspect().

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>