### PR TITLE
all: enabled scopelint + more gocritic checkers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - unconvert
     - unused
     - varcheck
+    - scopelint
   disable:
     - depguard
     - dupl
@@ -36,10 +37,87 @@ linters:
     - prealloc
     - gosec
   fast: false
+  linters:
+    enable:
+      - gocritic
+linters-settings:
+  gocritic:
+    enabled-checks:
+      - appendAssign
+      - appendCombine
+      - argOrder
+      - assignOp
+      - badCall
+      - badCond
+      - badRegexp
+      - boolExprSimplify
+      - captLocal
+      - caseOrder
+      - codegenComment
+      - commentFormatting
+      - commentedOutCode
+      - commentedOutImport
+      - defaultCaseOrder
+      - deferUnlambda
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupImport
+      - dupSubExpr
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - equalFold
+      - evalOrder
+      - exitAfterDefer
+      - filepathJoin
+      - flagDeref
+      - flagName
+      - ifElseChain
+      - importShadow
+      - indexAlloc
+      - initClause
+      - mapKey
+      - methodExprCall
+      - nestingReduce
+      - newDeref
+      - nilValReturn
+      - offBy1
+      - rangeExprCopy
+      - regexpMust
+      - regexpPattern
+      - regexpSimplify
+      - ruleguard
+      - singleCaseSwitch
+      - sloppyLen
+      - sloppyReassign
+      - sloppyTypeAssert
+      - sortSlice
+      - stringXbytes
+      - switchTrue
+      - truncateCmp
+      - typeAssertChain
+      - typeSwitchVar
+      - typeUnparen
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unnamedResult
+      - unnecessaryBlock
+      - unslice
+      - valSwap
+      - weakCond
+      - whyNoLint
+      - wrapperFunc
+      - yodaStyleExpr
+    settings:
+      ruleguard:
+        rules: "rules.go"
 
 issues:
   exclude-rules:
-    - path: php/parser/node
+    - path: php/parser
       linters:
         - gocritic
         - golint

--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -87,7 +87,7 @@ func parseEmbeddedRules(p *rules.Parser) ([]*rules.Set, error) {
 
 func appendRuleSet(rset *rules.Set, filter func(r rules.Rule) bool) {
 	appendRules := func(dst, src *rules.ScopedSet) {
-		for i, list := range src.RulesByKind {
+		for i, list := range &src.RulesByKind {
 			for _, r := range list {
 				if !filter(r) {
 					continue

--- a/src/constfold/eval.go
+++ b/src/constfold/eval.go
@@ -96,7 +96,7 @@ func Eval(st *meta.ClassParseState, e ir.Node) meta.ConstValue {
 		return meta.NewStringConst(e.Value)
 
 	case *ir.FunctionCallExpr:
-		// dirname(__FILE__)
+		// Only dirname(__FILE__) is const-folded right now.
 		if !meta.NameNodeEquals(e.Function, `dirname`) {
 			return meta.UnknownValue
 		}

--- a/src/ir/codegen/context.go
+++ b/src/ir/codegen/context.go
@@ -45,9 +45,9 @@ type codegenFile struct {
 	deps     []string
 }
 
-func (ctx *context) Debugf(format string, args ...interface{}) {
+func (ctx *context) Debugf(formatString string, args ...interface{}) {
 	if ctx.args.debug {
-		log.Println("DEBUG: " + fmt.Sprintf(format, args...))
+		log.Println("DEBUG: " + fmt.Sprintf(formatString, args...))
 	}
 }
 

--- a/src/ir/irconv/irconv_test.go
+++ b/src/ir/irconv/irconv_test.go
@@ -16,7 +16,8 @@ func BenchmarkInterpretString(b *testing.B) {
 		{name: "HarderInput", input: `\u{1f575} Hell\151, \x57orld! 💔`},
 	}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		b.Run(test.name+"Q1", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _ = interpretString(test.input, '\'')

--- a/src/langsrv/langsrv.go
+++ b/src/langsrv/langsrv.go
@@ -222,11 +222,11 @@ func handleTextDocumentDidOpen(req *baseRequest) error {
 		return err
 	}
 
-	uri := params.TextDocument.URI
-	lintdebug.Send("Open text document %s", uri)
+	u := params.TextDocument.URI
+	lintdebug.Send("Open text document %s", u)
 
-	if isFileScheme(uri) {
-		openFile(uri.Filename(), params.TextDocument.Text)
+	if isFileScheme(u) {
+		openFile(u.Filename(), params.TextDocument.Text)
 	}
 
 	return nil
@@ -238,11 +238,11 @@ func handleTextDocumentDidClose(req *baseRequest) error {
 		return err
 	}
 
-	uri := params.TextDocument.URI
-	lintdebug.Send("Close text document %s", uri)
+	u := params.TextDocument.URI
+	lintdebug.Send("Close text document %s", u)
 
-	if isFileScheme(uri) {
-		closeFile(uri.Filename())
+	if isFileScheme(u) {
+		closeFile(u.Filename())
 	}
 
 	return nil
@@ -259,10 +259,10 @@ func handleTextDocumentDidChange(req *baseRequest) error {
 		return nil
 	}
 
-	uri := params.TextDocument.URI
+	u := params.TextDocument.URI
 
-	if isFileScheme(uri) {
-		changeFile(uri.Filename(), params.ContentChanges[0].Text)
+	if isFileScheme(u) {
+		changeFile(u.Filename(), params.ContentChanges[0].Text)
 	}
 
 	return nil
@@ -284,12 +284,12 @@ func handleTextDocumentSymbol(req *baseRequest) error {
 	// TODO: make it actually safe
 
 	meta.OnIndexingComplete(func() {
-		uri := params.TextDocument.URI
+		u := params.TextDocument.URI
 
 		var result []vscode.SymbolInformation
 
-		if isFileScheme(uri) {
-			filename := uri.Filename()
+		if isFileScheme(u) {
+			filename := u.Filename()
 			res := meta.Info.GetMetaForFile(filename)
 
 			for _, classInfo := range res.Classes.H {

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -581,7 +581,8 @@ func (b *BlockWalker) handleTry(s *ir.TryStmt) bool {
 
 	// Assume that no code in try{} block has executed because exceptions can be thrown from anywhere.
 	// So we handle catches and finally blocks first.
-	for _, c := range s.Catches {
+	for i := range s.Catches {
+		c := s.Catches[i]
 		ctx := b.withNewContext(func() {
 			b.r.addScope(c, b.ctx.sc)
 			cc := c.(*ir.CatchStmt)
@@ -1208,11 +1209,12 @@ func (b *BlockWalker) handleIf(s *ir.IfStmt) bool {
 
 	walk := func(n ir.Node) (links int) {
 		// handle if (...) smth(); else other_thing(); // without braces
-		if els, ok := n.(*ir.ElseStmt); ok {
-			b.addStatement(els.Stmt)
-		} else if elsif, ok := n.(*ir.ElseIfStmt); ok {
-			b.addStatement(elsif.Stmt)
-		} else {
+		switch n := n.(type) {
+		case *ir.ElseStmt:
+			b.addStatement(n.Stmt)
+		case *ir.ElseIfStmt:
+			b.addStatement(n.Stmt)
+		default:
 			b.addStatement(n)
 		}
 
@@ -1324,7 +1326,9 @@ func (b *BlockWalker) handleSwitch(s *ir.SwitchStmt) bool {
 	haveDefault := false
 	breakFlags := FlagBreak | FlagContinue
 
-	for idx, c := range s.CaseList.Cases {
+	for i := range s.CaseList.Cases {
+		idx := i
+		c := s.CaseList.Cases[i]
 		var list []ir.Node
 
 		cond, list := getCaseStmts(c)

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -457,11 +457,11 @@ case INC:
 			Default:  true,
 			Quickfix: false,
 			Comment:  `Report commonly misspelled words in symbol names.`,
-			Before:   `function performace_test() ...`, //nolint:misspell
+			Before:   `function performace_test() ...`, //nolint:misspell // misspelled on purpose
 			After:    `function performance_test() ...`,
 		},
 
-		//nolint:misspell
+		//nolint:misspell // misspelled on purpose
 		{
 			Name:     "misspellComment",
 			Default:  true,
@@ -811,7 +811,8 @@ func reportListToMap(list []*Report) map[string][]*Report {
 		res[r.Filename] = append(res[r.Filename], r)
 	}
 
-	for _, l := range res {
+	for i := range res {
+		l := res[i]
 		sort.Slice(l, func(i, j int) bool {
 			return l[i].Line < l[j].Line
 		})

--- a/src/meta/const_value.go
+++ b/src/meta/const_value.go
@@ -97,7 +97,7 @@ func (c ConstValue) GetBool() bool {
 
 // ToBool converts x constant to boolean constants following PHP conversion rules.
 // Second bool result tells whether that conversion was successful.
-func (c ConstValue) ToBool() (bool, bool) {
+func (c ConstValue) ToBool() (value bool, ok bool) {
 	switch c.Type {
 	case Bool:
 		return c.GetBool(), true

--- a/src/meta/typestring.go
+++ b/src/meta/typestring.go
@@ -282,7 +282,7 @@ func UnwrapConstant(s string) (constName string) {
 }
 
 func formatType(s string) (res string) {
-	if len(s) == 0 || s[0] >= WMax {
+	if s == "" || s[0] >= WMax {
 		return s
 	}
 

--- a/src/phpdoc/parser.go
+++ b/src/phpdoc/parser.go
@@ -63,7 +63,7 @@ func Parse(parser *TypeParser, doc string) (res []CommentPart) {
 
 	for i, ln := range lines {
 		ln = strings.TrimSpace(ln)
-		if len(ln) == 0 {
+		if ln == "" {
 			continue
 		}
 

--- a/src/phpgrep/matcher_test.go
+++ b/src/phpgrep/matcher_test.go
@@ -42,7 +42,8 @@ func mustCompile(t testing.TB, c *Compiler, code string) *Matcher {
 }
 
 func runMatchTest(t *testing.T, c *Compiler, want bool, tests []*matcherTest) {
-	for i, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(fmt.Sprintf("%d_%v", i, want), func(t *testing.T) {
 			matcher := mustCompile(t, c, test.pattern)
 			have := matchInText(t, matcher, test.input)

--- a/src/solver/solver.go
+++ b/src/solver/solver.go
@@ -73,7 +73,7 @@ func (r *resolver) resolveTypeNoLateStaticBinding(class, typ string) map[string]
 		return result
 	}
 
-	if len(typ) == 0 || typ[0] >= meta.WMax {
+	if typ == "" || typ[0] >= meta.WMax {
 		return identityType(typ)
 	}
 

--- a/src/tests/checkers/misspell_test.go
+++ b/src/tests/checkers/misspell_test.go
@@ -13,7 +13,7 @@ func init() {
 	linter.TypoFixer = misspell.New()
 }
 
-//nolint:misspell
+//nolint:misspell // misspelled on purpose
 func TestMisspellPhpdocPositive(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
@@ -52,7 +52,7 @@ class c1 {
 	test.RunAndMatch()
 }
 
-//nolint:misspell
+//nolint:misspell // misspelled on purpose
 func TestMisspellPhpdocNegative(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 interface Responsable {}
@@ -84,7 +84,7 @@ class c1 {
 `)
 }
 
-//nolint:misspell
+//nolint:misspell // misspelled on purpose
 func TestMisspellNamePositive(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
@@ -118,7 +118,7 @@ class c {
 	test.RunAndMatch()
 }
 
-//nolint:misspell
+//nolint:misspell // misspelled on purpose
 func TestMisspellNameNegative(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 function includ() {

--- a/src/tests/golden/quickfix_test.go
+++ b/src/tests/golden/quickfix_test.go
@@ -54,7 +54,8 @@ func (t *quickFixTest) runQuickFixTest() {
 		t.t.Fatalf("Error while searching for files in the %s folder: %s", t.folder, err)
 	}
 
-	for _, file := range files {
+	for i := range files {
+		file := files[i]
 		t.t.Run(strings.TrimSuffix(filepath.Base(file), ".php"), func(t *testing.T) {
 			testFileName := file
 			expectedFileName := file + expectedExtension

--- a/src/tests/rules/rules_error_test.go
+++ b/src/tests/rules/rules_error_test.go
@@ -259,7 +259,8 @@ ${"boo"} = $_;
 func runRulesErrorTest(t *testing.T, rulesTest []ruleErrorTest) {
 	t.Helper()
 
-	for _, test := range rulesTest {
+	for i := range rulesTest {
+		test := rulesTest[i]
 		t.Run(test.name, func(t *testing.T) {
 			rparser := rules.NewParser()
 			_, err := rparser.Parse("<test>", strings.NewReader(test.rule))


### PR DESCRIPTION
Most range loop changes are due to the scopelint.
Capturing a loop variable into closure is not very reliable
and error-prone.

Instead of using this idiom:

	for _, x := range xs {
		x := x // Make it a normal local var
		// use x
	}

I used this one (I find it less confusion as it has no "self-assign"):

	for i := range xs {
		x := xs[i]
		// use x
	}