### PR TITLE
linter: disable phpdoc check by default

### DIFF
--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -263,7 +263,7 @@ thisFunctionExits();`,
 
 		{
 			Name:     "phpdoc",
-			Default:  true,
+			Default:  false,
 			Quickfix: false,
 			Comment:  `Report missing phpdoc on public methods.`,
 			Before: `public function process($acts, $config) {


### PR DESCRIPTION
Requiring phpdoc for public methods is good,
but for most projects it generates 90% of warnings
and it may be considered to be an unpleasant noise.

It's better to make NoVerify more user-friendly by
default, without any flags override (as it was a while ago).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>