### PR TITLE
linter: compute hashes when --output-baseline is set

### DIFF
--- a/src/cmd/linter_runner.go
+++ b/src/cmd/linter_runner.go
@@ -106,6 +106,8 @@ func (l *linterRunner) Init(ruleSets []*rules.Set, args *cmdlineArguments) error
 
 	l.config.PhpExtensions = strings.Split(args.phpExtensionsArg, ",")
 
+	l.config.ComputeBaselineHashes = l.args.baseline != "" || l.args.outputBaseline
+
 	if args.misspellList != "" {
 		err := LoadMisspellDicts(l.config, strings.Split(args.misspellList, ","))
 		if err != nil {

--- a/src/linter/conf.go
+++ b/src/linter/conf.go
@@ -15,8 +15,9 @@ import (
 type Config struct {
 	// BaselineProfile is a suppression database for warnings.
 	// Nil profile is an empty suppression profile.
-	BaselineProfile      *baseline.Profile
-	ConservativeBaseline bool
+	BaselineProfile       *baseline.Profile
+	ComputeBaselineHashes bool // Whether we need to compute report hashes
+	ConservativeBaseline  bool
 
 	ApplyQuickFixes bool
 

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -364,8 +364,8 @@ func (d *rootWalker) report(n ir.Node, lineNumber int, level int, checkName, msg
 	}
 	msg = fmt.Sprintf(msg, args...)
 	var hash uint64
-	if d.config.BaselineProfile != nil {
-		// If baseline is not enabled, don't waste time on hash computations.
+	// If baseline is not enabled, don't waste time on hash computations.
+	if d.config.ComputeBaselineHashes {
 		hash = d.reportHash(&pos, startLn, checkName, msg)
 		if count := d.ctx.baseline.Count(hash); count >= 1 {
 			if d.ctx.hashCounters == nil {


### PR DESCRIPTION
During one of the previous refactorings the baseline hash
computations were broken for the baseline output mode.
This resulted in all report hashes to be 0.

This change makes linter compute hashes when --output-baseline is set
in addtion to the case when --baseline is a non empty string.