### PR TITLE
linter: utils moved to a separate folder

### DIFF
--- a/src/linter/and_walker.go
+++ b/src/linter/and_walker.go
@@ -2,6 +2,7 @@ package linter
 
 import (
 	"github.com/VKCOM/noverify/src/ir"
+	"github.com/VKCOM/noverify/src/linter/utils"
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/solver"
 )
@@ -45,7 +46,7 @@ func (a *andWalker) EnterNode(w ir.Node) (res bool) {
 
 	case *ir.IssetExpr:
 		for _, v := range n.Variables {
-			varNode := findVarNode(v)
+			varNode := utils.FindVarNode(v)
 			if varNode == nil {
 				continue
 			}

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/VKCOM/noverify/src/constfold"
 	"github.com/VKCOM/noverify/src/ir"
 	"github.com/VKCOM/noverify/src/ir/irutil"
+	"github.com/VKCOM/noverify/src/linter/utils"
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/php/parser/freefloating"
 	"github.com/VKCOM/noverify/src/quickfix"
@@ -219,7 +220,7 @@ func (b *blockLinter) checkBinaryDupArgs(n, left, right ir.Node) {
 		return
 	}
 	if nodeEqual(b.walker.r.ctx.st, left, right) {
-		b.report(n, LevelWarning, "dupSubExpr", "duplicated operands value in %s expression", binaryOpString(n))
+		b.report(n, LevelWarning, "dupSubExpr", "duplicated operands value in %s expression", utils.BinaryOpString(n))
 	}
 }
 

--- a/src/meta/typesmap.go
+++ b/src/meta/typesmap.go
@@ -5,6 +5,8 @@ import (
 	"encoding/gob"
 	"sort"
 	"strings"
+
+	"github.com/VKCOM/noverify/src/phpdoc"
 )
 
 // Preallocated and shared immutable type maps.
@@ -389,4 +391,9 @@ func (m TypesMap) ArrayElemLazyType() TypesMap {
 		mm[UnwrapArrayOf(typ)] = struct{}{}
 	}
 	return TypesMap{m: mm, flags: m.flags}
+}
+
+func (m TypesMap) ToTypeExpr(p *phpdoc.TypeParser) phpdoc.Type {
+	typeString := m.String()
+	return p.Parse(typeString)
 }


### PR DESCRIPTION
We need to get rid of the fully dependency on the linter package
in order to be able to refactor the code easier in the future
and not get cycle import errors.