### PR TITLE
ir: ClassExtendsStmt.Name :: Node -> *Name

### DIFF
--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -1196,7 +1196,7 @@ func (c *Converter) convNode(n node.Node) ir.Node {
 		out := &ir.ClassExtendsStmt{}
 		out.FreeFloating = n.FreeFloating
 		out.Position = n.Position
-		out.ClassName = c.convNode(n.ClassName)
+		out.ClassName = c.convNode(n.ClassName).(*ir.Name)
 		return out
 
 	case *stmt.ClassImplements:

--- a/src/ir/irutil/clone.go
+++ b/src/ir/irutil/clone.go
@@ -300,7 +300,7 @@ func NodeClone(x ir.Node) ir.Node {
 	case *ir.ClassExtendsStmt:
 		clone := *x
 		if x.ClassName != nil {
-			clone.ClassName = NodeClone(x.ClassName)
+			clone.ClassName = NodeClone(x.ClassName).(*ir.Name)
 		}
 		return &clone
 	case *ir.ClassImplementsStmt:

--- a/src/ir/node_types.go
+++ b/src/ir/node_types.go
@@ -877,11 +877,10 @@ type ClassConstListStmt struct {
 }
 
 // ClassExtendsStmt is a `extends $ClassName` statement.
-// TODO: shouldn't ClassName be a *Name?
 type ClassExtendsStmt struct {
 	FreeFloating freefloating.Collection
 	Position     *position.Position
-	ClassName    Node
+	ClassName    *Name
 }
 
 // ClassImplementsStmt is a `implements $InterfaceNames...` statement.


### PR DESCRIPTION
We can't specialize []Node to []*Name as it would break all
the code that expects []Node in algorithms (like phpgrep and
dynamic rules). We should either wait for generics there or
use codegen even more.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>