### PR TITLE
cmd: removed the deprecated way to run NoVerify

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -121,7 +121,7 @@ func Run(cfg *MainConfig) (int, error) {
 			// sub commands themselves.
 			os.Args = append(os.Args[:subIdx], os.Args[subIdx+1:]...)
 		} else {
-			fmt.Printf("Sub-command %s doesn't exist\n\n", commandName)
+			fmt.Printf("Sub-command '%s' doesn't exist\n\n", commandName)
 			GlobalCmds.PrintHelpPage()
 			return 0, nil
 		}

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -120,7 +120,7 @@ func Run(cfg *MainConfig) (int, error) {
 			// Erase sub-command argument (index=1) to make it invisible for
 			// sub commands themselves.
 			os.Args = append(os.Args[:subIdx], os.Args[subIdx+1:]...)
-		} else if looksLikeCommandName(commandName) {
+		} else {
 			fmt.Printf("Sub-command %s doesn't exist\n\n", commandName)
 			GlobalCmds.PrintHelpPage()
 			return 0, nil

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -128,13 +128,7 @@ func Run(cfg *MainConfig) (int, error) {
 
 	}
 	if subcmd == nil {
-		log.Print(`
-
-NoVerify migrates to the new CLI using commands, launching in this way is still possible, but is already deprecated.
-Use 'noverify help' for more information.
-
-`)
-		subcmd, _ = GlobalCmds.GetCommand("check")
+		subcmd, _ = GlobalCmds.GetCommand("help")
 	}
 
 	status, err := subcmd.Main(cfg)

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -128,7 +128,8 @@ func Run(cfg *MainConfig) (int, error) {
 
 	}
 	if subcmd == nil {
-		subcmd, _ = GlobalCmds.GetCommand("help")
+		GlobalCmds.PrintHelpPage()
+		return 0, nil
 	}
 
 	status, err := subcmd.Main(cfg)

--- a/src/cmd/subcmd.go
+++ b/src/cmd/subcmd.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 )
 
 type SubCommand struct {
@@ -26,11 +25,4 @@ func (s *SubCommand) String() string {
 		res += fmt.Sprintf("\t\t$ noverify %s %s\n", s.Name, ex.Line)
 	}
 	return res
-}
-
-func looksLikeCommandName(s string) bool {
-	return !strings.HasPrefix(s, "-") &&
-		!strings.Contains(s, ".") &&
-		!strings.Contains(s, "/") &&
-		!strings.Contains(s, "\\")
 }

--- a/src/linttest/golden_linttest.go
+++ b/src/linttest/golden_linttest.go
@@ -252,6 +252,7 @@ func (s *GoldenE2ETestSuite) RunOnlyTests() {
 
 				outputFilename := fmt.Sprintf("phplinter-output-%s.json", test.Name)
 				args := []string{
+					"check",
 					"--critical", "",
 					"--output-json",
 					"--disable-cache", // TODO: test with cache as well


### PR DESCRIPTION
Now, when run without commands, help will be displayed.