### PR TITLE
linter: move bytes pool to worker.go

### DIFF
--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -1,7 +1,6 @@
 package linter
 
 import (
-	"bytes"
 	"log"
 	"regexp"
 	"strings"
@@ -67,10 +66,6 @@ func AnalyzeFileRootLevel(rootNode ir.Node, d *RootWalker) {
 	}
 
 	rootNode.Walk(b)
-}
-
-var bytesBufPool = sync.Pool{
-	New: func() interface{} { return &bytes.Buffer{} },
 }
 
 // DebugMessage is used to actually print debug messages.

--- a/src/linter/worker.go
+++ b/src/linter/worker.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	dbg "runtime/debug"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -61,6 +62,10 @@ func newWorker(id int) *Worker {
 }
 
 func (w *Worker) ID() int { return w.id }
+
+var bytesBufPool = sync.Pool{
+	New: func() interface{} { return &bytes.Buffer{} },
+}
 
 // ParseContents parses specified contents (or file) and returns *RootWalker.
 // Function does not update global meta.


### PR DESCRIPTION
That pool is used inside worker, so it belongs to the
worker.go file, not parser.go file.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>