### PR TITLE
meta: add some type string predicates

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -657,11 +657,7 @@ func (b *BlockWalker) checkArrayDimFetch(s *ir.ArrayDimFetchExpr) {
 
 	typ.Iterate(func(t string) {
 		// FullyQualified class name will have "\" in the beginning
-		if len(t) > 0 && t[0] == '\\' && !strings.HasSuffix(t, "[]") {
-			if strings.HasPrefix(t, `\shape$`) {
-				return
-			}
-
+		if meta.IsClassType(t) {
 			maybeHaveClasses = true
 
 			if !haveArrayAccess && solver.Implements(t, `\ArrayAccess`) {
@@ -1657,7 +1653,7 @@ func (b *BlockWalker) handleAssign(a *ir.Assign) bool {
 		tp := solver.ExprType(b.ctx.sc, b.r.ctx.st, a.Expression)
 		var shapeType string
 		tp.Iterate(func(t string) {
-			if strings.HasPrefix(t, `\shape$`) {
+			if meta.IsShapeType(t) {
 				shapeType = t
 			}
 		})

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -492,3 +492,11 @@ func NameNodeEquals(n ir.Node, s string) bool {
 		return false
 	}
 }
+
+func IsClassType(s string) bool {
+	return strings.HasPrefix(s, `\`) && !IsShapeType(s) && !IsArrayType(s)
+}
+
+func IsShapeType(s string) bool { return strings.HasPrefix(s, `\shape$`) }
+
+func IsArrayType(s string) bool { return strings.HasSuffix(s, `[]`) }

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -91,7 +91,7 @@ func NewTypesMapFromTypes(types []Type) TypesMap {
 func NewTypesMap(str string) TypesMap {
 	m := make(map[string]struct{}, strings.Count(str, "|")+1)
 	for _, s := range strings.Split(str, "|") {
-		for strings.HasSuffix(s, "[]") {
+		if IsArrayType(s) {
 			s = WrapArrayOf(strings.TrimSuffix(s, "[]"))
 		}
 		m[s] = struct{}{}

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -98,7 +98,7 @@ func (r *resolver) resolveTypeNoLateStaticBinding(class, typ string) map[string]
 	case meta.WElemOfKey:
 		arrayType, key := meta.UnwrapElemOfKey(typ)
 		for tt := range r.resolveType(class, arrayType) {
-			if strings.HasPrefix(tt, `\shape$`) {
+			if meta.IsShapeType(tt) {
 				res = r.solveElemOfShape(class, tt, key, res)
 			} else {
 				res = r.solveElemOf(tt, res)
@@ -228,7 +228,7 @@ func (r *resolver) solveElemOfShape(class, shapeName, key string, res map[string
 
 func (r *resolver) solveElemOf(tt string, res map[string]struct{}) map[string]struct{} {
 	switch {
-	case strings.HasSuffix(tt, "[]"):
+	case meta.IsArrayType(tt):
 		res[strings.TrimSuffix(tt, "[]")] = struct{}{}
 	case tt == "mixed":
 		res["mixed"] = struct{}{}
@@ -274,7 +274,7 @@ func (r *resolver) resolveTypes(class string, m meta.TypesMap) map[string]struct
 		delete(res, "empty_array")
 		specialized := false
 		for tt := range res {
-			if strings.HasSuffix(tt, "[]") {
+			if meta.IsArrayType(tt) {
 				specialized = true
 				break
 			}


### PR DESCRIPTION
So we don't duplicate `strings.HasPrefix(t, "\\shape$")` everywhere.
This is not the best solution as we could use something more
typed that just a string, but it's OK for now.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>