### PR TITLE
constfold: refactoring related to constants

### DIFF
--- a/src/constfold/binary_op.go
+++ b/src/constfold/binary_op.go
@@ -54,7 +54,7 @@ func Concat(x, y meta.ConstValue) meta.ConstValue {
 	v1, ok1 := x.ToString()
 	v2, ok2 := y.ToString()
 	if ok1 && ok2 {
-		return meta.NewStringConstant(v1 + v2)
+		return meta.NewStringConst(v1 + v2)
 	}
 	return meta.UnknownValue
 }
@@ -65,7 +65,7 @@ func Or(x, y meta.ConstValue) meta.ConstValue {
 	v1, ok1 := x.ToBool()
 	v2, ok2 := y.ToBool()
 	if ok1 && ok2 {
-		return meta.NewBoolConstant(v1 || v2)
+		return meta.NewBoolConst(v1 || v2)
 	}
 	return meta.UnknownValue
 }
@@ -76,7 +76,7 @@ func And(x, y meta.ConstValue) meta.ConstValue {
 	v1, ok1 := x.ToBool()
 	v2, ok2 := y.ToBool()
 	if ok1 && ok2 {
-		return meta.NewBoolConstant(v1 && v2)
+		return meta.NewBoolConst(v1 && v2)
 	}
 	return meta.UnknownValue
 }

--- a/src/constfold/eval.go
+++ b/src/constfold/eval.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Eval tries to compute the e using the constant expressions folding.
-// In case of failure, meta.UnknownValue and false flag is returned.
+// In case of failure, meta.UnknownValue is returned.
 func Eval(st *meta.ClassParseState, e ir.Node) meta.ConstValue {
 	// TODO: support more operators and some builtin PHP functions like strlen.
 

--- a/src/constfold/eval.go
+++ b/src/constfold/eval.go
@@ -11,19 +11,14 @@ import (
 
 // Eval tries to compute the e using the constant expressions folding.
 // In case of failure, meta.UnknownValue and false flag is returned.
-func Eval(st *meta.ClassParseState, e ir.Node) (meta.ConstValue, bool) {
-	res := eval(st, e)
-	return res, res.Type != meta.Undefined
-}
-
-func eval(st *meta.ClassParseState, e ir.Node) meta.ConstValue {
+func Eval(st *meta.ClassParseState, e ir.Node) meta.ConstValue {
 	// TODO: support more operators and some builtin PHP functions like strlen.
 
 	switch e := e.(type) {
 	case *ir.Argument:
-		return eval(st, e.Expr)
+		return Eval(st, e.Expr)
 	case *ir.ParenExpr:
-		return eval(st, e.Expr)
+		return Eval(st, e.Expr)
 
 	case *ir.ClassConstFetchExpr:
 		if !meta.IsIndexingComplete() {
@@ -56,32 +51,32 @@ func eval(st *meta.ClassParseState, e ir.Node) meta.ConstValue {
 		return info.Value
 
 	case *ir.UnaryMinusExpr:
-		return Neg(eval(st, e.Expr))
+		return Neg(Eval(st, e.Expr))
 
 	case *ir.BooleanNotExpr:
-		return Not(eval(st, e.Expr))
+		return Not(Eval(st, e.Expr))
 	case *ir.BooleanAndExpr:
-		return And(eval(st, e.Left), eval(st, e.Right))
+		return And(Eval(st, e.Left), Eval(st, e.Right))
 	case *ir.BooleanOrExpr:
-		return Or(eval(st, e.Left), eval(st, e.Right))
+		return Or(Eval(st, e.Left), Eval(st, e.Right))
 	case *ir.LogicalAndExpr:
-		return And(eval(st, e.Left), eval(st, e.Right))
+		return And(Eval(st, e.Left), Eval(st, e.Right))
 	case *ir.LogicalOrExpr:
-		return Or(eval(st, e.Left), eval(st, e.Right))
+		return Or(Eval(st, e.Left), Eval(st, e.Right))
 
 	case *ir.PlusExpr:
-		return Plus(eval(st, e.Left), eval(st, e.Right))
+		return Plus(Eval(st, e.Left), Eval(st, e.Right))
 	case *ir.MinusExpr:
-		return Minus(eval(st, e.Left), eval(st, e.Right))
+		return Minus(Eval(st, e.Left), Eval(st, e.Right))
 	case *ir.MulExpr:
-		return Mul(eval(st, e.Left), eval(st, e.Right))
+		return Mul(Eval(st, e.Left), Eval(st, e.Right))
 	case *ir.ConcatExpr:
-		return Concat(eval(st, e.Left), eval(st, e.Right))
+		return Concat(Eval(st, e.Left), Eval(st, e.Right))
 
 	case *ir.BitwiseAndExpr:
-		return BitAnd(eval(st, e.Left), eval(st, e.Right))
+		return BitAnd(Eval(st, e.Left), Eval(st, e.Right))
 	case *ir.BitwiseOrExpr:
-		return BitOr(eval(st, e.Left), eval(st, e.Right))
+		return BitOr(Eval(st, e.Left), Eval(st, e.Right))
 
 	case *ir.Lnumber:
 		value, err := strconv.ParseInt(e.Value, 0, 64)

--- a/src/constfold/unary_op.go
+++ b/src/constfold/unary_op.go
@@ -10,7 +10,7 @@ func Not(x meta.ConstValue) meta.ConstValue {
 	if !ok {
 		return meta.UnknownValue
 	}
-	return meta.NewBoolConstant(!v)
+	return meta.NewBoolConst(!v)
 }
 
 // Neg performs unary "-".

--- a/src/ir/normalize/normalize.go
+++ b/src/ir/normalize/normalize.go
@@ -247,8 +247,8 @@ func (norm *normalizer) normalizedStmtExpr(e ir.Node) ir.Node {
 }
 
 func (norm *normalizer) normalizedExpr(e ir.Node) ir.Node {
-	constFolded := constfold.Eval(norm.st, e)
-	if constFolded.Type != meta.Undefined {
+	constFolded, ok := constfold.Eval(norm.st, e)
+	if ok {
 		if e2 := constToIR(constFolded); e2 != nil {
 			return e2
 		}

--- a/src/ir/normalize/normalize.go
+++ b/src/ir/normalize/normalize.go
@@ -247,8 +247,8 @@ func (norm *normalizer) normalizedStmtExpr(e ir.Node) ir.Node {
 }
 
 func (norm *normalizer) normalizedExpr(e ir.Node) ir.Node {
-	constFolded, ok := constfold.Eval(norm.st, e)
-	if ok {
+	constFolded := constfold.Eval(norm.st, e)
+	if constFolded.IsValid() {
 		if e2 := constToIR(constFolded); e2 != nil {
 			return e2
 		}

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -525,8 +525,8 @@ func (b *blockLinter) checkArray(arr *ir.ArrayExpr) {
 			key = k.Value
 			constKey = true
 		case *ir.ConstFetchExpr:
-			v, ok := constfold.Eval(b.walker.r.ctx.st, k)
-			if !ok {
+			v := constfold.Eval(b.walker.r.ctx.st, k)
+			if !v.IsValid() {
 				continue
 			}
 

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -525,8 +525,8 @@ func (b *blockLinter) checkArray(arr *ir.ArrayExpr) {
 			key = k.Value
 			constKey = true
 		case *ir.ConstFetchExpr:
-			v := constfold.Eval(b.walker.r.ctx.st, k)
-			if v.Type == meta.Undefined {
+			v, ok := constfold.Eval(b.walker.r.ctx.st, k)
+			if !ok {
 				continue
 			}
 

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -944,7 +944,7 @@ func (d *RootWalker) enterClassConstList(s *ir.ClassConstListStmt) bool {
 		d.checkCommentMisspellings(c, c.PhpDocComment)
 		typ := solver.ExprTypeLocal(d.scope(), d.ctx.st, c.Expr)
 
-		value := constfold.Eval(d.ctx.st, c.Expr)
+		value, _ := constfold.Eval(d.ctx.st, c.Expr)
 
 		// TODO: handle duplicate constant
 		cl.Constants[nm] = meta.ConstInfo{
@@ -1623,7 +1623,7 @@ func (d *RootWalker) enterFunctionCall(s *ir.FunctionCallExpr) bool {
 		d.meta.Constants = make(meta.ConstantsMap)
 	}
 
-	value := constfold.Eval(d.ctx.st, valueArg)
+	value, _ := constfold.Eval(d.ctx.st, valueArg)
 
 	d.meta.Constants[`\`+strings.TrimFunc(str.Value, isQuote)] = meta.ConstInfo{
 		Pos:   d.getElementPos(s),
@@ -1711,7 +1711,7 @@ func (d *RootWalker) enterConstList(lst *ir.ConstListStmt) bool {
 	for _, sNode := range lst.Consts {
 		s := sNode.(*ir.ConstantStmt)
 
-		value := constfold.Eval(d.ctx.st, s.Expr)
+		value, _ := constfold.Eval(d.ctx.st, s.Expr)
 
 		id := s.ConstantName
 		nm := d.ctx.st.Namespace + `\` + id.Value

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -944,7 +944,7 @@ func (d *RootWalker) enterClassConstList(s *ir.ClassConstListStmt) bool {
 		d.checkCommentMisspellings(c, c.PhpDocComment)
 		typ := solver.ExprTypeLocal(d.scope(), d.ctx.st, c.Expr)
 
-		value, _ := constfold.Eval(d.ctx.st, c.Expr)
+		value := constfold.Eval(d.ctx.st, c.Expr)
 
 		// TODO: handle duplicate constant
 		cl.Constants[nm] = meta.ConstInfo{
@@ -1623,7 +1623,7 @@ func (d *RootWalker) enterFunctionCall(s *ir.FunctionCallExpr) bool {
 		d.meta.Constants = make(meta.ConstantsMap)
 	}
 
-	value, _ := constfold.Eval(d.ctx.st, valueArg)
+	value := constfold.Eval(d.ctx.st, valueArg)
 
 	d.meta.Constants[`\`+strings.TrimFunc(str.Value, isQuote)] = meta.ConstInfo{
 		Pos:   d.getElementPos(s),
@@ -1711,7 +1711,7 @@ func (d *RootWalker) enterConstList(lst *ir.ConstListStmt) bool {
 	for _, sNode := range lst.Consts {
 		s := sNode.(*ir.ConstantStmt)
 
-		value, _ := constfold.Eval(d.ctx.st, s.Expr)
+		value := constfold.Eval(d.ctx.st, s.Expr)
 
 		id := s.ConstantName
 		nm := d.ctx.st.Namespace + `\` + id.Value

--- a/src/meta/const_value.go
+++ b/src/meta/const_value.go
@@ -61,7 +61,7 @@ func (c ConstValue) IsValid() bool {
 
 // GetInt returns the value stored in c.Value cast to int type.
 //
-// Used with care, it can panic if the type is not equal to the
+// Should be used with care, it can panic if the type is not equal to the
 // required one. Usually used in places where the type has already
 // been clearly defined and the probability of panic is 0.
 func (c ConstValue) GetInt() int64 {
@@ -70,7 +70,7 @@ func (c ConstValue) GetInt() int64 {
 
 // GetFloat returns the value stored in c.Value cast to float type.
 //
-// Used with care, it can panic if the type is not equal to the
+// Should be used with care, it can panic if the type is not equal to the
 // required one. Usually used in places where the type has already
 // been clearly defined and the probability of panic is 0.
 func (c ConstValue) GetFloat() float64 {
@@ -79,7 +79,7 @@ func (c ConstValue) GetFloat() float64 {
 
 // GetString returns the value stored in c.Value cast to string type.
 //
-// Used with care, it can panic if the type is not equal to the
+// Should be used with care, it can panic if the type is not equal to the
 // required one. Usually used in places where the type has already
 // been clearly defined and the probability of panic is 0.
 func (c ConstValue) GetString() string {
@@ -88,7 +88,7 @@ func (c ConstValue) GetString() string {
 
 // GetBool returns the value stored in c.Value cast to bool type.
 //
-// Used with care, it can panic if the type is not equal to the
+// Should be used with care, it can panic if the type is not equal to the
 // required one. Usually used in places where the type has already
 // been clearly defined and the probability of panic is 0.
 func (c ConstValue) GetBool() bool {

--- a/src/meta/const_value.go
+++ b/src/meta/const_value.go
@@ -54,6 +54,11 @@ func NewBoolConst(v bool) ConstValue {
 	return ConstValue{Type: Bool, Value: v}
 }
 
+// IsValid checks that the value is valid and its type is not undefined.
+func (c ConstValue) IsValid() bool {
+	return c.Type != Undefined
+}
+
 // GetInt returns the value stored in c.Value cast to int type.
 //
 // Used with care, it can panic if the type is not equal to the

--- a/src/meta/const_value.go
+++ b/src/meta/const_value.go
@@ -23,43 +23,69 @@ var (
 	FalseValue   = ConstValue{Type: Bool, Value: false}
 )
 
+// ConstValue structure is used to store
+// the value and type of a constant.
 type ConstValue struct {
 	Type  ConstValueType
 	Value interface{}
 }
 
+// NewIntConst returns a new constant value with the
+// preset int type and the passed value v.
 func NewIntConst(v int64) ConstValue {
 	return ConstValue{Type: Integer, Value: v}
 }
 
+// NewFloatConst returns a new constant value with the
+// preset float type and the passed value v.
 func NewFloatConst(v float64) ConstValue {
 	return ConstValue{Type: Float, Value: v}
 }
 
-func NewStringConstant(v string) ConstValue {
+// NewStringConst returns a new constant value with the
+// preset string type and the passed value v.
+func NewStringConst(v string) ConstValue {
 	return ConstValue{Type: String, Value: v}
 }
 
-func NewBoolConstant(v bool) ConstValue {
+// NewBoolConst returns a new constant value with the
+// preset bool type and the passed value v.
+func NewBoolConst(v bool) ConstValue {
 	return ConstValue{Type: Bool, Value: v}
 }
 
 // GetInt returns the value stored in c.Value cast to int type.
+//
+// Used with care, it can panic if the type is not equal to the
+// required one. Usually used in places where the type has already
+// been clearly defined and the probability of panic is 0.
 func (c ConstValue) GetInt() int64 {
 	return c.Value.(int64)
 }
 
 // GetFloat returns the value stored in c.Value cast to float type.
+//
+// Used with care, it can panic if the type is not equal to the
+// required one. Usually used in places where the type has already
+// been clearly defined and the probability of panic is 0.
 func (c ConstValue) GetFloat() float64 {
 	return c.Value.(float64)
 }
 
 // GetString returns the value stored in c.Value cast to string type.
+//
+// Used with care, it can panic if the type is not equal to the
+// required one. Usually used in places where the type has already
+// been clearly defined and the probability of panic is 0.
 func (c ConstValue) GetString() string {
 	return c.Value.(string)
 }
 
 // GetBool returns the value stored in c.Value cast to bool type.
+//
+// Used with care, it can panic if the type is not equal to the
+// required one. Usually used in places where the type has already
+// been clearly defined and the probability of panic is 0.
 func (c ConstValue) GetBool() bool {
 	return c.Value.(bool)
 }
@@ -114,6 +140,25 @@ func (c ConstValue) ToString() (string, bool) {
 		return c.GetString(), true
 	}
 	return "", false
+}
+
+// IsEqual checks for equality with the passed constant value.
+//
+// If any of the constants are undefined, false is returned.
+func (c ConstValue) IsEqual(v ConstValue) bool {
+	if v.Type == Undefined || c.Type == Undefined {
+		return false
+	}
+
+	return c.Value == v.Value
+}
+
+func (c ConstValue) String() string {
+	if c.Type == Undefined {
+		return "Undefined type"
+	}
+
+	return fmt.Sprintf("%s(%v)", c.Type, c.Value)
 }
 
 func (c ConstValue) GobEncode() ([]byte, error) {
@@ -193,27 +238,4 @@ func (c *ConstValue) GobDecode(buf []byte) error {
 	c.Type = tp
 
 	return nil
-}
-
-func (c ConstValue) String() string {
-	if c.Type == Undefined {
-		return "Undefined type"
-	}
-
-	return fmt.Sprintf("%s(%v)", c.Type, c.Value)
-}
-
-func (c ConstValue) IsEqual(v ConstValue) bool {
-	if v.Type == Undefined || c.Type == Undefined {
-		return false
-	}
-
-	return c.Value == v.Value
-}
-
-type ConstInfo struct {
-	Pos         ElementPosition
-	Typ         TypesMap
-	AccessLevel AccessLevel
-	Value       ConstValue
 }

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -366,6 +366,13 @@ type PropertyInfo struct {
 	AccessLevel AccessLevel
 }
 
+type ConstInfo struct {
+	Pos         ElementPosition
+	Typ         TypesMap
+	AccessLevel AccessLevel
+	Value       ConstValue
+}
+
 type ClassFlags uint8
 
 const (


### PR DESCRIPTION
In the `eval` function, some direct constructs of the
`meta.ConstValue` structure has been replaced with
`meta.New[Type]Const` functions.

`meta.New[Type]Const` function names have been normalized.

A comment has been added for the `ConstValue.Get[Type]`,
`ConstValue.New[Type]Const`, `ConstValue.IsEqual` functions
and `ConstValue` structure.

The ConstInfo structure has been moved to a better
location – `metainfo.go`.