### PR TITLE
tests/rules: add t.Helper() call to runRulesTest

### DIFF
--- a/src/tests/rules/rules_test.go
+++ b/src/tests/rules/rules_test.go
@@ -446,6 +446,8 @@ function bad(string $x) {
 }
 
 func runRulesTest(t *testing.T, test *linttest.Suite, rfile string) {
+	t.Helper()
+
 	test.IgnoreUndeclaredChecks = true
 
 	rparser := rules.NewParser()


### PR DESCRIPTION
Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>