### PR TITLE
meta: add *Info param to the post-indexing callbacks

### DIFF
--- a/src/meta/info.go
+++ b/src/meta/info.go
@@ -9,7 +9,7 @@ import (
 type Info struct {
 	indexingComplete   bool
 	loadingStubs       bool
-	onIndexingComplete []func()
+	onIndexingComplete []func(*Info)
 
 	sync.Mutex
 	*Scope
@@ -44,9 +44,9 @@ func NewInfo() *Info {
 	}
 }
 
-func (i *Info) OnIndexingComplete(cb func()) {
+func (i *Info) OnIndexingComplete(cb func(*Info)) {
 	if i.indexingComplete {
-		cb()
+		cb(i)
 	} else {
 		i.onIndexingComplete = append(i.onIndexingComplete, cb)
 	}
@@ -73,7 +73,7 @@ func (i *Info) SetIndexingComplete(complete bool) {
 
 	if complete {
 		for _, cb := range i.onIndexingComplete {
-			cb()
+			cb(i)
 		}
 	}
 }


### PR DESCRIPTION
Since meta.Info is not global anymore, it's logical to
pass the actual Info object to the hook so it can operate
on the relevant object (the one that had the hook installed).