### PR TITLE
tests/golden: improve assignOp tests

### DIFF
--- a/src/tests/golden/testdata/embeddedrules/assignOp.php
+++ b/src/tests/golden/testdata/embeddedrules/assignOp.php
@@ -1,53 +1,85 @@
 <?php
-$a = 100;
-$a1 = 100;
-$b = 5;
 
+function assignPlus($a1, $b) {
+  global $a;
+  // $a += $b
+  $a = $a + $b; // Could rewrite
+  $a = $a1 + $b; // Ok
+}
 
-// $a += $b
-$a = $a + $b; // Could rewrite
-$a = $a1 + $b; // Ok
+function assignMinus($a1, $b) {
+  global $a;
+  // $a -= $b
+  $a = $a - $b; // Could rewrite
+  $a = $a1 - $b; // Ok
+}
 
-// $a -= $b
-$a = $a - $b; // Could rewrite
-$a = $a1 - $b; // Ok
+function assignMul($a1, $b) {
+  global $a;
+  // $a *= $b
+  $a = $a * $b; // Could rewrite
+  $a = $a1 * $b; // Ok
+}
 
-// $a *= $b
-$a = $a * $b; // Could rewrite
-$a = $a1 * $b; // Ok
+function assignDiv($a1, $b) {
+  global $a;
+  // $a /= $b
+  $a = $a / $b; // Could rewrite
+  $a = $a1 / $b; // Ok
+}
 
-// $a /= $b
-$a = $a / $b; // Could rewrite
-$a = $a1 / $b; // Ok
+function assignMod($a1, $b) {
+  global $a;
+  // $a %= $b
+  $a = $a % $b; // Could rewrite
+  $a = $a1 % $b; // Ok
+}
 
-// $a %= $b
-$a = $a % $b; // Could rewrite
-$a = $a1 % $b; // Ok
+function assignConcat($a1, $b) {
+  global $a;
+  // $a .= $b
+  $a = $a . $b; // Could rewrite
+  $a = $a1 . $b; // Ok
+}
 
-// $a .= $b
-$a = $a . $b; // Could rewrite
-$a = $a1 . $b; // Ok
+function assignBitAnd($a1, $b) {
+  global $a;
+  // $a &= $b
+  $a = $a & $b; // Could rewrite
+  $a = $a1 & $b; // Ok
+}
 
-// $a &= $b
-$a = $a & $b; // Could rewrite
-$a = $a1 & $b; // Ok
+function assignBitOr($a1, $b) {
+  global $a;
+  // $a |= $b
+  $a = $a | $b; // Could rewrite
+  $a = $a1 | $b; // Ok
+}
 
-// $a |= $b
-$a = $a | $b; // Could rewrite
-$a = $a1 | $b; // Ok
+function assignXor($a1, $b) {
+  global $a;
+  // $a ^= $b
+  $a = $a ^ $b; // Could rewrite
+  $a = $a1 ^ $b; // Ok
+}
 
-// $a ^= $b
-$a = $a ^ $b; // Could rewrite
-$a = $a1 ^ $b; // Ok
+function assignShiftLeft($a1, $b) {
+  global $a;
+  // $a <<= $b
+  $a = $a << $b; // Could rewrite
+  $a = $a1 << $b; // Ok
+}
 
-// $a <<= $b
-$a = $a << $b; // Could rewrite
-$a = $a1 << $b; // Ok
+function assignShiftRight($a1, $b) {
+  global $a;
+  // $a >>= $b
+  $a = $a >> $b; // Could rewrite
+  $a = $a1 >> $b; // Ok
+}
 
-// $a >>= $b
-$a = $a >> $b; // Could rewrite
-$a = $a1 >> $b; // Ok
-
-// $a ??= $b
-$a = $a ?? $b; // Could rewrite
-$a = $a1 ?? $b; // Ok
+function assignNullCoalesce($a1, $b) {
+  global $a;
+  // $a ??= $b
+  $a = $a ?? $b; // Could rewrite
+  $a = $a1 ?? $b; // Ok
+}

--- a/src/tests/golden/testdata/embeddedrules/golden.txt
+++ b/src/tests/golden/testdata/embeddedrules/golden.txt
@@ -22,42 +22,42 @@ WARNING argsOrder: potentially incorrect replace and string arguments order at t
 WARNING argsOrder: potentially incorrect replace and string arguments order at testdata/embeddedrules/argsOrder.php:51
   $_ = str_replace($search, $subj, '');
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a += $b` at testdata/embeddedrules/assignOp.php:8
-$a = $a + $b; // Could rewrite
-^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a -= $b` at testdata/embeddedrules/assignOp.php:12
-$a = $a - $b; // Could rewrite
-^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a *= $b` at testdata/embeddedrules/assignOp.php:16
-$a = $a * $b; // Could rewrite
-^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a /= $b` at testdata/embeddedrules/assignOp.php:20
-$a = $a / $b; // Could rewrite
-^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a %= $b` at testdata/embeddedrules/assignOp.php:24
-$a = $a % $b; // Could rewrite
-^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a .= $b` at testdata/embeddedrules/assignOp.php:28
-$a = $a . $b; // Could rewrite
-^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a &= $b` at testdata/embeddedrules/assignOp.php:32
-$a = $a & $b; // Could rewrite
-^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a |= $b` at testdata/embeddedrules/assignOp.php:36
-$a = $a | $b; // Could rewrite
-^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a ^= $b` at testdata/embeddedrules/assignOp.php:40
-$a = $a ^ $b; // Could rewrite
-^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a <<= $b` at testdata/embeddedrules/assignOp.php:44
-$a = $a << $b; // Could rewrite
-^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a >>= $b` at testdata/embeddedrules/assignOp.php:48
-$a = $a >> $b; // Could rewrite
-^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a ??= $b` at testdata/embeddedrules/assignOp.php:52
-$a = $a ?? $b; // Could rewrite
-^^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a += $b` at testdata/embeddedrules/assignOp.php:6
+  $a = $a + $b; // Could rewrite
+  ^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a -= $b` at testdata/embeddedrules/assignOp.php:13
+  $a = $a - $b; // Could rewrite
+  ^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a *= $b` at testdata/embeddedrules/assignOp.php:20
+  $a = $a * $b; // Could rewrite
+  ^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a /= $b` at testdata/embeddedrules/assignOp.php:27
+  $a = $a / $b; // Could rewrite
+  ^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a %= $b` at testdata/embeddedrules/assignOp.php:34
+  $a = $a % $b; // Could rewrite
+  ^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a .= $b` at testdata/embeddedrules/assignOp.php:41
+  $a = $a . $b; // Could rewrite
+  ^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a &= $b` at testdata/embeddedrules/assignOp.php:48
+  $a = $a & $b; // Could rewrite
+  ^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a |= $b` at testdata/embeddedrules/assignOp.php:55
+  $a = $a | $b; // Could rewrite
+  ^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a ^= $b` at testdata/embeddedrules/assignOp.php:62
+  $a = $a ^ $b; // Could rewrite
+  ^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a <<= $b` at testdata/embeddedrules/assignOp.php:69
+  $a = $a << $b; // Could rewrite
+  ^^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a >>= $b` at testdata/embeddedrules/assignOp.php:76
+  $a = $a >> $b; // Could rewrite
+  ^^^^^^^^^^^^^
+MAYBE   assignOp: could rewrite as `$a ??= $b` at testdata/embeddedrules/assignOp.php:83
+  $a = $a ?? $b; // Could rewrite
+  ^^^^^^^^^^^^^
 WARNING offBy1: probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:7
   $_ = $xs[count($xs)];
        ^^^^^^^^^^^^^^^


### PR DESCRIPTION
With functions per test we don't overwrite the
variable types which can lead to the unrelated checks
reporting this code.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>