### PR TITLE
ir/irutil: fix codegen for node slices

### DIFF
--- a/src/ir/irutil/clone.go
+++ b/src/ir/irutil/clone.go
@@ -47,13 +47,7 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.ArrowFunctionExpr:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Params))
-			for i := range x.Params {
-				sliceClone[i] = NodeClone(x.Params[i]).(ir.Node)
-			}
-			clone.Params = sliceClone
-		}
+		clone.Params = NodeSliceClone(x.Params)
 		if x.ReturnType != nil {
 			clone.ReturnType = NodeClone(x.ReturnType).(ir.Node)
 		}
@@ -261,46 +255,22 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.CaseListStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Cases))
-			for i := range x.Cases {
-				sliceClone[i] = NodeClone(x.Cases[i]).(ir.Node)
-			}
-			clone.Cases = sliceClone
-		}
+		clone.Cases = NodeSliceClone(x.Cases)
 		return &clone
 	case *ir.CaseStmt:
 		clone := *x
 		if x.Cond != nil {
 			clone.Cond = NodeClone(x.Cond).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.CatchStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Types))
-			for i := range x.Types {
-				sliceClone[i] = NodeClone(x.Types[i]).(ir.Node)
-			}
-			clone.Types = sliceClone
-		}
+		clone.Types = NodeSliceClone(x.Types)
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable).(*ir.SimpleVar)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.ClassConstFetchExpr:
 		clone := *x
@@ -320,13 +290,7 @@ func NodeClone(x ir.Node) ir.Node {
 			}
 			clone.Modifiers = sliceClone
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Consts))
-			for i := range x.Consts {
-				sliceClone[i] = NodeClone(x.Consts[i]).(ir.Node)
-			}
-			clone.Consts = sliceClone
-		}
+		clone.Consts = NodeSliceClone(x.Consts)
 		return &clone
 	case *ir.ClassExtendsStmt:
 		clone := *x
@@ -336,13 +300,7 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.ClassImplementsStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.InterfaceNames))
-			for i := range x.InterfaceNames {
-				sliceClone[i] = NodeClone(x.InterfaceNames[i]).(ir.Node)
-			}
-			clone.InterfaceNames = sliceClone
-		}
+		clone.InterfaceNames = NodeSliceClone(x.InterfaceNames)
 		return &clone
 	case *ir.ClassMethodStmt:
 		clone := *x
@@ -356,13 +314,7 @@ func NodeClone(x ir.Node) ir.Node {
 			}
 			clone.Modifiers = sliceClone
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Params))
-			for i := range x.Params {
-				sliceClone[i] = NodeClone(x.Params[i]).(ir.Node)
-			}
-			clone.Params = sliceClone
-		}
+		clone.Params = NodeSliceClone(x.Params)
 		if x.ReturnType != nil {
 			clone.ReturnType = NodeClone(x.ReturnType).(ir.Node)
 		}
@@ -382,26 +334,14 @@ func NodeClone(x ir.Node) ir.Node {
 			}
 			clone.Modifiers = sliceClone
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Args))
-			for i := range x.Args {
-				sliceClone[i] = NodeClone(x.Args[i]).(ir.Node)
-			}
-			clone.Args = sliceClone
-		}
 		if x.Extends != nil {
 			clone.Extends = NodeClone(x.Extends).(*ir.ClassExtendsStmt)
 		}
 		if x.Implements != nil {
 			clone.Implements = NodeClone(x.Implements).(*ir.ClassImplementsStmt)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
+		clone.Args = NodeSliceClone(x.Args)
 		return &clone
 	case *ir.CloneExpr:
 		clone := *x
@@ -411,36 +351,18 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.ClosureExpr:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Params))
-			for i := range x.Params {
-				sliceClone[i] = NodeClone(x.Params[i]).(ir.Node)
-			}
-			clone.Params = sliceClone
-		}
+		clone.Params = NodeSliceClone(x.Params)
 		if x.ClosureUse != nil {
 			clone.ClosureUse = NodeClone(x.ClosureUse).(*ir.ClosureUseExpr)
 		}
 		if x.ReturnType != nil {
 			clone.ReturnType = NodeClone(x.ReturnType).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.ClosureUseExpr:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Uses))
-			for i := range x.Uses {
-				sliceClone[i] = NodeClone(x.Uses[i]).(ir.Node)
-			}
-			clone.Uses = sliceClone
-		}
+		clone.Uses = NodeSliceClone(x.Uses)
 		return &clone
 	case *ir.CoalesceExpr:
 		clone := *x
@@ -468,13 +390,7 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.ConstListStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Consts))
-			for i := range x.Consts {
-				sliceClone[i] = NodeClone(x.Consts[i]).(ir.Node)
-			}
-			clone.Consts = sliceClone
-		}
+		clone.Consts = NodeSliceClone(x.Consts)
 		return &clone
 	case *ir.ConstantStmt:
 		clone := *x
@@ -493,26 +409,14 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.DeclareStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Consts))
-			for i := range x.Consts {
-				sliceClone[i] = NodeClone(x.Consts[i]).(ir.Node)
-			}
-			clone.Consts = sliceClone
-		}
+		clone.Consts = NodeSliceClone(x.Consts)
 		if x.Stmt != nil {
 			clone.Stmt = NodeClone(x.Stmt).(ir.Node)
 		}
 		return &clone
 	case *ir.DefaultStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.DivExpr:
 		clone := *x
@@ -537,13 +441,7 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.EchoStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Exprs))
-			for i := range x.Exprs {
-				sliceClone[i] = NodeClone(x.Exprs[i]).(ir.Node)
-			}
-			clone.Exprs = sliceClone
-		}
+		clone.Exprs = NodeSliceClone(x.Exprs)
 		return &clone
 	case *ir.ElseIfStmt:
 		clone := *x
@@ -568,13 +466,7 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.Encapsed:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Parts))
-			for i := range x.Parts {
-				sliceClone[i] = NodeClone(x.Parts[i]).(ir.Node)
-			}
-			clone.Parts = sliceClone
-		}
+		clone.Parts = NodeSliceClone(x.Parts)
 		return &clone
 	case *ir.EncapsedStringPart:
 		clone := *x
@@ -614,37 +506,13 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.FinallyStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.ForStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Init))
-			for i := range x.Init {
-				sliceClone[i] = NodeClone(x.Init[i]).(ir.Node)
-			}
-			clone.Init = sliceClone
-		}
-		{
-			sliceClone := make([]ir.Node, len(x.Cond))
-			for i := range x.Cond {
-				sliceClone[i] = NodeClone(x.Cond[i]).(ir.Node)
-			}
-			clone.Cond = sliceClone
-		}
-		{
-			sliceClone := make([]ir.Node, len(x.Loop))
-			for i := range x.Loop {
-				sliceClone[i] = NodeClone(x.Loop[i]).(ir.Node)
-			}
-			clone.Loop = sliceClone
-		}
+		clone.Init = NodeSliceClone(x.Init)
+		clone.Cond = NodeSliceClone(x.Cond)
+		clone.Loop = NodeSliceClone(x.Loop)
 		if x.Stmt != nil {
 			clone.Stmt = NodeClone(x.Stmt).(ir.Node)
 		}
@@ -669,46 +537,22 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Function != nil {
 			clone.Function = NodeClone(x.Function).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Args))
-			for i := range x.Args {
-				sliceClone[i] = NodeClone(x.Args[i]).(ir.Node)
-			}
-			clone.Args = sliceClone
-		}
+		clone.Args = NodeSliceClone(x.Args)
 		return &clone
 	case *ir.FunctionStmt:
 		clone := *x
 		if x.FunctionName != nil {
 			clone.FunctionName = NodeClone(x.FunctionName).(*ir.Identifier)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Params))
-			for i := range x.Params {
-				sliceClone[i] = NodeClone(x.Params[i]).(ir.Node)
-			}
-			clone.Params = sliceClone
-		}
+		clone.Params = NodeSliceClone(x.Params)
 		if x.ReturnType != nil {
 			clone.ReturnType = NodeClone(x.ReturnType).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.GlobalStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Vars))
-			for i := range x.Vars {
-				sliceClone[i] = NodeClone(x.Vars[i]).(ir.Node)
-			}
-			clone.Vars = sliceClone
-		}
+		clone.Vars = NodeSliceClone(x.Vars)
 		return &clone
 	case *ir.GotoStmt:
 		clone := *x
@@ -742,26 +586,14 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Prefix != nil {
 			clone.Prefix = NodeClone(x.Prefix).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.UseList))
-			for i := range x.UseList {
-				sliceClone[i] = NodeClone(x.UseList[i]).(ir.Node)
-			}
-			clone.UseList = sliceClone
-		}
+		clone.UseList = NodeSliceClone(x.UseList)
 		return &clone
 	case *ir.HaltCompilerStmt:
 		clone := *x
 		return &clone
 	case *ir.Heredoc:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Parts))
-			for i := range x.Parts {
-				sliceClone[i] = NodeClone(x.Parts[i]).(ir.Node)
-			}
-			clone.Parts = sliceClone
-		}
+		clone.Parts = NodeSliceClone(x.Parts)
 		return &clone
 	case *ir.IdenticalExpr:
 		clone := *x
@@ -783,13 +615,7 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Stmt != nil {
 			clone.Stmt = NodeClone(x.Stmt).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.ElseIf))
-			for i := range x.ElseIf {
-				sliceClone[i] = NodeClone(x.ElseIf[i]).(ir.Node)
-			}
-			clone.ElseIf = sliceClone
-		}
+		clone.ElseIf = NodeSliceClone(x.ElseIf)
 		if x.Else != nil {
 			clone.Else = NodeClone(x.Else).(ir.Node)
 		}
@@ -814,13 +640,7 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.InterfaceExtendsStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.InterfaceNames))
-			for i := range x.InterfaceNames {
-				sliceClone[i] = NodeClone(x.InterfaceNames[i]).(ir.Node)
-			}
-			clone.InterfaceNames = sliceClone
-		}
+		clone.InterfaceNames = NodeSliceClone(x.InterfaceNames)
 		return &clone
 	case *ir.InterfaceStmt:
 		clone := *x
@@ -830,23 +650,11 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Extends != nil {
 			clone.Extends = NodeClone(x.Extends).(*ir.InterfaceExtendsStmt)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.IssetExpr:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Variables))
-			for i := range x.Variables {
-				sliceClone[i] = NodeClone(x.Variables[i]).(ir.Node)
-			}
-			clone.Variables = sliceClone
-		}
+		clone.Variables = NodeSliceClone(x.Variables)
 		return &clone
 	case *ir.LabelStmt:
 		clone := *x
@@ -905,13 +713,7 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Method != nil {
 			clone.Method = NodeClone(x.Method).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Args))
-			for i := range x.Args {
-				sliceClone[i] = NodeClone(x.Args[i]).(ir.Node)
-			}
-			clone.Args = sliceClone
-		}
+		clone.Args = NodeSliceClone(x.Args)
 		return &clone
 	case *ir.MinusExpr:
 		clone := *x
@@ -948,26 +750,14 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.NamespaceName != nil {
 			clone.NamespaceName = NodeClone(x.NamespaceName).(*ir.Name)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.NewExpr:
 		clone := *x
 		if x.Class != nil {
 			clone.Class = NodeClone(x.Class).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Args))
-			for i := range x.Args {
-				sliceClone[i] = NodeClone(x.Args[i]).(ir.Node)
-			}
-			clone.Args = sliceClone
-		}
+		clone.Args = NodeSliceClone(x.Args)
 		return &clone
 	case *ir.NopStmt:
 		clone := *x
@@ -1083,13 +873,7 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Type != nil {
 			clone.Type = NodeClone(x.Type).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Properties))
-			for i := range x.Properties {
-				sliceClone[i] = NodeClone(x.Properties[i]).(ir.Node)
-			}
-			clone.Properties = sliceClone
-		}
+		clone.Properties = NodeSliceClone(x.Properties)
 		return &clone
 	case *ir.PropertyStmt:
 		clone := *x
@@ -1114,23 +898,11 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.Root:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.ShellExecExpr:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Parts))
-			for i := range x.Parts {
-				sliceClone[i] = NodeClone(x.Parts[i]).(ir.Node)
-			}
-			clone.Parts = sliceClone
-		}
+		clone.Parts = NodeSliceClone(x.Parts)
 		return &clone
 	case *ir.ShiftLeftExpr:
 		clone := *x
@@ -1188,13 +960,7 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Call != nil {
 			clone.Call = NodeClone(x.Call).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Args))
-			for i := range x.Args {
-				sliceClone[i] = NodeClone(x.Args[i]).(ir.Node)
-			}
-			clone.Args = sliceClone
-		}
+		clone.Args = NodeSliceClone(x.Args)
 		return &clone
 	case *ir.StaticPropertyFetchExpr:
 		clone := *x
@@ -1207,13 +973,7 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.StaticStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Vars))
-			for i := range x.Vars {
-				sliceClone[i] = NodeClone(x.Vars[i]).(ir.Node)
-			}
-			clone.Vars = sliceClone
-		}
+		clone.Vars = NodeSliceClone(x.Vars)
 		return &clone
 	case *ir.StaticVarStmt:
 		clone := *x
@@ -1226,13 +986,7 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.StmtList:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.String:
 		clone := *x
@@ -1266,13 +1020,7 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.TraitAdaptationListStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Adaptations))
-			for i := range x.Adaptations {
-				sliceClone[i] = NodeClone(x.Adaptations[i]).(ir.Node)
-			}
-			clone.Adaptations = sliceClone
-		}
+		clone.Adaptations = NodeSliceClone(x.Adaptations)
 		return &clone
 	case *ir.TraitMethodRefStmt:
 		clone := *x
@@ -1288,13 +1036,7 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.TraitName != nil {
 			clone.TraitName = NodeClone(x.TraitName).(*ir.Identifier)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
 		return &clone
 	case *ir.TraitUseAliasStmt:
 		clone := *x
@@ -1313,43 +1055,19 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Ref != nil {
 			clone.Ref = NodeClone(x.Ref).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Insteadof))
-			for i := range x.Insteadof {
-				sliceClone[i] = NodeClone(x.Insteadof[i]).(ir.Node)
-			}
-			clone.Insteadof = sliceClone
-		}
+		clone.Insteadof = NodeSliceClone(x.Insteadof)
 		return &clone
 	case *ir.TraitUseStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Traits))
-			for i := range x.Traits {
-				sliceClone[i] = NodeClone(x.Traits[i]).(ir.Node)
-			}
-			clone.Traits = sliceClone
-		}
+		clone.Traits = NodeSliceClone(x.Traits)
 		if x.TraitAdaptationList != nil {
 			clone.TraitAdaptationList = NodeClone(x.TraitAdaptationList).(ir.Node)
 		}
 		return &clone
 	case *ir.TryStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Stmts))
-			for i := range x.Stmts {
-				sliceClone[i] = NodeClone(x.Stmts[i]).(ir.Node)
-			}
-			clone.Stmts = sliceClone
-		}
-		{
-			sliceClone := make([]ir.Node, len(x.Catches))
-			for i := range x.Catches {
-				sliceClone[i] = NodeClone(x.Catches[i]).(ir.Node)
-			}
-			clone.Catches = sliceClone
-		}
+		clone.Stmts = NodeSliceClone(x.Stmts)
+		clone.Catches = NodeSliceClone(x.Catches)
 		if x.Finally != nil {
 			clone.Finally = NodeClone(x.Finally).(ir.Node)
 		}
@@ -1380,26 +1098,14 @@ func NodeClone(x ir.Node) ir.Node {
 		return &clone
 	case *ir.UnsetStmt:
 		clone := *x
-		{
-			sliceClone := make([]ir.Node, len(x.Vars))
-			for i := range x.Vars {
-				sliceClone[i] = NodeClone(x.Vars[i]).(ir.Node)
-			}
-			clone.Vars = sliceClone
-		}
+		clone.Vars = NodeSliceClone(x.Vars)
 		return &clone
 	case *ir.UseListStmt:
 		clone := *x
 		if x.UseType != nil {
 			clone.UseType = NodeClone(x.UseType).(ir.Node)
 		}
-		{
-			sliceClone := make([]ir.Node, len(x.Uses))
-			for i := range x.Uses {
-				sliceClone[i] = NodeClone(x.Uses[i]).(ir.Node)
-			}
-			clone.Uses = sliceClone
-		}
+		clone.Uses = NodeSliceClone(x.Uses)
 		return &clone
 	case *ir.UseStmt:
 		clone := *x

--- a/src/ir/irutil/codegen.go
+++ b/src/ir/irutil/codegen.go
@@ -119,7 +119,7 @@ func writeWalkCase(w *bytes.Buffer, pkg *packageData, typ *typeData) {
 	for i := 0; i < typ.info.NumFields(); i++ {
 		field := typ.info.Field(i)
 		switch typeString := field.Type().String(); typeString {
-		case "[]github.com/VKCOM/noverify/src/php/parser/node.Node":
+		case "[]ir.Node":
 			fmt.Fprintf(w, "    NodeSliceWalk(x.%[1]s, visit)\n", field.Name())
 		case "github.com/VKCOM/noverify/src/php/parser/freefloating.Collection":
 			// Do nothing.
@@ -159,7 +159,7 @@ func writeCloneCase(w *bytes.Buffer, pkg *packageData, typ *typeData) {
 	for i := 0; i < typ.info.NumFields(); i++ {
 		field := typ.info.Field(i)
 		switch typeString := field.Type().String(); typeString {
-		case "[]github.com/VKCOM/noverify/src/php/parser/node.Node":
+		case "[]ir.Node":
 			fmt.Fprintf(w, "    clone.%[1]s = NodeSliceClone(x.%[1]s)\n", field.Name())
 		case "github.com/VKCOM/noverify/src/php/parser/freefloating.Collection":
 			// Do nothing.
@@ -229,7 +229,7 @@ func writeCompare(w *bytes.Buffer, pkg *packageData, typ *typeData) {
 		switch typeString := field.Type().String(); typeString {
 		case "string", "bool":
 			fmt.Fprintf(w, "    if x.%[1]s != y.%[1]s { return false }\n", field.Name())
-		case "[]github.com/VKCOM/noverify/src/php/parser/node.Node":
+		case "[]ir.Node":
 			fmt.Fprintf(w, "    if !NodeSliceEqual(x.%[1]s, y.%[1]s) { return false }\n", field.Name())
 		case "github.com/VKCOM/noverify/src/php/parser/freefloating.Collection":
 			// Do nothing.

--- a/src/ir/irutil/equal.go
+++ b/src/ir/irutil/equal.go
@@ -84,13 +84,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if x.PhpDocComment != y.PhpDocComment {
 			return false
 		}
-		if len(x.Params) != len(y.Params) {
+		if !NodeSliceEqual(x.Params, y.Params) {
 			return false
-		}
-		for i := range x.Params {
-			if !NodeEqual(x.Params[i], y.Params[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.ReturnType, y.ReturnType) {
 			return false
@@ -371,13 +366,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Cases) != len(y.Cases) {
+		if !NodeSliceEqual(x.Cases, y.Cases) {
 			return false
-		}
-		for i := range x.Cases {
-			if !NodeEqual(x.Cases[i], y.Cases[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.CaseStmt:
@@ -388,13 +378,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Cond, y.Cond) {
 			return false
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.CatchStmt:
@@ -402,24 +387,14 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Types) != len(y.Types) {
+		if !NodeSliceEqual(x.Types, y.Types) {
 			return false
-		}
-		for i := range x.Types {
-			if !NodeEqual(x.Types[i], y.Types[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.ClassConstFetchExpr:
@@ -447,13 +422,8 @@ func NodeEqual(x, y ir.Node) bool {
 				return false
 			}
 		}
-		if len(x.Consts) != len(y.Consts) {
+		if !NodeSliceEqual(x.Consts, y.Consts) {
 			return false
-		}
-		for i := range x.Consts {
-			if !NodeEqual(x.Consts[i], y.Consts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.ClassExtendsStmt:
@@ -470,13 +440,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.InterfaceNames) != len(y.InterfaceNames) {
+		if !NodeSliceEqual(x.InterfaceNames, y.InterfaceNames) {
 			return false
-		}
-		for i := range x.InterfaceNames {
-			if !NodeEqual(x.InterfaceNames[i], y.InterfaceNames[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.ClassMethodStmt:
@@ -501,13 +466,8 @@ func NodeEqual(x, y ir.Node) bool {
 				return false
 			}
 		}
-		if len(x.Params) != len(y.Params) {
+		if !NodeSliceEqual(x.Params, y.Params) {
 			return false
-		}
-		for i := range x.Params {
-			if !NodeEqual(x.Params[i], y.Params[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.ReturnType, y.ReturnType) {
 			return false
@@ -535,27 +495,17 @@ func NodeEqual(x, y ir.Node) bool {
 				return false
 			}
 		}
-		if len(x.Args) != len(y.Args) {
-			return false
-		}
-		for i := range x.Args {
-			if !NodeEqual(x.Args[i], y.Args[i]) {
-				return false
-			}
-		}
 		if !NodeEqual(x.Extends, y.Extends) {
 			return false
 		}
 		if !NodeEqual(x.Implements, y.Implements) {
 			return false
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
 		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
+		if !NodeSliceEqual(x.Args, y.Args) {
+			return false
 		}
 		return true
 	case *ir.CloneExpr:
@@ -581,13 +531,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if x.PhpDocComment != y.PhpDocComment {
 			return false
 		}
-		if len(x.Params) != len(y.Params) {
+		if !NodeSliceEqual(x.Params, y.Params) {
 			return false
-		}
-		for i := range x.Params {
-			if !NodeEqual(x.Params[i], y.Params[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.ClosureUse, y.ClosureUse) {
 			return false
@@ -595,13 +540,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.ReturnType, y.ReturnType) {
 			return false
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.ClosureUseExpr:
@@ -609,13 +549,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Uses) != len(y.Uses) {
+		if !NodeSliceEqual(x.Uses, y.Uses) {
 			return false
-		}
-		for i := range x.Uses {
-			if !NodeEqual(x.Uses[i], y.Uses[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.CoalesceExpr:
@@ -656,13 +591,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Consts) != len(y.Consts) {
+		if !NodeSliceEqual(x.Consts, y.Consts) {
 			return false
-		}
-		for i := range x.Consts {
-			if !NodeEqual(x.Consts[i], y.Consts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.ConstantStmt:
@@ -694,13 +624,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Consts) != len(y.Consts) {
+		if !NodeSliceEqual(x.Consts, y.Consts) {
 			return false
-		}
-		for i := range x.Consts {
-			if !NodeEqual(x.Consts[i], y.Consts[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.Stmt, y.Stmt) {
 			return false
@@ -714,13 +639,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.DivExpr:
@@ -761,13 +681,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Exprs) != len(y.Exprs) {
+		if !NodeSliceEqual(x.Exprs, y.Exprs) {
 			return false
-		}
-		for i := range x.Exprs {
-			if !NodeEqual(x.Exprs[i], y.Exprs[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.ElseIfStmt:
@@ -814,13 +729,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Parts) != len(y.Parts) {
+		if !NodeSliceEqual(x.Parts, y.Parts) {
 			return false
-		}
-		for i := range x.Parts {
-			if !NodeEqual(x.Parts[i], y.Parts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.EncapsedStringPart:
@@ -888,13 +798,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.ForStmt:
@@ -902,29 +807,14 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Init) != len(y.Init) {
+		if !NodeSliceEqual(x.Init, y.Init) {
 			return false
 		}
-		for i := range x.Init {
-			if !NodeEqual(x.Init[i], y.Init[i]) {
-				return false
-			}
-		}
-		if len(x.Cond) != len(y.Cond) {
+		if !NodeSliceEqual(x.Cond, y.Cond) {
 			return false
 		}
-		for i := range x.Cond {
-			if !NodeEqual(x.Cond[i], y.Cond[i]) {
-				return false
-			}
-		}
-		if len(x.Loop) != len(y.Loop) {
+		if !NodeSliceEqual(x.Loop, y.Loop) {
 			return false
-		}
-		for i := range x.Loop {
-			if !NodeEqual(x.Loop[i], y.Loop[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.Stmt, y.Stmt) {
 			return false
@@ -962,13 +852,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Function, y.Function) {
 			return false
 		}
-		if len(x.Args) != len(y.Args) {
+		if !NodeSliceEqual(x.Args, y.Args) {
 			return false
-		}
-		for i := range x.Args {
-			if !NodeEqual(x.Args[i], y.Args[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.FunctionStmt:
@@ -985,24 +870,14 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.FunctionName, y.FunctionName) {
 			return false
 		}
-		if len(x.Params) != len(y.Params) {
+		if !NodeSliceEqual(x.Params, y.Params) {
 			return false
-		}
-		for i := range x.Params {
-			if !NodeEqual(x.Params[i], y.Params[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.ReturnType, y.ReturnType) {
 			return false
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.GlobalStmt:
@@ -1010,13 +885,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Vars) != len(y.Vars) {
+		if !NodeSliceEqual(x.Vars, y.Vars) {
 			return false
-		}
-		for i := range x.Vars {
-			if !NodeEqual(x.Vars[i], y.Vars[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.GotoStmt:
@@ -1063,13 +933,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Prefix, y.Prefix) {
 			return false
 		}
-		if len(x.UseList) != len(y.UseList) {
+		if !NodeSliceEqual(x.UseList, y.UseList) {
 			return false
-		}
-		for i := range x.UseList {
-			if !NodeEqual(x.UseList[i], y.UseList[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.HaltCompilerStmt:
@@ -1086,13 +951,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if x.Label != y.Label {
 			return false
 		}
-		if len(x.Parts) != len(y.Parts) {
+		if !NodeSliceEqual(x.Parts, y.Parts) {
 			return false
-		}
-		for i := range x.Parts {
-			if !NodeEqual(x.Parts[i], y.Parts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.IdenticalExpr:
@@ -1127,13 +987,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Stmt, y.Stmt) {
 			return false
 		}
-		if len(x.ElseIf) != len(y.ElseIf) {
+		if !NodeSliceEqual(x.ElseIf, y.ElseIf) {
 			return false
-		}
-		for i := range x.ElseIf {
-			if !NodeEqual(x.ElseIf[i], y.ElseIf[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.Else, y.Else) {
 			return false
@@ -1180,13 +1035,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.InterfaceNames) != len(y.InterfaceNames) {
+		if !NodeSliceEqual(x.InterfaceNames, y.InterfaceNames) {
 			return false
-		}
-		for i := range x.InterfaceNames {
-			if !NodeEqual(x.InterfaceNames[i], y.InterfaceNames[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.InterfaceStmt:
@@ -1203,13 +1053,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Extends, y.Extends) {
 			return false
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.IssetExpr:
@@ -1217,13 +1062,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Variables) != len(y.Variables) {
+		if !NodeSliceEqual(x.Variables, y.Variables) {
 			return false
-		}
-		for i := range x.Variables {
-			if !NodeEqual(x.Variables[i], y.Variables[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.LabelStmt:
@@ -1317,13 +1157,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Method, y.Method) {
 			return false
 		}
-		if len(x.Args) != len(y.Args) {
+		if !NodeSliceEqual(x.Args, y.Args) {
 			return false
-		}
-		for i := range x.Args {
-			if !NodeEqual(x.Args[i], y.Args[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.MinusExpr:
@@ -1379,13 +1214,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.NamespaceName, y.NamespaceName) {
 			return false
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.NewExpr:
@@ -1396,13 +1226,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Class, y.Class) {
 			return false
 		}
-		if len(x.Args) != len(y.Args) {
+		if !NodeSliceEqual(x.Args, y.Args) {
 			return false
-		}
-		for i := range x.Args {
-			if !NodeEqual(x.Args[i], y.Args[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.NopStmt:
@@ -1571,13 +1396,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Type, y.Type) {
 			return false
 		}
-		if len(x.Properties) != len(y.Properties) {
+		if !NodeSliceEqual(x.Properties, y.Properties) {
 			return false
-		}
-		for i := range x.Properties {
-			if !NodeEqual(x.Properties[i], y.Properties[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.PropertyStmt:
@@ -1618,13 +1438,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.ShellExecExpr:
@@ -1632,13 +1447,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Parts) != len(y.Parts) {
+		if !NodeSliceEqual(x.Parts, y.Parts) {
 			return false
-		}
-		for i := range x.Parts {
-			if !NodeEqual(x.Parts[i], y.Parts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.ShiftLeftExpr:
@@ -1721,13 +1531,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Call, y.Call) {
 			return false
 		}
-		if len(x.Args) != len(y.Args) {
+		if !NodeSliceEqual(x.Args, y.Args) {
 			return false
-		}
-		for i := range x.Args {
-			if !NodeEqual(x.Args[i], y.Args[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.StaticPropertyFetchExpr:
@@ -1747,13 +1552,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Vars) != len(y.Vars) {
+		if !NodeSliceEqual(x.Vars, y.Vars) {
 			return false
-		}
-		for i := range x.Vars {
-			if !NodeEqual(x.Vars[i], y.Vars[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.StaticVarStmt:
@@ -1773,13 +1573,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.String:
@@ -1788,6 +1583,9 @@ func NodeEqual(x, y ir.Node) bool {
 			return x == y
 		}
 		if x.Value != y.Value {
+			return false
+		}
+		if x.DoubleQuotes != y.DoubleQuotes {
 			return false
 		}
 		return true
@@ -1835,13 +1633,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Adaptations) != len(y.Adaptations) {
+		if !NodeSliceEqual(x.Adaptations, y.Adaptations) {
 			return false
-		}
-		for i := range x.Adaptations {
-			if !NodeEqual(x.Adaptations[i], y.Adaptations[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.TraitMethodRefStmt:
@@ -1867,13 +1660,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.TraitName, y.TraitName) {
 			return false
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
-		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.TraitUseAliasStmt:
@@ -1899,13 +1687,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Ref, y.Ref) {
 			return false
 		}
-		if len(x.Insteadof) != len(y.Insteadof) {
+		if !NodeSliceEqual(x.Insteadof, y.Insteadof) {
 			return false
-		}
-		for i := range x.Insteadof {
-			if !NodeEqual(x.Insteadof[i], y.Insteadof[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.TraitUseStmt:
@@ -1913,13 +1696,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Traits) != len(y.Traits) {
+		if !NodeSliceEqual(x.Traits, y.Traits) {
 			return false
-		}
-		for i := range x.Traits {
-			if !NodeEqual(x.Traits[i], y.Traits[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.TraitAdaptationList, y.TraitAdaptationList) {
 			return false
@@ -1930,21 +1708,11 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Stmts) != len(y.Stmts) {
+		if !NodeSliceEqual(x.Stmts, y.Stmts) {
 			return false
 		}
-		for i := range x.Stmts {
-			if !NodeEqual(x.Stmts[i], y.Stmts[i]) {
-				return false
-			}
-		}
-		if len(x.Catches) != len(y.Catches) {
+		if !NodeSliceEqual(x.Catches, y.Catches) {
 			return false
-		}
-		for i := range x.Catches {
-			if !NodeEqual(x.Catches[i], y.Catches[i]) {
-				return false
-			}
 		}
 		if !NodeEqual(x.Finally, y.Finally) {
 			return false
@@ -1994,13 +1762,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if len(x.Vars) != len(y.Vars) {
+		if !NodeSliceEqual(x.Vars, y.Vars) {
 			return false
-		}
-		for i := range x.Vars {
-			if !NodeEqual(x.Vars[i], y.Vars[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.UseListStmt:
@@ -2011,13 +1774,8 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.UseType, y.UseType) {
 			return false
 		}
-		if len(x.Uses) != len(y.Uses) {
+		if !NodeSliceEqual(x.Uses, y.Uses) {
 			return false
-		}
-		for i := range x.Uses {
-			if !NodeEqual(x.Uses[i], y.Uses[i]) {
-				return false
-			}
 		}
 		return true
 	case *ir.UseStmt:


### PR DESCRIPTION
This bug is a consequence of the AST->IR transition.

It doesn't make code incorrect, but we generated more
code than we could.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>