### PR TITLE
solver: fixed error with incorrect type inference for static::method calls

### DIFF
--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -52,7 +52,11 @@ func (r *resolver) collectMethodCallTypes(out, possibleTypes map[string]struct{}
 
 func (r *resolver) resolveType(class, typ string) map[string]struct{} {
 	res := r.resolveTypeNoLateStaticBinding(class, typ)
-	r.visited[typ] = res
+	if typ == "static" {
+		r.visited[typ+class] = res
+	} else {
+		r.visited[typ] = res
+	}
 
 	if _, ok := res["static"]; ok {
 		delete(res, "static")

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -615,6 +615,51 @@ func TestStaticResolutionInsideSameClass(t *testing.T) {
 	test.RunAndMatch()
 }
 
+func TestStaticResolutionInsideOtherStaticResolution(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+	class SomeMainClass extends ParentClass {
+		/**
+		* @var string
+		*/
+		public $testProperty = '';
+		
+		/**
+		* Some test method
+		*/
+		public function testMethod() {}
+	}
+	
+	class ParentClass {
+		/** @return static Some */
+		public static function findOne() {
+		// static here
+			return static::findByCondition();
+		}
+		
+		/** @return static Some */
+		public static function findByCondition() {
+			// and static here
+			$_ = static::find();
+			return new static();
+		}
+		
+		/** @return int object_id */
+		public static function find() {
+			return 0;
+		}
+	}
+	
+	function f() {
+		$result = '';
+		
+		$objectB = SomeMainClass::findOne();
+		$objectB->testMethod();
+		
+		$result .= $objectB->testProperty;
+		echo $result;
+	}`)
+}
+
 func TestInheritanceLoop(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
During type inference for a static::method call,
if the calling function internally makes another
static::method2 call, then a collision occurs
during type resolution.

To solve it, for "static" in r.visited,
"static" + class name is now stored as a key,
not just "static".

Fixes #776