### PR TITLE
baseline: use externally provided scratch buffer

### DIFF
--- a/src/baseline/baseline.go
+++ b/src/baseline/baseline.go
@@ -194,11 +194,10 @@ type HashFields struct {
 }
 
 // ReportHash computes the report signature hash for the baseline.
-func ReportHash(fields HashFields) uint64 {
+func ReportHash(scratchBuf *bytes.Buffer, fields HashFields) uint64 {
 	const partSeparator = byte('#')
 
-	var buf bytes.Buffer
-	buf.Grow(256)
+	buf := scratchBuf
 	buf.WriteString(fields.Filename)
 	buf.WriteByte(partSeparator)
 	buf.WriteString(fields.Scope)

--- a/src/baseline/baseline_test.go
+++ b/src/baseline/baseline_test.go
@@ -31,12 +31,12 @@ func TestWriteReadBaseline(t *testing.T) {
 				Scope:     fields.Scope,
 			}
 			fieldsList[i].Filename = filename
-			counters[ReportHash(fieldsList[i])]++
+			counters[ReportHash(&bytes.Buffer{}, fieldsList[i])]++
 		}
 
 		reports := make(map[uint64]Report, len(fieldsList))
 		for _, fields := range fieldsList {
-			hash := ReportHash(fields)
+			hash := ReportHash(&bytes.Buffer{}, fields)
 			reports[hash] = Report{
 				Hash:  hash,
 				Count: counters[hash],

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -441,7 +441,6 @@ func (d *RootWalker) report(n ir.Node, lineNumber int, level int, checkName, msg
 		var hash uint64
 		if BaselineProfile != nil {
 			// If baseline is not enabled, don't waste time on hash computations.
-			// See #727.
 			hash = d.reportHash(&pos, startLn, checkName, msg)
 			if count := d.ctx.baseline.Count(hash); count >= 1 {
 				if d.ctx.hashCounters == nil {
@@ -530,7 +529,8 @@ func (d *RootWalker) reportHash(pos *position.Position, startLine []byte, checkN
 	// We'll see how it goes.
 	filename := filepath.Base(d.ctx.st.CurrentFile)
 
-	return baseline.ReportHash(baseline.HashFields{
+	d.ctx.scratchBuf.Reset()
+	return baseline.ReportHash(&d.ctx.scratchBuf, baseline.HashFields{
 		Filename:  filename,
 		PrevLine:  bytes.TrimSuffix(prevLine, []byte("\r")),
 		StartLine: bytes.TrimSuffix(startLine, []byte("\r")),

--- a/src/linter/worker_context.go
+++ b/src/linter/worker_context.go
@@ -1,6 +1,8 @@
 package linter
 
 import (
+	"bytes"
+
 	"github.com/VKCOM/noverify/src/phpdoc"
 )
 
@@ -13,10 +15,13 @@ import (
 // from different threads, so we can re-use it without synchronization.
 type WorkerContext struct {
 	phpdocTypeParser *phpdoc.TypeParser
+
+	scratchBuf bytes.Buffer
 }
 
 func NewWorkerContext() *WorkerContext {
 	return &WorkerContext{
 		phpdocTypeParser: phpdoc.NewTypeParser(),
+		scratchBuf:       bytes.Buffer{},
 	}
 }


### PR DESCRIPTION
With this trick, we get rid of all hash computation
related allocations. workerContext.scratchBuf can
be used anywhere where we need a buffer for tmp results.

Fixes #727

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>