### PR TITLE
ir/codegen: don't generate code for PhpDoc types

### DIFF
--- a/src/ir/codegen/gen_clone.go
+++ b/src/ir/codegen/gen_clone.go
@@ -59,6 +59,8 @@ func (g *genClone) writeCloneCase(w *bytes.Buffer, pkg *packageData, typ *typeDa
 			// Do nothing.
 		case "*github.com/VKCOM/noverify/src/php/parser/position.Position":
 			// Do nothing.
+		case "[]github.com/VKCOM/noverify/src/phpdoc.CommentPart":
+			// Do nothing.
 		case "string", "bool":
 			// Do nothing.
 		case "ir.Class":

--- a/src/ir/codegen/gen_equal.go
+++ b/src/ir/codegen/gen_equal.go
@@ -52,6 +52,8 @@ func (g *genEqual) writeCompare(w *bytes.Buffer, pkg *packageData, typ *typeData
 			// Do nothing.
 		case "*github.com/VKCOM/noverify/src/php/parser/position.Position":
 			// Do nothing.
+		case "[]github.com/VKCOM/noverify/src/phpdoc.CommentPart":
+			// Do nothing.
 		case "ir.Class":
 			fmt.Fprintf(w, "    if !classEqual(x.%[1]s, y.%[1]s) { return false }\n", field.Name())
 		default:


### PR DESCRIPTION
After we switched to the pre-parsed phpdoc in IR nodes,
we did not run go generate on the src/ir, so the bug was unnoticed.