### PR TITLE
phpdoc: fix type parser panic on type names with '-'

### DIFF
--- a/src/phpdoc/type_parser.go
+++ b/src/phpdoc/type_parser.go
@@ -433,8 +433,8 @@ func (p *TypeParser) isDigit(ch byte) bool {
 }
 
 func (p *TypeParser) isNameChar(ch byte) bool {
-	// [\\a-zA-Z_\x7f-\xff0-9]
-	return ch == '\\' || p.isFirstIdentChar(ch) || p.isDigit(ch)
+	// [\\a-zA-Z_\x7f-\xff0-9] and '-'
+	return ch == '\\' || p.isFirstIdentChar(ch) || p.isDigit(ch) || ch == '-'
 }
 
 func (p *TypeParser) isFirstIdentChar(ch byte) bool {

--- a/src/phpdoc/type_parser_test.go
+++ b/src/phpdoc/type_parser_test.go
@@ -19,6 +19,7 @@ func TestParser(t *testing.T) {
 		{`foo`, `Name="foo"`},
 		{`\A\B`, `Name="\A\B"`},
 		{`$this`, `Name="$this"`},
+		{`non-empty-list`, `Name="non-empty-list"`},
 
 		// Ints.
 		{`0`, `Int="0"`},
@@ -79,6 +80,9 @@ func TestParser(t *testing.T) {
 		{`array<int>`, `Generic="array<int>"{Name="array" Name="int"}`},
 		{`array<int,string>`, `Generic="array<int,string>"{Name="array" Name="int" Name="string"}`},
 		{`array<int, array<string, stdclass> >`, `Generic="array<int, array<string, stdclass> >"{Name="array" Name="int" Generic="array<string, stdclass>"{Name="array" Name="string" Name="stdclass"}}`},
+		{`array<non-empty-list<string>>`, `Generic="array<non-empty-list<string>>"{Name="array" Generic="non-empty-list<string>"{Name="non-empty-list" Name="string"}}`},
+		{`array<non-empty-list<string>`, `Generic="array<non-empty-list<string>"{Name="array" Generic="non-empty-list<string>"{Name="non-empty-list" Name="string"}}`},
+		{`non-empty-list<string>`, `Generic="non-empty-list<string>"{Name="non-empty-list" Name="string"}`},
 		{`?A<B>`, `Nullable="?A<B>"{Generic="A<B>"{Name="A" Name="B"}}`},
 
 		// Alternative generic syntax 1.


### PR DESCRIPTION
Some type names, like `non-empty-list` contain '-' in their names.
We don't want to fail parsing those.