### PR TITLE
linter: assume int|string array key types in foreach stmt

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -52,6 +52,11 @@ const (
 	varStatic
 )
 
+// arrayKeyType is an universal PHP array key type.
+// In PHP, all array keys are converted to either int or string,
+// so we can always assume that `int|string` is good enough.
+var arrayKeyType = meta.NewTypesMap("int|string").Immutable()
+
 // BlockWalker is used to process function/method contents.
 type BlockWalker struct {
 	ctx *blockContext
@@ -1098,7 +1103,7 @@ func (b *BlockWalker) handleForeach(s *ir.ForeachStmt) bool {
 				b.handleVariableNode(s.Variable, meta.NewTypesMap(meta.WrapElemOf(typ)), "foreach_value")
 			})
 
-			b.handleVariableNode(s.Key, meta.TypesMap{}, "foreach_key")
+			b.handleVariableNode(s.Key, arrayKeyType, "foreach_key")
 			if list, ok := s.Variable.(*ir.ListExpr); ok {
 				for _, item := range list.Items {
 					b.handleVariableNode(item.Val, meta.TypesMap{}, "foreach_value")

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -46,6 +46,28 @@ func init() {
 	})
 }
 
+func TestExprTypeForeachKey(t *testing.T) {
+	code := `<?php
+$xs = [[1], [2]];
+
+foreach ($xs as $k => $ys) {
+  exprtype($k, 'int|string');
+
+  foreach ($xs as $k2 => $_) {
+    exprtype($k2, 'int|string');
+    $k2 = 10;
+    exprtype($k2, 'precise int');
+  }
+
+  exprtype($k, 'int|string');
+
+  $v = $xs ? $k : [1];
+  exprtype($v, 'int|int[]|string');
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func TestExprTypeRecursiveType1(t *testing.T) {
 	code := `<?php
 class Feed {


### PR DESCRIPTION
To avoid types map allocation in every foreach statement,
we'll use a global immutable `int|string` types map for this.

This particular types information is useful for warning
messages, so the user gets {int|string}->method instead of
{mixed}->method and it will be easier to see that the
linter does infer the types and it's not a false positive.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>