### PR TITLE
cmd: fix -allow-checks filtering of rules

### DIFF
--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -90,7 +90,7 @@ func appendRuleSet(rset *rules.Set, filter func(r rules.Rule) bool) {
 		for i, list := range src.RulesByKind {
 			for _, r := range list {
 				if !filter(r) {
-					break
+					continue
 				}
 				dst.RulesByKind[i] = append(dst.RulesByKind[i], r)
 			}


### PR DESCRIPTION
Due to the `break` instead of `continue` inside the filtering
loop we disabled all rules from the category if any of the rules
are rejected by the -allow-checks flag.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>