### PR TITLE
linter: two methods for getting the string representation of a node are combined into one

### DIFF
--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -658,7 +658,7 @@ func (b *blockLinter) checkArray(arr *ir.ArrayExpr) {
 		}
 
 		if n, ok := keys[key]; ok {
-			origKey := string(b.walker.r.nodeText(n))
+			origKey := b.walker.r.fmtNode(n)
 			dupKey := fmt.Sprintf("%#q", key)
 			msg := fmt.Sprintf("Duplicate array key %s", origKey)
 			if origKey != dupKey && origKey != key {
@@ -892,7 +892,7 @@ func (b *blockLinter) checkRegexp(e *ir.FunctionCallExpr, arg *ir.Argument) {
 	pat := s.Value
 	simplified := b.walker.r.reSimplifier.simplifyRegexp(pat)
 	if simplified != "" {
-		rawPattern := b.walker.r.nodeText(s)
+		rawPattern := b.walker.r.fmtNode(s)
 		b.report(arg, LevelDoNotReject, "regexpSimplify", "May re-write %s as '%s'",
 			rawPattern, simplified)
 	}

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -658,7 +658,7 @@ func (b *blockLinter) checkArray(arr *ir.ArrayExpr) {
 		}
 
 		if n, ok := keys[key]; ok {
-			origKey := b.walker.r.fmtNode(n)
+			origKey := b.walker.r.nodeText(n)
 			dupKey := fmt.Sprintf("%#q", key)
 			msg := fmt.Sprintf("Duplicate array key %s", origKey)
 			if origKey != dupKey && origKey != key {
@@ -892,7 +892,7 @@ func (b *blockLinter) checkRegexp(e *ir.FunctionCallExpr, arg *ir.Argument) {
 	pat := s.Value
 	simplified := b.walker.r.reSimplifier.simplifyRegexp(pat)
 	if simplified != "" {
-		rawPattern := b.walker.r.fmtNode(s)
+		rawPattern := b.walker.r.nodeText(s)
 		b.report(arg, LevelDoNotReject, "regexpSimplify", "May re-write %s as '%s'",
 			rawPattern, simplified)
 	}

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1717,9 +1717,9 @@ func (d *rootWalker) runRules(n ir.Node, sc *meta.Scope, rlist []rules.Rule) {
 	}
 }
 
-// fmtNode is used to get the string that represents the
+// nodeText is used to get the string that represents the
 // passed node more efficiently than irutil.FmtNode.
-func (d *rootWalker) fmtNode(n ir.Node) string {
+func (d *rootWalker) nodeText(n ir.Node) string {
 	pos := ir.GetPosition(n)
 	from, to := pos.StartPos, pos.EndPos
 	src := d.file.Contents()
@@ -1735,7 +1735,7 @@ func (d *rootWalker) fmtNode(n ir.Node) string {
 func (d *rootWalker) renderRuleMessage(msg string, n ir.Node, m phpgrep.MatchData, truncate bool) string {
 	// "$$" stands for the entire matched node, like $0 in regexp.
 	if strings.Contains(msg, "$$") {
-		msg = strings.ReplaceAll(msg, "$$", d.fmtNode(n))
+		msg = strings.ReplaceAll(msg, "$$", d.nodeText(n))
 	}
 
 	if len(m.Capture) == 0 {
@@ -1746,7 +1746,7 @@ func (d *rootWalker) renderRuleMessage(msg string, n ir.Node, m phpgrep.MatchDat
 		if !strings.Contains(msg, key) {
 			continue
 		}
-		nodeString := d.fmtNode(c.Node)
+		nodeString := d.nodeText(c.Node)
 		// Don't interpolate strings that are too long
 		// or contain a newline.
 		var replacement string

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1717,10 +1717,11 @@ func (d *rootWalker) runRules(n ir.Node, sc *meta.Scope, rlist []rules.Rule) {
 	}
 }
 
-func (d *rootWalker) sourceNodeString(n ir.Node) string {
+// fmtNode is used to get the string that represents the
+// passed node more efficiently than irutil.FmtNode.
+func (d *rootWalker) fmtNode(n ir.Node) string {
 	pos := ir.GetPosition(n)
-	from := pos.StartPos
-	to := pos.EndPos
+	from, to := pos.StartPos, pos.EndPos
 	src := d.file.Contents()
 	// Taking a node from the source code preserves the original formatting
 	// and is more efficient than printing it.
@@ -1734,7 +1735,7 @@ func (d *rootWalker) sourceNodeString(n ir.Node) string {
 func (d *rootWalker) renderRuleMessage(msg string, n ir.Node, m phpgrep.MatchData, truncate bool) string {
 	// "$$" stands for the entire matched node, like $0 in regexp.
 	if strings.Contains(msg, "$$") {
-		msg = strings.ReplaceAll(msg, "$$", d.sourceNodeString(n))
+		msg = strings.ReplaceAll(msg, "$$", d.fmtNode(n))
 	}
 
 	if len(m.Capture) == 0 {
@@ -1745,7 +1746,7 @@ func (d *rootWalker) renderRuleMessage(msg string, n ir.Node, m phpgrep.MatchDat
 		if !strings.Contains(msg, key) {
 			continue
 		}
-		nodeString := d.sourceNodeString(c.Node)
+		nodeString := d.fmtNode(c.Node)
 		// Don't interpolate strings that are too long
 		// or contain a newline.
 		var replacement string
@@ -1942,11 +1943,6 @@ func (d *rootWalker) checkKeywordCase(n ir.Node, keyword string) {
 	// Only works for nodes that have a keyword of interest
 	// as the leftmost token.
 	d.checkKeywordCasePos(n, ir.GetPosition(n).StartPos, keyword)
-}
-
-func (d *rootWalker) nodeText(n ir.Node) []byte {
-	pos := ir.GetPosition(n)
-	return d.file.Contents()[pos.StartPos:pos.EndPos]
 }
 
 func (d *rootWalker) parseClassPHPDoc(n ir.Node, doc []phpdoc.CommentPart) classPhpDocParseResult {


### PR DESCRIPTION
The method was named `fmtNode`.