### PR TITLE
ir/irconv: don't panic on invalid strings

### DIFF
--- a/src/ir/freefloating.go
+++ b/src/ir/freefloating.go
@@ -47,6 +47,8 @@ func (n *AssignShiftLeft) GetFreeFloating() *freefloating.Collection { return &n
 
 func (n *AssignShiftRight) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
 
+func (n *BadString) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
+
 func (n *BitwiseAndExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }
 
 func (n *BitwiseNotExpr) GetFreeFloating() *freefloating.Collection { return &n.FreeFloating }

--- a/src/ir/get_node_kind.go
+++ b/src/ir/get_node_kind.go
@@ -29,6 +29,7 @@ const (
 	KindAssignReference
 	KindAssignShiftLeft
 	KindAssignShiftRight
+	KindBadString
 	KindBitwiseAndExpr
 	KindBitwiseNotExpr
 	KindBitwiseOrExpr
@@ -207,6 +208,8 @@ func GetNodeKind(x Node) NodeKind {
 		return KindAssignShiftLeft
 	case *AssignShiftRight:
 		return KindAssignShiftRight
+	case *BadString:
+		return KindBadString
 	case *BitwiseAndExpr:
 		return KindBitwiseAndExpr
 	case *BitwiseNotExpr:

--- a/src/ir/get_position.go
+++ b/src/ir/get_position.go
@@ -50,6 +50,8 @@ func GetPosition(n Node) *position.Position {
 		return n.Position
 	case *AssignShiftRight:
 		return n.Position
+	case *BadString:
+		return n.Position
 	case *BitwiseAndExpr:
 		return n.Position
 	case *BitwiseNotExpr:

--- a/src/ir/irutil/clone.go
+++ b/src/ir/irutil/clone.go
@@ -195,6 +195,9 @@ func NodeClone(x ir.Node) ir.Node {
 			clone.Expression = NodeClone(x.Expression)
 		}
 		return &clone
+	case *ir.BadString:
+		clone := *x
+		return &clone
 	case *ir.BitwiseAndExpr:
 		clone := *x
 		if x.Left != nil {

--- a/src/ir/irutil/equal.go
+++ b/src/ir/irutil/equal.go
@@ -286,6 +286,21 @@ func NodeEqual(x, y ir.Node) bool {
 			return false
 		}
 		return true
+	case *ir.BadString:
+		y, ok := y.(*ir.BadString)
+		if !ok || x == nil || y == nil {
+			return x == y
+		}
+		if x.Value != y.Value {
+			return false
+		}
+		if x.DoubleQuotes != y.DoubleQuotes {
+			return false
+		}
+		if x.Error != y.Error {
+			return false
+		}
+		return true
 	case *ir.BitwiseAndExpr:
 		y, ok := y.(*ir.BitwiseAndExpr)
 		if !ok || x == nil || y == nil {

--- a/src/ir/node_types.go
+++ b/src/ir/node_types.go
@@ -815,12 +815,23 @@ type MagicConstant struct {
 // The $Value contains interpreted string bytes, if you need a raw
 // string value, use positions and fetch relevant the source bytes.
 //
-// DoubleQuotes tell whether originally this string literal was ""-quoted.
+// $DoubleQuotes tell whether originally this string literal was ""-quoted.
 type String struct {
 	FreeFloating freefloating.Collection
 	Position     *position.Position
 	Value        string
 	DoubleQuotes bool
+}
+
+// BadString is a string that we couldn't interpret correctly.
+// The $Value contains uninterpreted (raw) string bytes.
+// $Error contains the reason why this string is "bad".
+type BadString struct {
+	FreeFloating freefloating.Collection
+	Position     *position.Position
+	Value        string
+	DoubleQuotes bool
+	Error        string
 }
 
 // BreakStmt is a `break $Expr` statement.

--- a/src/ir/walk.go
+++ b/src/ir/walk.go
@@ -277,6 +277,13 @@ func (n *AssignShiftRight) Walk(v Visitor) {
 	v.LeaveNode(n)
 }
 
+func (n *BadString) Walk(v Visitor) {
+	if !v.EnterNode(n) {
+		return
+	}
+	v.LeaveNode(n)
+}
+
 func (n *BitwiseAndExpr) Walk(v Visitor) {
 	if !v.EnterNode(n) {
 		return

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -163,6 +163,9 @@ func (b *blockLinter) enterNode(n ir.Node) {
 
 	case *ir.InterfaceStmt:
 		b.checkInterfaceStmt(n)
+
+	case *ir.BadString:
+		b.report(n, LevelSyntax, "syntax", "%s", n.Error)
 	}
 }
 

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -12,6 +12,19 @@ import (
 	"github.com/VKCOM/noverify/src/meta"
 )
 
+func TestBadString(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+$_ = "\u{";
+$_ = "\u{zzzz}";
+`)
+	test.Expect = []string{
+		`missing closing '}' for UTF-8 sequence`,
+		`decode UTF-8 codepoints: invalid syntax`,
+	}
+	test.RunAndMatch()
+}
+
 func TestStringNoQuotes(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 $arr = [];


### PR DESCRIPTION
Instead, emit BadString with a special Error field
that can be examined by the linter later to emit a warning.

php-parser does only partial strings validation, so
we might encounter badly encoded UTF-8 escapes as
well as some other issues. We'll report them as a
syntax errors in linter.

Previously, interpretString() function assumed that
parsed string literals are valid PHP literals.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>