### PR TITLE
tests/golden: execute e2e tests in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 phplinter.sh
 phplinter.exe
-phplinter-output.json
+phplinter-output-*.json
 err.log
 src/cmd/stubs/phpstorm-stubs/
 y.output


### PR DESCRIPTION
This change makes e2e tests finish ~20% faster.

In order to make parallel execution possible, all tests
write to a different output file.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>