### PR TITLE
checkers: fix regexpsimplify handling of named capture alt forms

### DIFF
--- a/src/tests/checkers/regexpsimplify_test.go
+++ b/src/tests/checkers/regexpsimplify_test.go
@@ -6,6 +6,23 @@ import (
 	"github.com/VKCOM/noverify/src/linttest"
 )
 
+func TestRESimplifyNamedCaptureForms(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{`stubs/phpstorm-stubs/pcre/pcre.php`}
+	test.AddFile(`<?php
+function f($s) {
+  preg_match('~(?P<abc>[0-9])~', $s);
+  preg_match('~(?<abc>[0-9])~', $s);
+  preg_match("~(?'abc'[0-9])~", $s); // Ignore due to the FormNamedCaptureQuote
+}
+`)
+	test.Expect = []string{
+		`May re-write '~(?P<abc>[0-9])~' as '~(?P<abc>\d)~'`,
+		`May re-write '~(?<abc>[0-9])~' as '~(?<abc>\d)~'`,
+	}
+	test.RunAndMatch()
+}
+
 func TestRESimplifyMixed(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.LoadStubs = []string{`stubs/phpstorm-stubs/pcre/pcre.php`}


### PR DESCRIPTION
Named capture always printed like ?P<name>, but it can have 2
more forms: ?<name> and ?'name'.

The quoted format is extra tricky as we always suggest '-quoted
replacements; we give up if we find this form to avoid invalid
suggestions. It's possible to suggest "-quoted literals in
the future, but it may require more changes (and tests).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>