### PR TITLE
meta,linter: use TypesMap.Map instead of TypesMap.AppendString

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -690,7 +690,7 @@ func (d *RootWalker) handleFuncStmts(params []meta.FuncParam, uses, stmts []ir.N
 
 	switch {
 	case b.bareReturn && b.returnsValue:
-		b.returnTypes = b.returnTypes.AppendString("null")
+		b.returnTypes = meta.MergeTypeMaps(b.returnTypes, meta.NullType)
 	case b.returnTypes.IsEmpty() && b.returnsValue:
 		b.returnTypes = meta.MixedType
 	}
@@ -1429,9 +1429,7 @@ func (d *RootWalker) callbackParamByIndex(param ir.Node, argType meta.TypesMap) 
 	if ok {
 		typ = tp
 	} else {
-		argType.Iterate(func(t string) {
-			typ = typ.AppendString(meta.WrapElemOf(t))
-		})
+		typ = argType.Map(meta.WrapElemOf)
 	}
 
 	arg := meta.FuncParam{
@@ -1519,9 +1517,7 @@ func (d *RootWalker) parseFuncArgs(params []ir.Node, parTypes phpDocParamsMap, s
 		}
 
 		if p.Variadic {
-			arrTyp := meta.NewEmptyTypesMap(typ.Len())
-			typ.Iterate(func(t string) { arrTyp = arrTyp.AppendString(meta.WrapArrayOf(t)) })
-			typ = arrTyp
+			typ = typ.Map(meta.WrapArrayOf)
 		}
 
 		sc.AddVarName(v.Name, typ, "param", meta.VarAlwaysDefined)

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -95,7 +95,8 @@ func typesMapToTypeExpr(p *phpdoc.TypeParser, m meta.TypesMap) phpdoc.Type {
 func MergeTypeMaps(left meta.TypesMap, right meta.TypesMap) meta.TypesMap {
 	var hasAtLeastOneArray bool
 	var hasAtLeastOneClass bool
-	newMap := meta.NewEmptyTypesMap(left.Len() + right.Len())
+
+	merged := make(map[string]struct{}, left.Len()+right.Len())
 
 	left.Iterate(func(typ string) {
 		if typ[0] == meta.WArrayOf {
@@ -104,7 +105,7 @@ func MergeTypeMaps(left meta.TypesMap, right meta.TypesMap) meta.TypesMap {
 		if typ[0] == '\\' {
 			hasAtLeastOneClass = true
 		}
-		newMap.AppendString(typ)
+		merged[typ] = struct{}{}
 	})
 
 	right.Iterate(func(typ string) {
@@ -114,10 +115,10 @@ func MergeTypeMaps(left meta.TypesMap, right meta.TypesMap) meta.TypesMap {
 		if typ == "object" && hasAtLeastOneClass {
 			return
 		}
-		newMap.AppendString(typ)
+		merged[typ] = struct{}{}
 	})
 
-	return newMap
+	return meta.NewTypesMapFromMap(merged)
 }
 
 // functionReturnType returns the return type of a function over computed types

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -254,10 +254,7 @@ func internalFuncType(nm string, sc *meta.Scope, cs *meta.ClassParseState, c *ir
 		return typ, true
 
 	case meta.OverrideElementType:
-		newTyp := meta.NewEmptyTypesMap(typ.Len())
-		typ.Iterate(func(t string) {
-			newTyp = newTyp.AppendString(meta.WrapElemOf(t))
-		})
+		newTyp := typ.Map(meta.WrapElemOf)
 		return newTyp, true
 
 	case meta.OverrideClassType:
@@ -305,12 +302,7 @@ func arrayType(sc *meta.Scope, cs *meta.ClassParseState, items []*ir.ArrayItemEx
 		}
 	}
 
-	wrapped := meta.NewEmptyTypesMap(firstElementType.Len())
-	firstElementType.Iterate(func(t string) {
-		wrapped.AppendString(meta.WrapArrayOf(t))
-	})
-
-	return wrapped
+	return firstElementType.Map(meta.WrapArrayOf)
 }
 
 func newExprType(n *ir.NewExpr, cs *meta.ClassParseState) meta.TypesMap {

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -105,6 +105,49 @@ function not_an_array($xs) {
 	runExprTypeTest(t, &exprTypeTestParams{code: code})
 }
 
+func TestExprTypeCatch(t *testing.T) {
+	code := `<?php
+try {
+} catch (Foo $x) {
+  exprtype($x, '\Foo');
+} catch (Exception $e) {
+  exprtype($e, '\Exception');
+} catch (A|B $ab) {
+  exprtype($ab, '\A|\B');
+} catch (\A\B\C $abc) {
+  exprtype($abc, '\A\B\C');
+  exprtype($ab, 'undefined');
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
+func TestExprTypeVariadicParam(t *testing.T) {
+	code := `<?php
+function scalar_int(int ...$xs) {
+  exprtype($xs, 'int[]');
+}
+
+function no_typehint(...$xs) {
+  exprtype($xs, 'mixed'); // TODO: mixed[]?
+}
+
+function foo_array(Foo ...$xs) {
+  exprtype($xs, '\Foo[]');
+}
+
+function mixed_array2(array ...$xs) {
+  exprtype($xs, 'mixed[][]');
+}
+
+/** @param $xs Foo */
+function scalar_int(int ...$xs) {
+  exprtype($xs, '\Foo|int[]');
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func TestExprTypeForeachKey(t *testing.T) {
 	code := `<?php
 $xs = [[1], [2]];
@@ -1536,6 +1579,13 @@ function bare_ret2($cond) {
   return;
 }
 exprtype(bare_ret2(false), 'int|null');
+
+function bare_ret3($cond) {
+  if ($cond == 1) { return 10; }
+  if ($cond == 2) { return ""; }
+  return;
+}
+exprtype(bare_ret3(10), 'int|null|string');
 
 function untyped_param($x) { return $x; }
 exprtype(untyped_param(0), 'mixed');


### PR DESCRIPTION
The TypesMap.AppendString may mutate the map, which makes it harder
for us to migrate to fully immutable type maps.

The new Map() method is supposed to be used in places where we
want to create a new types map based on other types map.

All current AppendString usages were replaced and the method itself
is removed now.