### PR TITLE
linter: unexport many symbols

### DIFF
--- a/src/linter/and_walker.go
+++ b/src/linter/and_walker.go
@@ -12,7 +12,7 @@ import (
 // All variables defined by andWalker should be removed after
 // if body is handled, this is why we collect varsToDelete.
 type andWalker struct {
-	b *BlockWalker
+	b *blockWalker
 
 	varsToDelete []ir.Node
 }

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -56,8 +56,8 @@ const (
 // so we can always assume that `int|string` is good enough.
 var arrayKeyType = meta.NewTypesMap("int|string").Immutable()
 
-// BlockWalker is used to process function/method contents.
-type BlockWalker struct {
+// blockWalker is used to process function/method contents.
+type blockWalker struct {
 	ctx *blockContext
 
 	linter blockLinter
@@ -101,11 +101,11 @@ type BlockWalker struct {
 	nonLocalVars map[string]variableKind
 
 	inArrowFunction    bool
-	parentBlockWalkers []*BlockWalker // all parent block walkers if we handle nested arrow functions.
+	parentBlockWalkers []*blockWalker // all parent block walkers if we handle nested arrow functions.
 }
 
-func newBlockWalker(r *RootWalker, sc *meta.Scope) *BlockWalker {
-	b := &BlockWalker{
+func newBlockWalker(r *RootWalker, sc *meta.Scope) *blockWalker {
+	b := &blockWalker{
 		r:            r,
 		ctx:          &blockContext{sc: sc},
 		unusedVars:   make(map[string][]ir.Node),
@@ -116,7 +116,7 @@ func newBlockWalker(r *RootWalker, sc *meta.Scope) *BlockWalker {
 	return b
 }
 
-func (b *BlockWalker) addStatement(n ir.Node) {
+func (b *blockWalker) addStatement(n ir.Node) {
 	if b.statements == nil {
 		b.statements = make(map[ir.Node]struct{})
 	}
@@ -136,7 +136,7 @@ func (b *BlockWalker) addStatement(n ir.Node) {
 	b.statements[assignment] = struct{}{}
 }
 
-func (b *BlockWalker) reportDeadCode(n ir.Node) {
+func (b *blockWalker) reportDeadCode(n ir.Node) {
 	if b.ctx.deadCodeReported {
 		return
 	}
@@ -162,7 +162,7 @@ func (b *BlockWalker) reportDeadCode(n ir.Node) {
 }
 
 // EnterNode is called before walking to inner nodes.
-func (b *BlockWalker) EnterNode(n ir.Node) (res bool) {
+func (b *blockWalker) EnterNode(n ir.Node) (res bool) {
 	res = true
 
 	for _, c := range b.custom {
@@ -339,7 +339,7 @@ func (b *BlockWalker) EnterNode(n ir.Node) (res bool) {
 	return res
 }
 
-func (b *BlockWalker) checkDupGlobal(s *ir.GlobalStmt) {
+func (b *blockWalker) checkDupGlobal(s *ir.GlobalStmt) {
 	vars := make(map[string]struct{}, len(s.Vars))
 	for _, v := range s.Vars {
 		v, ok := v.(*ir.SimpleVar)
@@ -361,7 +361,7 @@ func (b *BlockWalker) checkDupGlobal(s *ir.GlobalStmt) {
 	}
 }
 
-func (b *BlockWalker) handleAndCheckGlobalStmt(s *ir.GlobalStmt) {
+func (b *blockWalker) handleAndCheckGlobalStmt(s *ir.GlobalStmt) {
 	if !b.rootLevel {
 		b.checkDupGlobal(s)
 	}
@@ -381,7 +381,7 @@ func (b *BlockWalker) handleAndCheckGlobalStmt(s *ir.GlobalStmt) {
 	}
 }
 
-func (b *BlockWalker) handleFunction(fun *ir.FunctionStmt) bool {
+func (b *blockWalker) handleFunction(fun *ir.FunctionStmt) bool {
 	if b.ignoreFunctionBodies {
 		return false
 	}
@@ -389,7 +389,7 @@ func (b *BlockWalker) handleFunction(fun *ir.FunctionStmt) bool {
 	return b.r.enterFunction(fun)
 }
 
-func (b *BlockWalker) handleArrowFunction(fun *ir.ArrowFunctionExpr) bool {
+func (b *blockWalker) handleArrowFunction(fun *ir.ArrowFunctionExpr) bool {
 	if b.ignoreFunctionBodies {
 		return false
 	}
@@ -397,7 +397,7 @@ func (b *BlockWalker) handleArrowFunction(fun *ir.ArrowFunctionExpr) bool {
 	return b.enterArrowFunction(fun)
 }
 
-func (b *BlockWalker) handleReturn(ret *ir.ReturnStmt) {
+func (b *blockWalker) handleReturn(ret *ir.ReturnStmt) {
 	if ret.Expr == nil {
 		// Return without explicit return value.
 		b.bareReturn = true
@@ -409,7 +409,7 @@ func (b *BlockWalker) handleReturn(ret *ir.ReturnStmt) {
 	b.returnTypes = b.returnTypes.Append(typ)
 }
 
-func (b *BlockWalker) handleLogicalOr(or *ir.LogicalOrExpr) bool {
+func (b *blockWalker) handleLogicalOr(or *ir.LogicalOrExpr) bool {
 	or.Left.Walk(b)
 
 	// We're going to discard "or" RHS effects on the exit flags.
@@ -420,11 +420,11 @@ func (b *BlockWalker) handleLogicalOr(or *ir.LogicalOrExpr) bool {
 	return false
 }
 
-func (b *BlockWalker) addNonLocalVarName(nm string, kind variableKind) {
+func (b *blockWalker) addNonLocalVarName(nm string, kind variableKind) {
 	b.nonLocalVars[nm] = kind
 }
 
-func (b *BlockWalker) addNonLocalVar(v ir.Node, kind variableKind) {
+func (b *blockWalker) addNonLocalVar(v ir.Node, kind variableKind) {
 	sv, ok := v.(*ir.SimpleVar)
 	if !ok {
 		return
@@ -433,7 +433,7 @@ func (b *BlockWalker) addNonLocalVar(v ir.Node, kind variableKind) {
 }
 
 // replaceVar must be used to track assignments to conrete var nodes if they are available
-func (b *BlockWalker) replaceVar(v ir.Node, typ meta.TypesMap, reason string, flags meta.VarFlags) {
+func (b *blockWalker) replaceVar(v ir.Node, typ meta.TypesMap, reason string, flags meta.VarFlags) {
 	b.ctx.sc.ReplaceVar(v, typ, reason, flags)
 	sv, ok := v.(*ir.SimpleVar)
 	if !ok {
@@ -443,7 +443,7 @@ func (b *BlockWalker) replaceVar(v ir.Node, typ meta.TypesMap, reason string, fl
 	b.trackVarName(v, sv.Name)
 }
 
-func (b *BlockWalker) trackVarName(n ir.Node, nm string) {
+func (b *blockWalker) trackVarName(n ir.Node, nm string) {
 	// Writes to non-local variables do count as usages
 	if _, ok := b.nonLocalVars[nm]; ok {
 		b.untrackVarName(nm)
@@ -457,18 +457,18 @@ func (b *BlockWalker) trackVarName(n ir.Node, nm string) {
 	}
 }
 
-func (b *BlockWalker) untrackVarName(nm string) {
+func (b *blockWalker) untrackVarName(nm string) {
 	delete(b.unusedVars, nm)
 	delete(b.unusedParams, nm)
 }
 
-func (b *BlockWalker) addVarName(n ir.Node, nm string, typ meta.TypesMap, reason string, flags meta.VarFlags) {
+func (b *blockWalker) addVarName(n ir.Node, nm string, typ meta.TypesMap, reason string, flags meta.VarFlags) {
 	b.ctx.sc.AddVarName(nm, typ, reason, flags)
 	b.trackVarName(n, nm)
 }
 
 // addVar must be used to track assignments to conrete var nodes if they are available
-func (b *BlockWalker) addVar(v ir.Node, typ meta.TypesMap, reason string, flags meta.VarFlags) {
+func (b *blockWalker) addVar(v ir.Node, typ meta.TypesMap, reason string, flags meta.VarFlags) {
 	b.ctx.sc.AddVar(v, typ, reason, flags)
 	sv, ok := v.(*ir.SimpleVar)
 	if !ok {
@@ -477,7 +477,7 @@ func (b *BlockWalker) addVar(v ir.Node, typ meta.TypesMap, reason string, flags 
 	b.trackVarName(v, sv.Name)
 }
 
-func (b *BlockWalker) walkComments(n ir.Node, c freefloating.String) {
+func (b *blockWalker) walkComments(n ir.Node, c freefloating.String) {
 	if c.StringType != freefloating.CommentType {
 		return
 	}
@@ -502,7 +502,7 @@ func (b *BlockWalker) walkComments(n ir.Node, c freefloating.String) {
 	}
 }
 
-func (b *BlockWalker) handleUnset(s *ir.UnsetStmt) bool {
+func (b *blockWalker) handleUnset(s *ir.UnsetStmt) bool {
 	for _, v := range s.Vars {
 		switch v := v.(type) {
 		case *ir.SimpleVar:
@@ -522,7 +522,7 @@ func (b *BlockWalker) handleUnset(s *ir.UnsetStmt) bool {
 	return false
 }
 
-func (b *BlockWalker) handleIsset(s *ir.IssetExpr) bool {
+func (b *blockWalker) handleIsset(s *ir.IssetExpr) bool {
 	for _, v := range s.Variables {
 		switch v := v.(type) {
 		case *ir.Var:
@@ -541,7 +541,7 @@ func (b *BlockWalker) handleIsset(s *ir.IssetExpr) bool {
 	return false
 }
 
-func (b *BlockWalker) handleEmpty(s *ir.EmptyExpr) bool {
+func (b *blockWalker) handleEmpty(s *ir.EmptyExpr) bool {
 	switch v := s.Expr.(type) {
 	case *ir.Var:
 		// Do nothing.
@@ -565,7 +565,7 @@ func (b *BlockWalker) handleEmpty(s *ir.EmptyExpr) bool {
 //
 // Returns the context that was assigned during callback execution (the new context),
 // so it can be examined at the call site.
-func (b *BlockWalker) withNewContext(action func()) *blockContext {
+func (b *blockWalker) withNewContext(action func()) *blockContext {
 	oldCtx := b.ctx
 	newCtx := copyBlockContext(b.ctx)
 
@@ -576,7 +576,7 @@ func (b *BlockWalker) withNewContext(action func()) *blockContext {
 	return newCtx
 }
 
-func (b *BlockWalker) handleTry(s *ir.TryStmt) bool {
+func (b *blockWalker) handleTry(s *ir.TryStmt) bool {
 	contexts := make([]*blockContext, 0, len(s.Catches)+1)
 
 	// Assume that no code in try{} block has executed because exceptions can be thrown from anywhere.
@@ -642,7 +642,7 @@ func (b *BlockWalker) handleTry(s *ir.TryStmt) bool {
 	return false
 }
 
-func (b *BlockWalker) handleCatch(s *ir.CatchStmt) {
+func (b *blockWalker) handleCatch(s *ir.CatchStmt) {
 	types := make([]meta.Type, 0, len(s.Types))
 	for _, t := range s.Types {
 		typ, ok := solver.GetClassName(b.r.ctx.st, t)
@@ -664,7 +664,7 @@ func (b *BlockWalker) handleCatch(s *ir.CatchStmt) {
 }
 
 // We still need to analyze expressions in isset()/unset()/empty() statements
-func (b *BlockWalker) handleIssetDimFetch(e *ir.ArrayDimFetchExpr) {
+func (b *blockWalker) handleIssetDimFetch(e *ir.ArrayDimFetchExpr) {
 	b.checkArrayDimFetch(e)
 
 	switch v := e.Variable.(type) {
@@ -683,7 +683,7 @@ func (b *BlockWalker) handleIssetDimFetch(e *ir.ArrayDimFetchExpr) {
 	}
 }
 
-func (b *BlockWalker) handleCallArgs(args []ir.Node, fn meta.FuncInfo) {
+func (b *blockWalker) handleCallArgs(args []ir.Node, fn meta.FuncInfo) {
 	for i, arg := range args {
 		if i >= len(fn.Params) {
 			arg.Walk(b)
@@ -733,7 +733,7 @@ func (b *BlockWalker) handleCallArgs(args []ir.Node, fn meta.FuncInfo) {
 	}
 }
 
-func (b *BlockWalker) handleFunctionCall(e *ir.FunctionCallExpr) bool {
+func (b *blockWalker) handleFunctionCall(e *ir.FunctionCallExpr) bool {
 	call := resolveFunctionCall(b.ctx.sc, b.r.ctx.st, b.ctx.customTypes, e)
 
 	e.Function.Walk(b)
@@ -754,7 +754,7 @@ func (b *BlockWalker) handleFunctionCall(e *ir.FunctionCallExpr) bool {
 
 // handleCompactCallArgs treats strings anywhere in the argument list as uses
 // of the variables named by those strings, which is how compact() behaves.
-func (b *BlockWalker) handleCompactCallArgs(args []ir.Node) {
+func (b *blockWalker) handleCompactCallArgs(args []ir.Node) {
 	// Recursively flatten the argument list and extract strings
 	var strs []*ir.String
 	for len(args) > 0 {
@@ -783,7 +783,7 @@ func (b *BlockWalker) handleCompactCallArgs(args []ir.Node) {
 	}
 }
 
-func (b *BlockWalker) handleMethodCall(e *ir.MethodCallExpr) bool {
+func (b *blockWalker) handleMethodCall(e *ir.MethodCallExpr) bool {
 	call := resolveMethodCall(b.ctx.sc, b.r.ctx.st, b.ctx.customTypes, e)
 
 	e.Variable.Walk(b)
@@ -797,7 +797,7 @@ func (b *BlockWalker) handleMethodCall(e *ir.MethodCallExpr) bool {
 	return false
 }
 
-func (b *BlockWalker) handleStaticCall(e *ir.StaticCallExpr) bool {
+func (b *blockWalker) handleStaticCall(e *ir.StaticCallExpr) bool {
 	call := resolveStaticMethodCall(b.r.ctx.st, e)
 	b.callsParentConstructor = call.isCallsParentConstructor
 
@@ -810,7 +810,7 @@ func (b *BlockWalker) handleStaticCall(e *ir.StaticCallExpr) bool {
 	return false
 }
 
-func (b *BlockWalker) isThisInsideClosure(varNode ir.Node) bool {
+func (b *blockWalker) isThisInsideClosure(varNode ir.Node) bool {
 	if !b.ctx.sc.IsInClosure() {
 		return false
 	}
@@ -822,13 +822,13 @@ func (b *BlockWalker) isThisInsideClosure(varNode ir.Node) bool {
 	return variable.Name == `this`
 }
 
-func (b *BlockWalker) handlePropertyFetch(e *ir.PropertyFetchExpr) bool {
+func (b *blockWalker) handlePropertyFetch(e *ir.PropertyFetchExpr) bool {
 	e.Variable.Walk(b)
 	e.Property.Walk(b)
 	return false
 }
 
-func (b *BlockWalker) handleStaticPropertyFetch(e *ir.StaticPropertyFetchExpr) bool {
+func (b *blockWalker) handleStaticPropertyFetch(e *ir.StaticPropertyFetchExpr) bool {
 	e.Class.Walk(b)
 
 	if propertyVarNode, propertyIsVarNode := e.Property.(*ir.Var); propertyIsVarNode {
@@ -838,11 +838,11 @@ func (b *BlockWalker) handleStaticPropertyFetch(e *ir.StaticPropertyFetchExpr) b
 	return false
 }
 
-func (b *BlockWalker) handleArray(arr *ir.ArrayExpr) bool {
+func (b *blockWalker) handleArray(arr *ir.ArrayExpr) bool {
 	return b.handleArrayItems(arr.Items)
 }
 
-func (b *BlockWalker) handleArrayItems(items []*ir.ArrayItemExpr) bool {
+func (b *blockWalker) handleArrayItems(items []*ir.ArrayItemExpr) bool {
 	for _, item := range items {
 		if item.Val != nil {
 			item.Val.Walk(b)
@@ -855,12 +855,12 @@ func (b *BlockWalker) handleArrayItems(items []*ir.ArrayItemExpr) bool {
 	return false
 }
 
-func (b *BlockWalker) handleClassConstFetch(e *ir.ClassConstFetchExpr) bool {
+func (b *blockWalker) handleClassConstFetch(e *ir.ClassConstFetchExpr) bool {
 	e.Class.Walk(b)
 	return false
 }
 
-func (b *BlockWalker) handleForeach(s *ir.ForeachStmt) bool {
+func (b *blockWalker) handleForeach(s *ir.ForeachStmt) bool {
 	// TODO: add reference semantics to foreach analyze as well
 
 	// expression is always executed and is executed in base context
@@ -919,7 +919,7 @@ func (b *BlockWalker) handleForeach(s *ir.ForeachStmt) bool {
 	return false
 }
 
-func (b *BlockWalker) handleFor(s *ir.ForStmt) bool {
+func (b *blockWalker) handleFor(s *ir.ForStmt) bool {
 	for _, v := range s.Init {
 		b.addStatement(v)
 		v.Walk(b)
@@ -949,7 +949,7 @@ func (b *BlockWalker) handleFor(s *ir.ForStmt) bool {
 	return false
 }
 
-func (b *BlockWalker) enterArrowFunction(fun *ir.ArrowFunctionExpr) bool {
+func (b *blockWalker) enterArrowFunction(fun *ir.ArrowFunctionExpr) bool {
 	sc := meta.NewScope()
 
 	doc := b.r.parsePHPDoc(fun, fun.PhpDoc, fun.Params)
@@ -962,7 +962,7 @@ func (b *BlockWalker) enterArrowFunction(fun *ir.ArrowFunctionExpr) bool {
 	return false
 }
 
-func (b *BlockWalker) enterClosure(fun *ir.ClosureExpr, haveThis bool, thisType meta.TypesMap, closureSolver *solver.ClosureCallerInfo) bool {
+func (b *blockWalker) enterClosure(fun *ir.ClosureExpr, haveThis bool, thisType meta.TypesMap, closureSolver *solver.ClosureCallerInfo) bool {
 	sc := meta.NewScope()
 	sc.SetInClosure(true)
 
@@ -1012,14 +1012,14 @@ func (b *BlockWalker) enterClosure(fun *ir.ClosureExpr, haveThis bool, thisType 
 	return false
 }
 
-func (b *BlockWalker) maybeAddAllVars(sc *meta.Scope, reason string) {
+func (b *blockWalker) maybeAddAllVars(sc *meta.Scope, reason string) {
 	sc.Iterate(func(varName string, typ meta.TypesMap, flags meta.VarFlags) {
 		flags &^= meta.VarAlwaysDefined
 		b.ctx.sc.AddVarName(varName, typ, reason, flags)
 	})
 }
 
-func (b *BlockWalker) handleWhile(s *ir.WhileStmt) bool {
+func (b *blockWalker) handleWhile(s *ir.WhileStmt) bool {
 	if s.Cond != nil {
 		s.Cond.Walk(b)
 	}
@@ -1038,7 +1038,7 @@ func (b *BlockWalker) handleWhile(s *ir.WhileStmt) bool {
 	return false
 }
 
-func (b *BlockWalker) handleDo(s *ir.DoStmt) bool {
+func (b *blockWalker) handleDo(s *ir.DoStmt) bool {
 	if s.Stmt != nil {
 		oldInnermostLoop := b.ctx.innermostLoop
 		oldInsideLoop := b.ctx.insideLoop
@@ -1057,12 +1057,12 @@ func (b *BlockWalker) handleDo(s *ir.DoStmt) bool {
 }
 
 // propagateFlags is like propagateFlagsFromBranches, but for a simple single block case.
-func (b *BlockWalker) propagateFlags(other *blockContext) {
+func (b *blockWalker) propagateFlags(other *blockContext) {
 	b.ctx.containsExitFlags |= other.containsExitFlags
 }
 
 // Propagate premature exit flags from visited branches ("contexts").
-func (b *BlockWalker) propagateFlagsFromBranches(contexts []*blockContext, linksCount int) {
+func (b *blockWalker) propagateFlagsFromBranches(contexts []*blockContext, linksCount int) {
 	allExit := false
 	prematureExitFlags := 0
 
@@ -1087,7 +1087,7 @@ func (b *BlockWalker) propagateFlagsFromBranches(contexts []*blockContext, links
 	}
 }
 
-func (b *BlockWalker) handleVariable(v ir.Node) bool {
+func (b *blockWalker) handleVariable(v ir.Node) bool {
 	var varName string
 	switch v := v.(type) {
 	case *ir.Var:
@@ -1163,7 +1163,7 @@ func (b *BlockWalker) handleVariable(v ir.Node) bool {
 	return false
 }
 
-func (b *BlockWalker) handleTernary(e *ir.TernaryExpr) bool {
+func (b *blockWalker) handleTernary(e *ir.TernaryExpr) bool {
 	if e.IfTrue == nil {
 		return true // Skip `$x ?: $y` expressions
 	}
@@ -1179,7 +1179,7 @@ func (b *BlockWalker) handleTernary(e *ir.TernaryExpr) bool {
 	return false
 }
 
-func (b *BlockWalker) handleIf(s *ir.IfStmt) bool {
+func (b *blockWalker) handleIf(s *ir.IfStmt) bool {
 	var varsToDelete []ir.Node
 	customMethods := len(b.ctx.customMethods)
 	customFunctions := len(b.ctx.customFunctions)
@@ -1279,7 +1279,7 @@ func (b *BlockWalker) handleIf(s *ir.IfStmt) bool {
 	return false
 }
 
-func (b *BlockWalker) handleElseIf(s *ir.ElseIfStmt) {
+func (b *blockWalker) handleElseIf(s *ir.ElseIfStmt) {
 	if s.Merged {
 		b.r.checkKeywordCase(s, "else")
 		if ff := (*s.GetFreeFloating())[freefloating.Else]; len(ff) != 0 {
@@ -1291,7 +1291,7 @@ func (b *BlockWalker) handleElseIf(s *ir.ElseIfStmt) {
 	}
 }
 
-func (b *BlockWalker) iterateNextCases(cases []ir.Node, startIdx int) {
+func (b *blockWalker) iterateNextCases(cases []ir.Node, startIdx int) {
 	for i := startIdx; i < len(cases); i++ {
 		cond, list := getCaseStmts(cases[i])
 		if cond != nil {
@@ -1310,7 +1310,7 @@ func (b *BlockWalker) iterateNextCases(cases []ir.Node, startIdx int) {
 	}
 }
 
-func (b *BlockWalker) handleSwitch(s *ir.SwitchStmt) bool {
+func (b *blockWalker) handleSwitch(s *ir.SwitchStmt) bool {
 	// first condition is always executed, so run it in base context
 	if s.Cond != nil {
 		s.Cond.Walk(b)
@@ -1429,7 +1429,7 @@ func (b *BlockWalker) handleSwitch(s *ir.SwitchStmt) bool {
 // if $a was previously undefined,
 // handle case when doing assignment like '$a[] = 4;'
 // or call to function that accepts like exec("command", $a)
-func (b *BlockWalker) handleAndCheckDimFetchLValue(e *ir.ArrayDimFetchExpr, reason string, typ meta.TypesMap) {
+func (b *blockWalker) handleAndCheckDimFetchLValue(e *ir.ArrayDimFetchExpr, reason string, typ meta.TypesMap) {
 	b.checkArrayDimFetch(e)
 
 	switch v := e.Variable.(type) {
@@ -1449,7 +1449,7 @@ func (b *BlockWalker) handleAndCheckDimFetchLValue(e *ir.ArrayDimFetchExpr, reas
 	}
 }
 
-func (b *BlockWalker) checkArrayDimFetch(s *ir.ArrayDimFetchExpr) {
+func (b *blockWalker) checkArrayDimFetch(s *ir.ArrayDimFetchExpr) {
 	if !meta.IsIndexingComplete() {
 		return
 	}
@@ -1478,7 +1478,7 @@ func (b *BlockWalker) checkArrayDimFetch(s *ir.ArrayDimFetchExpr) {
 }
 
 // some day, perhaps, there will be some difference between handleAssignReference and handleAssign
-func (b *BlockWalker) handleAssignReference(a *ir.AssignReference) bool {
+func (b *blockWalker) handleAssignReference(a *ir.AssignReference) bool {
 	switch v := a.Variable.(type) {
 	case *ir.ArrayDimFetchExpr:
 		b.handleAndCheckDimFetchLValue(v, "assign_array", meta.MixedType)
@@ -1500,7 +1500,7 @@ func (b *BlockWalker) handleAssignReference(a *ir.AssignReference) bool {
 	return false
 }
 
-func (b *BlockWalker) handleAssignShapeToList(items []*ir.ArrayItemExpr, info meta.ClassInfo) {
+func (b *blockWalker) handleAssignShapeToList(items []*ir.ArrayItemExpr, info meta.ClassInfo) {
 	for i, item := range items {
 		var prop meta.PropertyInfo
 		var ok bool
@@ -1533,7 +1533,7 @@ func (b *BlockWalker) handleAssignShapeToList(items []*ir.ArrayItemExpr, info me
 	}
 }
 
-func (b *BlockWalker) handleAssignList(list *ir.ListExpr, rhs ir.Node) {
+func (b *blockWalker) handleAssignList(list *ir.ListExpr, rhs ir.Node) {
 	typ := solver.ExprType(b.ctx.sc, b.r.ctx.st, rhs)
 
 	// TODO: test if we can prealloc elemTypes to const size hint like 2
@@ -1582,7 +1582,7 @@ func (b *BlockWalker) handleAssignList(list *ir.ListExpr, rhs ir.Node) {
 	}
 }
 
-func (b *BlockWalker) paramClobberCheck(v *ir.SimpleVar) {
+func (b *blockWalker) paramClobberCheck(v *ir.SimpleVar) {
 	if b.callsFuncGetArgs {
 		return
 	}
@@ -1591,7 +1591,7 @@ func (b *BlockWalker) paramClobberCheck(v *ir.SimpleVar) {
 	}
 }
 
-func (b *BlockWalker) handleAssign(a *ir.Assign) bool {
+func (b *blockWalker) handleAssign(a *ir.Assign) bool {
 	a.Expression.Walk(b)
 
 	switch v := a.Variable.(type) {
@@ -1667,7 +1667,7 @@ func (b *BlockWalker) handleAssign(a *ir.Assign) bool {
 	return false
 }
 
-func (b *BlockWalker) handleAssignOp(assign ir.Node) {
+func (b *blockWalker) handleAssignOp(assign ir.Node) {
 	var typ meta.TypesMap
 	var v ir.Node
 
@@ -1725,7 +1725,7 @@ func (b *BlockWalker) handleAssignOp(assign ir.Node) {
 	b.replaceVar(v, typ, "assign", meta.VarAlwaysDefined)
 }
 
-func (b *BlockWalker) flushUnused() {
+func (b *blockWalker) flushUnused() {
 	if !meta.IsIndexingComplete() {
 		return
 	}
@@ -1752,7 +1752,7 @@ func (b *BlockWalker) flushUnused() {
 	}
 }
 
-func (b *BlockWalker) handleVariableNode(n ir.Node, typ meta.TypesMap, what string) {
+func (b *blockWalker) handleVariableNode(n ir.Node, typ meta.TypesMap, what string) {
 	if n == nil {
 		return
 	}
@@ -1771,7 +1771,7 @@ func (b *BlockWalker) handleVariableNode(n ir.Node, typ meta.TypesMap, what stri
 }
 
 // LeaveNode is called after all children have been visited.
-func (b *BlockWalker) LeaveNode(w ir.Node) {
+func (b *blockWalker) LeaveNode(w ir.Node) {
 	for _, c := range b.custom {
 		c.BeforeLeaveNode(w)
 	}
@@ -1803,10 +1803,10 @@ func (b *BlockWalker) LeaveNode(w ir.Node) {
 	}
 }
 
-func (b *BlockWalker) sideEffectFree(n ir.Node) bool {
+func (b *blockWalker) sideEffectFree(n ir.Node) bool {
 	return solver.SideEffectFree(b.ctx.sc, b.r.ctx.st, b.ctx.customTypes, n)
 }
 
-func (b *BlockWalker) exprType(n ir.Node) meta.TypesMap {
+func (b *blockWalker) exprType(n ir.Node) meta.TypesMap {
 	return solver.ExprTypeCustom(b.ctx.sc, b.r.ctx.st, n, b.ctx.customTypes)
 }

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -15,7 +15,7 @@ import (
 )
 
 type blockLinter struct {
-	walker *BlockWalker
+	walker *blockWalker
 }
 
 func (b *blockLinter) enterNode(n ir.Node) {

--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -172,7 +172,7 @@ func (ctx *RootContext) File() *workspace.File {
 
 // BlockContext is the context for block checker.
 type BlockContext struct {
-	w *BlockWalker
+	w *blockWalker
 }
 
 // NodePath returns a node path up to the current traversal position.

--- a/src/linter/debug.go
+++ b/src/linter/debug.go
@@ -1,0 +1,12 @@
+package linter
+
+import (
+	"log"
+)
+
+// DebugMessage is used to actually print debug messages.
+func DebugMessage(msg string, args ...interface{}) {
+	if Debug {
+		log.Printf(msg, args...)
+	}
+}

--- a/src/linter/limits.go
+++ b/src/linter/limits.go
@@ -2,8 +2,8 @@ package linter
 
 import "github.com/VKCOM/noverify/src/lintdebug"
 
-// ParseWaiter waits to allow parsing of a file.
-type ParseWaiter struct {
+// parseWaiter waits to allow parsing of a file.
+type parseWaiter struct {
 	size int
 }
 
@@ -42,18 +42,18 @@ func MemoryLimiterThread() {
 	}
 }
 
-// BeforeParse must be called before parsing file, so that soft memory
+// beforeParse must be called before parsing file, so that soft memory
 // limit can be applied.
 // Do not forget to call Finish()!
-func BeforeParse(size int, filename string) *ParseWaiter {
+func beforeParse(size int, filename string) *parseWaiter {
 	parseStartCh <- memoryRequest{size: size, filename: filename}
-	return &ParseWaiter{
+	return &parseWaiter{
 		size: size,
 	}
 }
 
 // Finish must be called after parsing is finished (e.g. using defer p.Finish()) to
 // allow other goroutines to parse files.
-func (p *ParseWaiter) Finish() {
+func (p *parseWaiter) Finish() {
 	parseFinishedCh <- p.size
 }

--- a/src/linter/parser.go
+++ b/src/linter/parser.go
@@ -1,13 +1,11 @@
 package linter
 
 import (
-	"log"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/VKCOM/noverify/src/ir"
 	"github.com/VKCOM/noverify/src/lintdebug"
 	"github.com/VKCOM/noverify/src/meta"
 	"github.com/VKCOM/noverify/src/rules"
@@ -31,32 +29,6 @@ func cloneRulesForFile(filename string, ruleSet *rules.ScopedSet) *rules.ScopedS
 		clone.RulesByKind[i] = res
 	}
 	return &clone
-}
-
-// AnalyzeFileRootLevel does analyze file top-level code.
-// This method is exposed for language server use, you usually
-// do not need to call it yourself.
-func AnalyzeFileRootLevel(rootNode ir.Node, d *RootWalker) {
-	sc := meta.NewScope()
-	sc.AddVarName("argv", meta.NewTypesMap("string[]"), "predefined", meta.VarAlwaysDefined)
-	sc.AddVarName("argc", meta.NewTypesMap("int"), "predefined", meta.VarAlwaysDefined)
-
-	b := newBlockWalker(d, sc)
-	b.ignoreFunctionBodies = true
-	b.rootLevel = true
-
-	for _, createFn := range d.customBlock {
-		b.custom = append(b.custom, createFn(&BlockContext{w: b}))
-	}
-
-	rootNode.Walk(b)
-}
-
-// DebugMessage is used to actually print debug messages.
-func DebugMessage(msg string, args ...interface{}) {
-	if Debug {
-		log.Printf(msg, args...)
-	}
 }
 
 // ParseFilenames is used to do initial parsing of files.

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -535,7 +535,7 @@ type handleFuncResult struct {
 	callsParentConstructor bool
 }
 
-func (d *RootWalker) handleArrowFuncExpr(params []meta.FuncParam, expr ir.Node, sc *meta.Scope, parentBlockWalker *BlockWalker) handleFuncResult {
+func (d *RootWalker) handleArrowFuncExpr(params []meta.FuncParam, expr ir.Node, sc *meta.Scope, parentBlockWalker *blockWalker) handleFuncResult {
 	b := newBlockWalker(d, sc)
 	b.inArrowFunction = true
 	parentBlockWalker.parentBlockWalkers = append(parentBlockWalker.parentBlockWalkers, parentBlockWalker)

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -90,9 +90,9 @@ func typesMapToTypeExpr(p *phpdoc.TypeParser, m meta.TypesMap) phpdoc.Type {
 	return p.Parse(typeString)
 }
 
-// MergeTypeMaps merges two typesmaps without losing information.
+// mergeTypeMaps merges two typesmaps without losing information.
 // So merging int[] and array will give int[], and Foo and object will give Foo.
-func MergeTypeMaps(left meta.TypesMap, right meta.TypesMap) meta.TypesMap {
+func mergeTypeMaps(left meta.TypesMap, right meta.TypesMap) meta.TypesMap {
 	var hasAtLeastOneArray bool
 	var hasAtLeastOneClass bool
 
@@ -135,7 +135,7 @@ func MergeTypeMaps(left meta.TypesMap, right meta.TypesMap) meta.TypesMap {
 func functionReturnType(phpdocReturnType meta.TypesMap, hintReturnType meta.TypesMap, actualReturnTypes meta.TypesMap) meta.TypesMap {
 	var returnTypes meta.TypesMap
 	if !phpdocReturnType.IsEmpty() || !hintReturnType.IsEmpty() {
-		returnTypes = MergeTypeMaps(phpdocReturnType, hintReturnType)
+		returnTypes = mergeTypeMaps(phpdocReturnType, hintReturnType)
 	} else {
 		returnTypes = actualReturnTypes
 	}


### PR DESCRIPTION
Most notable, RootWalker and BlockWalker are unexported now.