### PR TITLE
phpgrep: add "call" meta node

### DIFF
--- a/src/phpgrep/compile.go
+++ b/src/phpgrep/compile.go
@@ -93,6 +93,8 @@ func (c *compiler) EnterNode(n ir.Node) bool {
 		v.Expr = anyNum{metaNode{name: name}}
 	case "expr":
 		v.Expr = anyExpr{metaNode{name: name}}
+	case "call":
+		v.Expr = anyCall{metaNode{name: name}}
 	case "const":
 		v.Expr = anyConst{metaNode{name: name}}
 	case "func":

--- a/src/phpgrep/matcher.go
+++ b/src/phpgrep/matcher.go
@@ -753,6 +753,13 @@ func (m *matcher) eqVar(state *matcherState, x *ir.Var, y ir.Node) bool {
 		}
 	case anyExpr:
 		return nodeIsExpr(y) && m.matchNamed(state, vn.name, y)
+	case anyCall:
+		switch y.(type) {
+		case *ir.FunctionCallExpr, *ir.StaticCallExpr, *ir.MethodCallExpr:
+			return m.matchNamed(state, vn.name, y)
+		default:
+			return false
+		}
 	}
 
 	if y, ok := y.(*ir.Var); ok {

--- a/src/phpgrep/matcher_test.go
+++ b/src/phpgrep/matcher_test.go
@@ -379,6 +379,12 @@ func TestMatch(t *testing.T) {
 		{`${"func"}`, `function($x) {}`},
 		{`${"func"}`, `function() { return 1; }`},
 
+		{`${"call"}`, `f()`},
+		{`${"call"}`, `$o->method()`},
+		{`${"call"}`, `C::method()`},
+		{`${"call"}`, `$a[0]->method()`},
+		{`${"x:call"} + ${"x:call"}`, `f() + f()`},
+
 		{`1`, `1`},
 		{`(1)`, `(1)`},
 		{`((1))`, `((1))`},
@@ -534,6 +540,10 @@ func TestMatchNegative(t *testing.T) {
 		{`${"func"}`, `1`},
 		{`${"func"}`, `$x`},
 		{`${"func"}`, `f()`},
+
+		{`${"call"}`, `10`},
+		{`${"call"}`, `$x[0]`},
+		{`${"x:call"} + ${"x:call"}`, `f() + g()`},
 
 		{`(1)`, `1`},
 		{`((1))`, `(1)`},

--- a/src/phpgrep/meta_nodes.go
+++ b/src/phpgrep/meta_nodes.go
@@ -21,5 +21,6 @@ type (
 	anyStr1  struct{ metaNode }
 	anyNum   struct{ metaNode }
 	anyExpr  struct{ metaNode }
+	anyCall  struct{ metaNode }
 	anyFunc  struct{ metaNode }
 )

--- a/src/phpgrep/pattern_language.md
+++ b/src/phpgrep/pattern_language.md
@@ -60,6 +60,7 @@ matcher_class = <see the table of supported classes below>
 | `var` | Variable |
 | `func` | Anonymous function/closure expression |
 | `expr` | Any expression |
+| `call` | Function or method (static or not) call expression |
 
 Some examples of complete matcher expressions:
 * `${'*'}` - matches any number of nodes


### PR DESCRIPTION
Matches FunctionCall, MethodCall, StaticCall.

Useful for the command-line github.com/quasilyte/phpgrep tool.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>