### PR TITLE
linter: fixed type inference for callback arguments if they have type hint

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1370,10 +1370,17 @@ func (d *RootWalker) parseTypeNode(n ir.Node) (typ meta.TypesMap, ok bool) {
 func (d *RootWalker) callbackParamByIndex(param ir.Node, argType meta.TypesMap) meta.FuncParam {
 	p := param.(*ir.Parameter)
 	v := p.Variable
+
 	var typ meta.TypesMap
-	argType.Iterate(func(t string) {
-		typ = typ.AppendString(meta.WrapElemOf(t))
-	})
+	tp, ok := d.parseTypeNode(p.VariableType)
+	if ok {
+		typ = tp
+	} else {
+		argType.Iterate(func(t string) {
+			typ = typ.AppendString(meta.WrapElemOf(t))
+		})
+	}
+
 	arg := meta.FuncParam{
 		IsRef: p.ByRef,
 		Name:  v.Name,

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -2303,6 +2303,40 @@ array_reduce($foo_array, function($carry, $item) {
   exprtype($item, "\Foo");
 });
 
+// mixed array, but function args with type hints
+$mixed_arr = [];
+usort($mixed_arr, function(Foo $a, Foo $b) {
+  exprtype($a, "\Foo");
+  exprtype($b, "\Foo");
+});
+
+$mixed_arr_2 = [];
+usort($mixed_arr_2, function(int $a, int $b) {
+  exprtype($a, "int");
+  exprtype($b, "int");
+});
+
+// mixed array, but not all function args have type hints
+$mixed_arr_3 = [];
+usort($mixed_arr_3, function(Foo $a, $b) {
+  exprtype($a, "\Foo");
+  exprtype($b, "mixed");
+});
+
+// non mixed array, but function args with type hints
+$non_mixed_arr = [1, 2, 3];
+usort($non_mixed_arr, function(int $a, int $b) {
+  exprtype($a, "int");
+  exprtype($b, "int");
+});
+
+// non mixed array, but not all function args have type hints
+$non_mixed_arr_2 = [new Foo, new Foo, new Foo];
+usort($non_mixed_arr_2, function(Foo $a, $b) {
+  exprtype($a, "\Foo");
+  exprtype($b, "\Foo");
+});
+
 some_function_without_model(function($b) {
   exprtype($b, "mixed");
 }, $d);


### PR DESCRIPTION
Due to the introduction of a new
`parseFuncArgsForCallback` function
for processing callback arguments,
we lost the type hints processing,
since an early exit from `parseFuncArgs`
is done and does not reach the type
hints processing. Therefore, we have
to process type hints explicitly.