### PR TITLE
linter: added beforeEnterFile in RootWalker and BeforeEnterFile in RootChecker

### DIFF
--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -81,6 +81,7 @@ type BlockChecker interface {
 // RootChecker is a custom linter that should operator only at root level.
 // Block level analysis (function and method bodies and all if/else/for/etc blocks) must be performed in BlockChecker.
 type RootChecker interface {
+	BeforeEnterFile()
 	AfterLeaveFile()
 	BeforeEnterNode(ir.Node)
 	AfterEnterNode(ir.Node)

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -2018,6 +2018,12 @@ func (d *RootWalker) parseClassPHPDoc(n ir.Node, doc []phpdoc.CommentPart) class
 	return result
 }
 
+func (d *RootWalker) beforeEnterFile() {
+	for _, c := range d.custom {
+		c.BeforeEnterFile()
+	}
+}
+
 func (d *RootWalker) afterLeaveFile() {
 	for _, c := range d.custom {
 		c.AfterLeaveFile()

--- a/src/linter/worker.go
+++ b/src/linter/worker.go
@@ -14,6 +14,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/quasilyte/regex/syntax"
+
 	"github.com/VKCOM/noverify/src/git"
 	"github.com/VKCOM/noverify/src/inputs"
 	"github.com/VKCOM/noverify/src/ir"
@@ -23,7 +25,6 @@ import (
 	"github.com/VKCOM/noverify/src/php/parser/php7"
 	"github.com/VKCOM/noverify/src/quickfix"
 	"github.com/VKCOM/noverify/src/workspace"
-	"github.com/quasilyte/regex/syntax"
 )
 
 // Worker is a linter handle that is expected to be executed in a single goroutine context.
@@ -256,6 +257,7 @@ func (w *Worker) analyzeFile(filename string, contents []byte, parser *php7.Pars
 	walker.InitFromParser(contents, parser)
 	walker.InitCustom()
 
+	walker.beforeEnterFile()
 	rootIR.Walk(walker)
 	if meta.IsIndexingComplete() {
 		AnalyzeFileRootLevel(rootIR, walker)


### PR DESCRIPTION
In order to be able to implement a third-party `RootChecker` with a state change before entering the file, we need these two methods.