### PR TITLE
workspace: fixed bug when untracked binary was added in git mode and this led to panic

### DIFF
--- a/src/workspace/files.go
+++ b/src/workspace/files.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/VKCOM/noverify/src/git"
 	"github.com/karrick/godirwalk"
+
+	"github.com/VKCOM/noverify/src/git"
 )
 
 type ReadCallback func(ch chan FileInfo)
@@ -99,6 +100,10 @@ func readFilenames(ch chan<- FileInfo, filename string, filter *FilenameFilter) 
 
 	if !st.IsDir() {
 		if filter.IgnoreFile(filename) {
+			return
+		}
+
+		if !isPHPExtension(filename) {
 			return
 		}
 


### PR DESCRIPTION
In git mode, in the case of untracked files, the `gitParseUntracked` function is called, which passes the list of files to the `workspace.ReadFilenames` function, in which the `readFilenames` function is called for each file.

The problem is that if not a directory is passed, then the following code is executed

```go
if !st.IsDir() {
  if filter.IgnoreFile(filename) {
    return
  }

  ch <- FileInfo{Filename: filename}
  return
}
```

Where there is no extension check, which is present when traversing a folder below the function.
Let's add a check here and the error will go away.