### PR TITLE
ir/irconv: fixed unnecessary space before the word "class" in printer

### DIFF
--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -1169,7 +1169,7 @@ func convertNode(state *convState, n node.Node) ir.Node {
 		out.PhpDocComment = n.PhpDocComment
 		out.ClassName = convertNode(state, n.ClassName).(*ir.Identifier)
 		{
-			if len(n.Modifiers) != 0 {
+			if n.Modifiers != nil {
 				slice := make([]*ir.Identifier, len(n.Modifiers))
 				for i := range n.Modifiers {
 					slice[i] = convertNode(state, n.Modifiers[i]).(*ir.Identifier)

--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -1169,11 +1169,13 @@ func convertNode(state *convState, n node.Node) ir.Node {
 		out.PhpDocComment = n.PhpDocComment
 		out.ClassName = convertNode(state, n.ClassName).(*ir.Identifier)
 		{
-			slice := make([]*ir.Identifier, len(n.Modifiers))
-			for i := range n.Modifiers {
-				slice[i] = convertNode(state, n.Modifiers[i]).(*ir.Identifier)
+			if len(n.Modifiers) != 0 {
+				slice := make([]*ir.Identifier, len(n.Modifiers))
+				for i := range n.Modifiers {
+					slice[i] = convertNode(state, n.Modifiers[i]).(*ir.Identifier)
+				}
+				out.Modifiers = slice
 			}
-			out.Modifiers = slice
 		}
 		if n.ArgumentList != nil {
 			out.ArgsFreeFloating = n.ArgumentList.FreeFloating


### PR DESCRIPTION
Fixed bug where slice of class modifiers had zero length but not nil, which led to an unnecessary space before the word "class".