### PR TITLE
ir: introduce AnonClassExpr node

### DIFF
--- a/src/ir/freefloating.go
+++ b/src/ir/freefloating.go
@@ -34,6 +34,8 @@ func (n *AssignShiftLeft) GetFreeFloating() *freefloating.Collection { return &n
 
 func (n *AssignShiftRight) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
 
+func (n *AnonClassExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
+
 func (n *BitwiseAndExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
 
 func (n *BitwiseOrExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }

--- a/src/ir/helper_types.go
+++ b/src/ir/helper_types.go
@@ -1,0 +1,15 @@
+package ir
+
+// Helper types are not real nodes, they're usually used
+// to express some structure that is common between several nodes.
+//
+// In other words, structs defined in this file do not implement the Node interface.
+
+// Class is a common shape between the ClassStmt and AnonClassExpr.
+// It doesn't include positions/freefloating info.
+type Class struct {
+	PhpDocComment string
+	Extends       *ClassExtendsStmt
+	Implements    *ClassImplementsStmt
+	Stmts         []Node
+}

--- a/src/ir/irfmt/printer.go
+++ b/src/ir/irfmt/printer.go
@@ -79,6 +79,9 @@ func (p *PrettyPrinter) printIndent() {
 func (p *PrettyPrinter) printNode(n ir.Node) {
 	switch n := n.(type) {
 
+	case *ir.AnonClassExpr:
+		p.printExprAnonClass(n)
+
 	// node
 
 	case *ir.Root:
@@ -385,6 +388,38 @@ func (p *PrettyPrinter) printNode(n ir.Node) {
 	case *ir.WhileStmt:
 		p.printStmtWhile(n)
 	}
+}
+
+func (p *PrettyPrinter) printClass(class ir.Class) {
+	if class.Extends != nil {
+		io.WriteString(p.w, " extends ")
+		p.Print(class.Extends.ClassName)
+	}
+
+	if class.Implements != nil {
+		io.WriteString(p.w, " implements ")
+		p.joinPrint(", ", class.Implements.InterfaceNames)
+	}
+
+	io.WriteString(p.w, "\n")
+	p.printIndent()
+	io.WriteString(p.w, "{\n")
+	p.printNodes(class.Stmts)
+	io.WriteString(p.w, "\n")
+	p.printIndent()
+	io.WriteString(p.w, "}")
+}
+
+func (p *PrettyPrinter) printExprAnonClass(n *ir.AnonClassExpr) {
+	io.WriteString(p.w, "class")
+
+	if len(n.Args) != 0 {
+		io.WriteString(p.w, "(")
+		p.joinPrint(", ", n.Args)
+		io.WriteString(p.w, ")")
+	}
+
+	p.printClass(n.Class)
 }
 
 // node
@@ -1159,34 +1194,10 @@ func (p *PrettyPrinter) printStmtClass(n *ir.ClassStmt) {
 	}
 	io.WriteString(p.w, "class")
 
-	if n.ClassName != nil {
-		io.WriteString(p.w, " ")
-		p.Print(n.ClassName)
-	}
+	io.WriteString(p.w, " ")
+	p.Print(n.ClassName)
 
-	if len(n.Args) != 0 {
-		io.WriteString(p.w, "(")
-		p.joinPrint(", ", n.Args)
-		io.WriteString(p.w, ")")
-	}
-
-	if n.Extends != nil {
-		io.WriteString(p.w, " extends ")
-		p.Print(n.Extends.ClassName)
-	}
-
-	if n.Implements != nil {
-		io.WriteString(p.w, " implements ")
-		p.joinPrint(", ", n.Implements.InterfaceNames)
-	}
-
-	io.WriteString(p.w, "\n")
-	p.printIndent()
-	io.WriteString(p.w, "{\n")
-	p.printNodes(n.Stmts)
-	io.WriteString(p.w, "\n")
-	p.printIndent()
-	io.WriteString(p.w, "}")
+	p.printClass(n.Class)
 }
 
 func (p *PrettyPrinter) printStmtClassConstList(n *ir.ClassConstListStmt) {

--- a/src/ir/irfmt/printer_test.go
+++ b/src/ir/irfmt/printer_test.go
@@ -848,6 +848,18 @@ endswitch;
 		`while ($a);
 
 `,
+		`new class
+{
+    public $foo = 10;
+};
+
+`,
+		`new class(1, "arg2")
+{
+
+};
+
+`,
 	}
 
 	for _, code := range testCases {

--- a/src/ir/irutil/clone.go
+++ b/src/ir/irutil/clone.go
@@ -11,6 +11,11 @@ func NodeClone(x ir.Node) ir.Node {
 		return nil
 	}
 	switch x := x.(type) {
+	case *ir.AnonClassExpr:
+		clone := *x
+		clone.Class = classClone(x.Class)
+		clone.Args = NodeSliceClone(x.Args)
+		return &clone
 	case *ir.Argument:
 		clone := *x
 		if x.Expr != nil {
@@ -334,14 +339,7 @@ func NodeClone(x ir.Node) ir.Node {
 			}
 			clone.Modifiers = sliceClone
 		}
-		if x.Extends != nil {
-			clone.Extends = NodeClone(x.Extends).(*ir.ClassExtendsStmt)
-		}
-		if x.Implements != nil {
-			clone.Implements = NodeClone(x.Implements).(*ir.ClassImplementsStmt)
-		}
-		clone.Stmts = NodeSliceClone(x.Stmts)
-		clone.Args = NodeSliceClone(x.Args)
+		clone.Class = classClone(x.Class)
 		return &clone
 	case *ir.CloneExpr:
 		clone := *x

--- a/src/ir/irutil/codegen.go
+++ b/src/ir/irutil/codegen.go
@@ -167,6 +167,8 @@ func writeCloneCase(w *bytes.Buffer, pkg *packageData, typ *typeData) {
 			// Do nothing.
 		case "string", "bool":
 			// Do nothing.
+		case "ir.Class":
+			fmt.Fprintf(w, "    clone.%[1]s = classClone(x.%[1]s)\n", field.Name())
 		default:
 			if !strings.HasPrefix(typeString, "[]") {
 				fmt.Fprintf(w, "    if x.%s != nil {\n", field.Name())
@@ -235,6 +237,8 @@ func writeCompare(w *bytes.Buffer, pkg *packageData, typ *typeData) {
 			// Do nothing.
 		case "*github.com/VKCOM/noverify/src/php/parser/position.Position":
 			// Do nothing.
+		case "ir.Class":
+			fmt.Fprintf(w, "    if !classEqual(x.%[1]s, y.%[1]s) { return false }\n", field.Name())
 		default:
 			if !strings.HasPrefix(typeString, "[]") {
 				fmt.Fprintf(w, "    if !NodeEqual(x.%[1]s, y.%[1]s) { return false }\n", field.Name())
@@ -286,6 +290,11 @@ func loadPackage(ctx *context, pkg string) error {
 		path:  pkg,
 		scope: root,
 	}
+	nodeObject := root.Lookup("Node")
+	nodeIface, ok := nodeObject.Type().Underlying().(*types.Interface)
+	if !ok {
+		panic(fmt.Sprintf("can't find ir.Node type"))
+	}
 	for _, sym := range root.Names() {
 		tn, ok := root.Lookup(sym).(*types.TypeName)
 		if !ok {
@@ -297,6 +306,9 @@ func loadPackage(ctx *context, pkg string) error {
 		}
 		structType, ok := named.Underlying().(*types.Struct)
 		if !ok {
+			continue
+		}
+		if !types.Implements(types.NewPointer(named), nodeIface) {
 			continue
 		}
 		result.types = append(result.types, &typeData{

--- a/src/ir/irutil/equal.go
+++ b/src/ir/irutil/equal.go
@@ -11,6 +11,18 @@ func NodeEqual(x, y ir.Node) bool {
 		return x == y
 	}
 	switch x := x.(type) {
+	case *ir.AnonClassExpr:
+		y, ok := y.(*ir.AnonClassExpr)
+		if !ok || x == nil || y == nil {
+			return x == y
+		}
+		if !classEqual(x.Class, y.Class) {
+			return false
+		}
+		if !NodeSliceEqual(x.Args, y.Args) {
+			return false
+		}
+		return true
 	case *ir.Argument:
 		y, ok := y.(*ir.Argument)
 		if !ok || x == nil || y == nil {
@@ -481,9 +493,6 @@ func NodeEqual(x, y ir.Node) bool {
 		if !ok || x == nil || y == nil {
 			return x == y
 		}
-		if x.PhpDocComment != y.PhpDocComment {
-			return false
-		}
 		if !NodeEqual(x.ClassName, y.ClassName) {
 			return false
 		}
@@ -495,16 +504,7 @@ func NodeEqual(x, y ir.Node) bool {
 				return false
 			}
 		}
-		if !NodeEqual(x.Extends, y.Extends) {
-			return false
-		}
-		if !NodeEqual(x.Implements, y.Implements) {
-			return false
-		}
-		if !NodeSliceEqual(x.Stmts, y.Stmts) {
-			return false
-		}
-		if !NodeSliceEqual(x.Args, y.Args) {
+		if !classEqual(x.Class, y.Class) {
 			return false
 		}
 		return true

--- a/src/ir/irutil/irtutil.go
+++ b/src/ir/irutil/irtutil.go
@@ -72,3 +72,19 @@ func IsAssign(n ir.Node) bool {
 func FmtNode(n ir.Node) string {
 	return irfmt.Node(n)
 }
+
+func classEqual(x, y ir.Class) bool {
+	return x.PhpDocComment == y.PhpDocComment &&
+		NodeEqual(x.Extends, y.Extends) &&
+		NodeEqual(x.Implements, y.Implements) &&
+		NodeSliceEqual(x.Stmts, y.Stmts)
+}
+
+func classClone(x ir.Class) ir.Class {
+	return ir.Class{
+		PhpDocComment: x.PhpDocComment,
+		Extends:       NodeClone(x.Extends).(*ir.ClassExtendsStmt),
+		Implements:    NodeClone(x.Implements).(*ir.ClassImplementsStmt),
+		Stmts:         NodeSliceClone(x.Stmts),
+	}
+}

--- a/src/ir/methods.go
+++ b/src/ir/methods.go
@@ -87,4 +87,4 @@ func (n *NewExpr) Arg(i int) *Argument { return n.Args[i].(*Argument) }
 func (n *StaticCallExpr) Arg(i int) *Argument { return n.Args[i].(*Argument) }
 
 // Arg returns the ith argument.
-func (n *ClassStmt) Arg(i int) *Argument { return n.Args[i].(*Argument) }
+func (n *AnonClassExpr) Arg(i int) *Argument { return n.Args[i].(*Argument) }

--- a/src/ir/types.go
+++ b/src/ir/types.go
@@ -120,6 +120,15 @@ type AssignShiftRight struct {
 	Expression   Node
 }
 
+type AnonClassExpr struct {
+	FreeFloating freefloating.Collection
+	Position     *position.Position
+	Class
+
+	ArgsFreeFloating freefloating.Collection
+	Args             []Node
+}
+
 type BitwiseAndExpr struct {
 	FreeFloating freefloating.Collection
 	Position     *position.Position
@@ -715,17 +724,11 @@ type CatchStmt struct {
 }
 
 type ClassStmt struct {
-	FreeFloating  freefloating.Collection
-	Position      *position.Position
-	PhpDocComment string
-	ClassName     *Identifier
-	Modifiers     []*Identifier
-	Extends       *ClassExtendsStmt
-	Implements    *ClassImplementsStmt
-	Stmts         []Node
-
-	ArgsFreeFloating freefloating.Collection
-	Args             []Node
+	FreeFloating freefloating.Collection
+	Position     *position.Position
+	ClassName    *Identifier
+	Modifiers    []*Identifier
+	Class
 }
 
 type ClassConstListStmt struct {

--- a/src/ir/walk.go
+++ b/src/ir/walk.go
@@ -195,6 +195,27 @@ func (n *AssignShiftRight) Walk(v Visitor) {
 	v.LeaveNode(n)
 }
 
+func (n *AnonClassExpr) Walk(v Visitor) {
+	if !v.EnterNode(n) {
+		return
+	}
+	for _, arg := range n.Args {
+		arg.Walk(v)
+	}
+	if n.Extends != nil {
+		n.Extends.Walk(v)
+	}
+	if n.Implements != nil {
+		n.Implements.Walk(v)
+	}
+	for i := range n.Stmts {
+		if n.Stmts[i] != nil {
+			n.Stmts[i].Walk(v)
+		}
+	}
+	v.LeaveNode(n)
+}
+
 func (n *BitwiseAndExpr) Walk(v Visitor) {
 	if !v.EnterNode(n) {
 		return
@@ -1228,9 +1249,6 @@ func (n *ClassStmt) Walk(v Visitor) {
 		if n.Modifiers[i] != nil {
 			n.Modifiers[i].Walk(v)
 		}
-	}
-	for _, arg := range n.Args {
-		arg.Walk(v)
 	}
 	if n.Extends != nil {
 		n.Extends.Walk(v)

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -269,6 +269,8 @@ func (b *BlockWalker) EnterNode(n ir.Node) (res bool) {
 		res = b.handleVariable(s)
 	case *ir.FunctionStmt:
 		res = b.handleFunction(s)
+	case *ir.AnonClassExpr:
+		res = !b.ignoreFunctionBodies
 	case *ir.ClassStmt:
 		if b.ignoreFunctionBodies {
 			res = false

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -287,7 +287,7 @@ func (b *blockLinter) checkNew(e *ir.NewExpr) {
 	b.walker.r.checkKeywordCase(e, "new")
 
 	// Can't handle `new class() ...` yet.
-	if _, ok := e.Class.(*ir.ClassStmt); ok {
+	if _, ok := e.Class.(*ir.AnonClassExpr); ok {
 		return
 	}
 

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -181,7 +181,7 @@ func (d *RootWalker) EnterNode(n ir.Node) (res bool) {
 		}
 	}
 
-	if class, ok := n.(*ir.ClassStmt); ok && class.ClassName == nil {
+	if _, ok := n.(*ir.AnonClassExpr); ok {
 		// TODO: remove when #62 and anon class support in general is ready.
 		return false // Don't walk nor enter anon classes
 	}

--- a/src/phpgrep/matcher.go
+++ b/src/phpgrep/matcher.go
@@ -209,6 +209,8 @@ func (m *matcher) eqNode(state *matcherState, x, y ir.Node) bool {
 		return false // FIXME #23
 	case *ir.TraitStmt:
 		return false // FIXME #23
+	case *ir.AnonClassExpr:
+		return false
 
 	case *ir.InlineHTMLStmt:
 		y, ok := y.(*ir.InlineHTMLStmt)

--- a/src/tests/regression/pull236_test.go
+++ b/src/tests/regression/pull236_test.go
@@ -1,0 +1,18 @@
+package regression_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestPull236(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+$_ = new class {
+  private function f() { return 10; }
+
+  /** @return int */
+  public function g() { return $this->f(); }
+};
+`)
+}


### PR DESCRIPTION
Instead of having ClassStmt node for both normal class
declarations and anon class expressions, make ClassStmt
relevant only for class declarations and new AnonClassExpr
for anonymous class expressions.

I tried to update the code that could be affected by this,
but we don't have enough tests with anon classes unfortunately.

See #732

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>