### PR TITLE
ir/irutil: fixed bug where assign null coalesce gave DiscardExpr warning

### DIFF
--- a/src/ir/irutil/irtutil.go
+++ b/src/ir/irutil/irtutil.go
@@ -59,7 +59,8 @@ func IsAssign(n ir.Node) bool {
 		*ir.AssignShiftRight,
 		*ir.AssignMinus,
 		*ir.AssignMod,
-		*ir.AssignMul:
+		*ir.AssignMul,
+		*ir.AssignCoalesce:
 		return true
 	default:
 		return false

--- a/src/tests/checkers/discard_expr_test.go
+++ b/src/tests/checkers/discard_expr_test.go
@@ -191,6 +191,9 @@ class Foo {
     return self::$x;
   }
 }
+
+$a = 10;
+$xs ??= $a; // Ok
 `)
 	test.Expect = []string{
 		`expression evaluated but not used`,


### PR DESCRIPTION
Fixes #786 