### PR TITLE
linter: declare checkers that were missing from the docs

### DIFF
--- a/example/custom/main.go
+++ b/example/custom/main.go
@@ -16,7 +16,7 @@ func init() {
 	linter.RegisterBlockChecker(func(ctx *linter.BlockContext) linter.BlockChecker { return &block{ctx: ctx} })
 
 	linter.DeclareCheck(linter.CheckInfo{
-		Name:    "strictCmp",
+		Name:    "exampleStrictCmp",
 		Default: true,
 		Comment: "Report not-strict-enough comparisons.",
 	})
@@ -59,11 +59,11 @@ func (b *block) BeforeEnterNode(n ir.Node) {
 		b.handleFunctionCall(n)
 	case *ir.EqualExpr:
 		if isString(b.ctx, n.Left) || isString(b.ctx, n.Right) {
-			b.ctx.Report(n, linter.LevelWarning, "strictCmp", "Strings must be compared using '===' operator")
+			b.ctx.Report(n, linter.LevelWarning, "exampleStrictCmp", "Strings must be compared using '===' operator")
 		}
 	case *ir.NotEqualExpr:
 		if isString(b.ctx, n.Left) || isString(b.ctx, n.Right) {
-			b.ctx.Report(n, linter.LevelWarning, "strictCmp", "Strings must be compared using '!==' operator")
+			b.ctx.Report(n, linter.LevelWarning, "exampleStrictCmp", "Strings must be compared using '!==' operator")
 		}
 	}
 }
@@ -90,5 +90,5 @@ func (b *block) handleInArrayCall(e *ir.FunctionCallExpr) {
 		return
 	}
 
-	b.ctx.Report(e, linter.LevelWarning, "strictCmp", "3rd argument of in_array must be true when comparing strings")
+	b.ctx.Report(e, linter.LevelWarning, "exampleStrictCmp", "3rd argument of in_array must be true when comparing strings")
 }

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -71,6 +71,9 @@ func Run(cfg *MainConfig) (int, error) {
 	if err != nil {
 		return 1, fmt.Errorf("preload rules: %v", err)
 	}
+	for _, rset := range ruleSets {
+		linter.DeclareRules(rset)
+	}
 
 	var args cmdlineArguments
 	bindFlags(ruleSets, &args)

--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -9,6 +9,7 @@ import (
 	"github.com/VKCOM/noverify/src/linter/lintapi"
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/phpdoc"
+	"github.com/VKCOM/noverify/src/rules"
 	"github.com/VKCOM/noverify/src/vscode"
 )
 
@@ -290,6 +291,17 @@ func RegisterRootCheckerWithCacher(cacher MetaCacher, c RootCheckerCreateFunc) {
 		}
 	}
 	metaCachers = append(metaCachers, cacher)
+}
+
+func DeclareRules(rset *rules.Set) {
+	for _, ruleName := range rset.Names {
+		// TODO: better documentation. See #466.
+		DeclareCheck(CheckInfo{
+			Name:    ruleName,
+			Comment: fmt.Sprintf("%s is a dynamic rule", ruleName),
+			Default: true,
+		})
+	}
 }
 
 // DeclareCheck declares a check described by an info.

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -486,6 +486,38 @@ function performance_test() {}`,
   public function __set($name, $value) {} // Ok
 }`,
 		},
+
+		{
+			Name:    "nameCase",
+			Default: true,
+			Comment: `Report symbol case mismatches.`,
+			Before: `class Foo {}
+$foo = new foo();`,
+			After: `class Foo {}
+$foo = new Foo();`,
+		},
+
+		{
+			Name:    "strictCmp",
+			Default: true,
+			Comment: `Report non-strict comparison with false/true/null.`,
+			Before:  `$result == null`,
+			After:   `$result === null`,
+		},
+
+		{
+			Name:    "paramClobber",
+			Default: true,
+			Comment: `Report assignments that overwrite params prior to their usage.`,
+			Before: `function api_get_video($user_id) {
+  $user_id = 0;
+  return get_video($user_id);
+}`,
+			After: `function api_get_video($user_id) {
+  $user_id = $user_id ?: 0;
+  return get_video($user_id);
+}`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/tests/custom/path_test.go
+++ b/src/tests/custom/path_test.go
@@ -16,6 +16,12 @@ func init() {
 	})
 }
 
+func runPathTest(t *testing.T, suite *linttest.Suite) {
+	t.Helper()
+	suite.IgnoreUndeclaredChecks = true
+	linttest.RunFilterMatch(suite, "pathTest")
+}
+
 func TestPathTryCatch(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
@@ -29,7 +35,7 @@ try {
 		`$_try (cond=false) : *ir.Root/*ir.TryStmt/*ir.EchoStmt/*ir.SimpleVar`,
 		`$_catch (cond=true) : *ir.Root/*ir.TryStmt/*ir.CatchStmt/*ir.EchoStmt/*ir.SimpleVar`,
 	}
-	linttest.RunFilterMatch(test, "pathTest")
+	runPathTest(t, test)
 }
 
 func TestPathIfElse(t *testing.T) {
@@ -51,7 +57,7 @@ if ($cond1) {
 		`$_elseif2 (cond=true) : *ir.Root/*ir.IfStmt/*ir.StmtList/*ir.ExpressionStmt/*ir.SimpleVar`,
 		`$_else (cond=true) : *ir.Root/*ir.IfStmt/*ir.ElseStmt/*ir.StmtList/*ir.EchoStmt/*ir.SimpleVar`,
 	}
-	linttest.RunFilterMatch(test, "pathTest")
+	runPathTest(t, test)
 }
 
 func TestPathArgument(t *testing.T) {
@@ -64,7 +70,7 @@ f($_arg1, [$_arg2], $a + $_arg3);
 		`$_arg2 (cond=false) : *ir.Root/*ir.ExpressionStmt/*ir.FunctionCallExpr/*ir.Argument/*ir.ArrayExpr/*ir.SimpleVar`,
 		`$_arg3 (cond=false) : *ir.Root/*ir.ExpressionStmt/*ir.FunctionCallExpr/*ir.Argument/*ir.PlusExpr/*ir.SimpleVar`,
 	}
-	linttest.RunFilterMatch(test, "pathTest")
+	runPathTest(t, test)
 }
 
 func TestPathTernary(t *testing.T) {
@@ -77,7 +83,7 @@ echo $_ternary_cond ? $_ternary_true : $_ternary_false;
 		`$_ternary_true (cond=true) : *ir.Root/*ir.EchoStmt/*ir.TernaryExpr/*ir.SimpleVar`,
 		`$_ternary_false (cond=true) : *ir.Root/*ir.EchoStmt/*ir.TernaryExpr/*ir.SimpleVar`,
 	}
-	linttest.RunFilterMatch(test, "pathTest")
+	runPathTest(t, test)
 }
 
 func TestPathTopLevel(t *testing.T) {
@@ -105,7 +111,7 @@ do {
 		`$_at_least_once (cond=false) : *ir.Root/*ir.DoStmt/*ir.StmtList/*ir.ExpressionStmt/*ir.SimpleVar`,
 		`$_do_while_cond (cond=false) : *ir.Root/*ir.DoStmt/*ir.SimpleVar`,
 	}
-	linttest.RunFilterMatch(test, "pathTest")
+	runPathTest(t, test)
 }
 
 func TestPathFuncScope(t *testing.T) {
@@ -128,7 +134,7 @@ function f() {
 		`$_inside_loop (cond=true) : *ir.ForStmt/*ir.StmtList/*ir.ReturnStmt/*ir.SimpleVar`,
 		`$_outside_loops (cond=false) : *ir.ReturnStmt/*ir.SimpleVar`,
 	}
-	linttest.RunFilterMatch(test, "pathTest")
+	runPathTest(t, test)
 }
 
 func TestPathMethodScope(t *testing.T) {
@@ -153,7 +159,7 @@ class C {
 		`$_inside_loop (cond=true) : *ir.ForStmt/*ir.StmtList/*ir.ReturnStmt/*ir.SimpleVar`,
 		`$_outside_loops (cond=false) : *ir.ReturnStmt/*ir.SimpleVar`,
 	}
-	linttest.RunFilterMatch(test, "pathTest")
+	runPathTest(t, test)
 }
 
 type pathTester struct {

--- a/src/tests/golden/golden_test.go
+++ b/src/tests/golden/golden_test.go
@@ -21,6 +21,17 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	enableAllRules := func(_ rules.Rule) bool { return true }
+	p := rules.NewParser()
+	linter.Rules = rules.NewSet()
+	ruleSets, err := cmd.InitEmbeddedRules(p, enableAllRules)
+	if err != nil {
+		panic(fmt.Sprintf("init embedded rules: %v", err))
+	}
+	for _, rset := range ruleSets {
+		linter.DeclareRules(rset)
+	}
+
 	exitCode := m.Run()
 
 	_ = os.Remove("phplinter.exe")
@@ -57,13 +68,6 @@ func TestGolden(t *testing.T) {
 	defer func(rset *rules.Set) {
 		linter.Rules = rset
 	}(linter.Rules)
-
-	enableAllRules := func(_ rules.Rule) bool { return true }
-	p := rules.NewParser()
-	linter.Rules = rules.NewSet()
-	if _, err := cmd.InitEmbeddedRules(p, enableAllRules); err != nil {
-		t.Fatalf("init embedded rules: %v", err)
-	}
 
 	targets := []*goldenTest{
 		{

--- a/src/tests/rules/rules_test.go
+++ b/src/tests/rules/rules_test.go
@@ -411,6 +411,8 @@ function bad(string $x) {
 }
 
 func runRulesTest(t *testing.T, test *linttest.Suite, rfile string) {
+	test.IgnoreUndeclaredChecks = true
+
 	rparser := rules.NewParser()
 	rset, err := rparser.Parse("<test>", strings.NewReader(rfile))
 	if err != nil {


### PR DESCRIPTION
To avoid adding a checker without a declaration in future,
a special check is added to the linttest framework.

If we get a report from unknown (undeclared) checker,
it will fail the test.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>