### PR TITLE
linter: improve list(...)=$a type inference for arrays

### DIFF
--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -46,6 +46,65 @@ func init() {
 	})
 }
 
+func TestExprTypeListOverArray(t *testing.T) {
+	code := `<?php
+/**
+ * @param int[] $xs
+ */
+function ints($xs) {
+  list ($a, $b) = $xs;
+  exprtype($a, 'int');
+  exprtype($b, 'int');
+}
+
+/**
+ * @param string[]|false $xs
+ */
+function strings_or_false($xs) {
+  list ($a, $b) = $xs;
+  exprtype($a, 'string');
+  exprtype($b, 'string');
+}
+
+/**
+ * @param null|\Foo[]|int $xs
+ */
+function null_or_foos_or_int($xs) {
+  list ($a, $b) = $xs;
+  exprtype($a, '\Foo');
+  exprtype($b, '\Foo');
+}
+
+/**
+ * @param int[]|string[] $xs
+ */
+function ints_or_strings($xs) {
+  list ($a, $b) = $xs;
+  exprtype($a, 'int|string');
+  exprtype($b, 'int|string');
+}
+
+/**
+ * @param mixed[]|string[]|int[]|false $xs
+ */
+function mixeds_or_strings_or_ints_or_false($xs) {
+  list ($a, $b) = $xs;
+  exprtype($a, 'int|mixed|string');
+  exprtype($b, 'int|mixed|string');
+}
+
+/**
+ * @param int|float|null $xs
+ */
+function not_an_array($xs) {
+  list ($a, $b) = $xs;
+  exprtype($a, 'unknown_from_list');
+  exprtype($b, 'unknown_from_list');
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func TestExprTypeForeachKey(t *testing.T) {
 	code := `<?php
 $xs = [[1], [2]];

--- a/src/tests/golden/testdata/underscore/golden.txt
+++ b/src/tests/golden/testdata/underscore/golden.txt
@@ -106,16 +106,16 @@ INFO    unused: Variable __ is unused (use $_ to ignore this inspection) at test
 INFO    unused: Variable args is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:615
     $args = self::_wrapArgs(func_get_args(), 1);
     ^^^^^
-ERROR   undefined: Property {\__|null|unknown_from_list}->isEqual does not exist at testdata/underscore/underscore.php:723
+ERROR   undefined: Property {\__|mixed|null}->isEqual does not exist at testdata/underscore/underscore.php:723
       if(is_object($a) && isset($a->isEqual)) return self::_wrap($a->isEqual($b));
                                     ^^^^^^^
-ERROR   undefined: Property {null|unknown_from_list}->isEqual does not exist at testdata/underscore/underscore.php:724
+ERROR   undefined: Property {mixed|null}->isEqual does not exist at testdata/underscore/underscore.php:724
       if(is_object($b) && isset($b->isEqual)) return self::_wrap($b->isEqual($a));
                                     ^^^^^^^
-ERROR   undefined: Call to undefined method {null|unknown_from_list}->isEqual() at testdata/underscore/underscore.php:724
+ERROR   undefined: Call to undefined method {mixed|null}->isEqual() at testdata/underscore/underscore.php:724
       if(is_object($b) && isset($b->isEqual)) return self::_wrap($b->isEqual($a));
                                                                      ^^^^^^^
-MAYBE   arrayAccess: Array access to non-array type \__|null|unknown_from_list at testdata/underscore/underscore.php:725
+MAYBE   arrayAccess: Array access to non-array type \__|mixed|null at testdata/underscore/underscore.php:725
       if(is_array($a) && array_key_exists('isEqual', $a)) return self::_wrap($a['isEqual']($b));
                                                                              ^^
 ERROR   undefined: Property {mixed}->_uniqueId does not exist at testdata/underscore/underscore.php:822


### PR DESCRIPTION
Like PhpStorm, collect all array types and assign a union
type of all element types to the list variables.

	$xs = [1, 2];
	list ($a, $b) = $xs;
	// $a is int
	// $b is int

This way we get more types information.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>