### PR TITLE
linter: remove deprecated parser funcs from linter API

### DIFF
--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -13,7 +13,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/VKCOM/noverify/src/git"
+	"github.com/VKCOM/noverify/src/ir"
 	"github.com/VKCOM/noverify/src/linttest/assert"
+	"github.com/VKCOM/noverify/src/workspace"
 )
 
 func TestCache(t *testing.T) {
@@ -117,7 +120,7 @@ main();
 `
 
 	runTest := func(iteration int) {
-		_, root, err := ParseContents("cachetest.php", []byte(code), nil, nil)
+		_, root, err := parseContents("cachetest.php", []byte(code), nil, nil)
 		if err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -187,4 +190,15 @@ func collectCacheStrings(data string) string {
 	enc := sha512.New()
 	_, _ = enc.Write([]byte(strings.Join(parts, ","))) // sha512.Write always returns nil error
 	return hex.EncodeToString(enc.Sum(nil))
+}
+
+func parseContents(filename string, contents []byte, lineRanges []git.LineRange, allowDisabled *regexp.Regexp) (root *ir.Root, walker *RootWalker, err error) {
+	w := NewLintingWorker(0)
+	w.AllowDisable = allowDisabled
+	file := workspace.FileInfo{
+		Name:       filename,
+		Contents:   contents,
+		LineRanges: lineRanges,
+	}
+	return w.ParseContents(file)
 }

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -7,37 +7,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/VKCOM/noverify/src/git"
 	"github.com/VKCOM/noverify/src/ir"
 	"github.com/VKCOM/noverify/src/lintdebug"
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/rules"
 	"github.com/VKCOM/noverify/src/workspace"
 )
-
-// ParseContents is a legacy way of linting files.
-// Deprecated: use Worker.ParseContents instead.
-func ParseContents(filename string, contents []byte, lineRanges []git.LineRange, allowDisabled *regexp.Regexp) (root *ir.Root, walker *RootWalker, err error) {
-	w := NewLintingWorker(0)
-	w.AllowDisable = allowDisabled
-	file := workspace.FileInfo{
-		Name:       filename,
-		Contents:   contents,
-		LineRanges: lineRanges,
-	}
-	return w.ParseContents(file)
-}
-
-// IndexFile is a legacy way of indexing files.
-// Deprecated: use Worker.IndexFile instead.
-func IndexFile(filename string, contents []byte) error {
-	w := NewIndexingWorker(0)
-	file := workspace.FileInfo{
-		Name:     filename,
-		Contents: contents,
-	}
-	return w.IndexFile(file)
-}
 
 func cloneRulesForFile(filename string, ruleSet *rules.ScopedSet) *rules.ScopedSet {
 	if ruleSet == nil {


### PR DESCRIPTION
Let's not give 100 ways to run the linter.