### PR TITLE
cmd: fixed a problem with displaying a message about the possibility …

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -363,7 +363,7 @@ func analyzeReports(l *linterRunner, cfg *MainConfig, diff []*linter.Report) (cr
 		}
 	}
 
-	containsAutofixableReports = haveAutofixableReports(diff)
+	containsAutofixableReports = haveAutofixableReports(filtered)
 
 	if l.args.outputJSON {
 		type reportList struct {

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -325,6 +325,10 @@ func FormatReport(r *linter.Report) string {
 }
 
 func haveAutofixableReports(reports []*linter.Report) bool {
+	if len(reports) == 0 {
+		return false
+	}
+
 	declaredChecks := linter.GetDeclaredChecks()
 	checksWithQuickfix := make(map[string]struct{})
 


### PR DESCRIPTION
…to fix some errors using autofixes

Due to the fact that unfiltered reports were passed
to the check function, a situation could occur that
the report was not passed by the filter, but the
function checked it and returned the result that
there are reports with auto-fixes.