### PR TITLE
cmd: small refactor rule init code

### DIFF
--- a/src/cmd/help.go
+++ b/src/cmd/help.go
@@ -47,11 +47,12 @@ func Help(*MainConfig) (int, error) {
 func declareRules() *linter.Config {
 	p := rules.NewParser()
 	config := linter.NewConfig()
-	config.Rules = rules.NewSet()
-	ruleSets, err := InitEmbeddedRules(config, p, func(r rules.Rule) bool { return true })
+
+	ruleSets, err := AddEmbeddedRules(config.Rules, p, func(r rules.Rule) bool { return true })
 	if err != nil {
 		panic(err)
 	}
+
 	for _, rset := range ruleSets {
 		config.Checkers.DeclareRules(rset)
 	}

--- a/src/cmd/help.go
+++ b/src/cmd/help.go
@@ -47,6 +47,7 @@ func Help(*MainConfig) (int, error) {
 func declareRules() *linter.Config {
 	p := rules.NewParser()
 	config := linter.NewConfig()
+	config.Rules = rules.NewSet()
 	ruleSets, err := InitEmbeddedRules(config, p, func(r rules.Rule) bool { return true })
 	if err != nil {
 		panic(err)

--- a/src/cmd/linter_runner.go
+++ b/src/cmd/linter_runner.go
@@ -203,9 +203,8 @@ func (l *linterRunner) initRules(ruleSets []*rules.Set) error {
 		return l.IsEnabledByFlags(r.Name)
 	}
 
-	l.config.Rules = rules.NewSet()
 	for _, rset := range ruleSets {
-		appendRuleSet(l.config, rset, ruleFilter)
+		appendRuleSet(l.config.Rules, rset, ruleFilter)
 	}
 
 	return nil

--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -11,17 +11,17 @@ import (
 	"github.com/VKCOM/noverify/src/rules"
 )
 
-func AddEmbeddedRules(rulesSet *rules.Set, p *rules.Parser, filter func(r rules.Rule) bool) ([]*rules.Set, error) {
-	ruleSets, err := parseEmbeddedRules(p)
+func AddEmbeddedRules(rset *rules.Set, p *rules.Parser, filter func(r rules.Rule) bool) ([]*rules.Set, error) {
+	embeddedRules, err := parseEmbeddedRules(p)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, rset := range ruleSets {
-		appendRuleSet(rulesSet, rset, filter)
+	for _, embeddedRule := range embeddedRules {
+		appendRuleSet(rset, embeddedRule, filter)
 	}
 
-	return ruleSets, nil
+	return embeddedRules, nil
 }
 
 func parseRules() ([]*rules.Set, error) {

--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -17,6 +17,7 @@ func InitEmbeddedRules(config *linter.Config, p *rules.Parser, filter func(r rul
 	if err != nil {
 		return nil, err
 	}
+
 	for _, rset := range ruleSets {
 		appendRuleSet(config, rset, filter)
 	}

--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -86,7 +86,7 @@ func parseEmbeddedRules(p *rules.Parser) ([]*rules.Set, error) {
 	return ruleSets, nil
 }
 
-func appendRuleSet(rulesSet *rules.Set, rset *rules.Set, filter func(r rules.Rule) bool) {
+func appendRuleSet(dstSet *rules.Set, srcSet *rules.Set, filter func(r rules.Rule) bool) {
 	appendRules := func(dst, src *rules.ScopedSet) {
 		for i, list := range &src.RulesByKind {
 			for _, r := range list {
@@ -97,7 +97,7 @@ func appendRuleSet(rulesSet *rules.Set, rset *rules.Set, filter func(r rules.Rul
 			}
 		}
 	}
-	appendRules(rulesSet.Any, rset.Any)
-	appendRules(rulesSet.Root, rset.Root)
-	appendRules(rulesSet.Local, rset.Local)
+	appendRules(dstSet.Any, srcSet.Any)
+	appendRules(dstSet.Root, srcSet.Root)
+	appendRules(dstSet.Local, srcSet.Local)
 }

--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/VKCOM/noverify/src/cmd/embeddedrules"
+	"github.com/VKCOM/noverify/src/ir"
 	"github.com/VKCOM/noverify/src/rules"
 )
 
@@ -88,12 +89,13 @@ func parseEmbeddedRules(p *rules.Parser) ([]*rules.Set, error) {
 
 func appendRuleSet(dstSet *rules.Set, srcSet *rules.Set, filter func(r rules.Rule) bool) {
 	appendRules := func(dst, src *rules.ScopedSet) {
-		for i, list := range &src.RulesByKind {
-			for _, r := range list {
-				if !filter(r) {
+		for kind, ruleByKind := range &src.RulesByKind {
+			for _, rule := range ruleByKind {
+				if !filter(rule) {
 					continue
 				}
-				dst.RulesByKind[i] = append(dst.RulesByKind[i], r)
+
+				dst.Add(ir.NodeKind(kind), rule)
 			}
 		}
 	}

--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -11,14 +11,14 @@ import (
 	"github.com/VKCOM/noverify/src/rules"
 )
 
-func AddEmbeddedRules(rules *rules.Set, p *rules.Parser, filter func(r rules.Rule) bool) ([]*rules.Set, error) {
+func AddEmbeddedRules(rulesSet *rules.Set, p *rules.Parser, filter func(r rules.Rule) bool) ([]*rules.Set, error) {
 	ruleSets, err := parseEmbeddedRules(p)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, rset := range ruleSets {
-		appendRuleSet(rules, rset, filter)
+		appendRuleSet(rulesSet, rset, filter)
 	}
 
 	return ruleSets, nil

--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -8,19 +8,19 @@ import (
 	"strings"
 
 	"github.com/VKCOM/noverify/src/cmd/embeddedrules"
-	"github.com/VKCOM/noverify/src/linter"
 	"github.com/VKCOM/noverify/src/rules"
 )
 
-func InitEmbeddedRules(config *linter.Config, p *rules.Parser, filter func(r rules.Rule) bool) ([]*rules.Set, error) {
+func AddEmbeddedRules(rules *rules.Set, p *rules.Parser, filter func(r rules.Rule) bool) ([]*rules.Set, error) {
 	ruleSets, err := parseEmbeddedRules(p)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, rset := range ruleSets {
-		appendRuleSet(config, rset, filter)
+		appendRuleSet(rules, rset, filter)
 	}
+
 	return ruleSets, nil
 }
 
@@ -86,7 +86,7 @@ func parseEmbeddedRules(p *rules.Parser) ([]*rules.Set, error) {
 	return ruleSets, nil
 }
 
-func appendRuleSet(config *linter.Config, rset *rules.Set, filter func(r rules.Rule) bool) {
+func appendRuleSet(rulesSet *rules.Set, rset *rules.Set, filter func(r rules.Rule) bool) {
 	appendRules := func(dst, src *rules.ScopedSet) {
 		for i, list := range &src.RulesByKind {
 			for _, r := range list {
@@ -97,7 +97,7 @@ func appendRuleSet(config *linter.Config, rset *rules.Set, filter func(r rules.R
 			}
 		}
 	}
-	appendRules(config.Rules.Any, rset.Any)
-	appendRules(config.Rules.Root, rset.Root)
-	appendRules(config.Rules.Local, rset.Local)
+	appendRules(rulesSet.Any, rset.Any)
+	appendRules(rulesSet.Root, rset.Root)
+	appendRules(rulesSet.Local, rset.Local)
 }

--- a/src/cmd/rules.go
+++ b/src/cmd/rules.go
@@ -13,16 +13,16 @@ import (
 )
 
 func AddEmbeddedRules(rset *rules.Set, p *rules.Parser, filter func(r rules.Rule) bool) ([]*rules.Set, error) {
-	embeddedRules, err := parseEmbeddedRules(p)
+	embeddedRuleSets, err := parseEmbeddedRules(p)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, embeddedRule := range embeddedRules {
-		appendRuleSet(rset, embeddedRule, filter)
+	for _, embeddedRuleSet := range embeddedRuleSets {
+		appendRuleSet(rset, embeddedRuleSet, filter)
 	}
 
-	return embeddedRules, nil
+	return embeddedRuleSets, nil
 }
 
 func parseRules() ([]*rules.Set, error) {

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -329,11 +329,12 @@ func (b *blockWalker) EnterNode(n ir.Node) (res bool) {
 	if b.isIndexingComplete() {
 		b.linter.enterNode(n)
 	}
-	if b.isIndexingComplete() && b.r.anyRset != nil {
+	if b.isIndexingComplete() {
 		// Note: no need to check localRset for nil.
 		kind := ir.GetNodeKind(n)
-		b.r.runRules(n, b.ctx.sc, b.r.anyRset.RulesByKind[kind])
-		if !b.rootLevel {
+		if b.r.anyRset != nil {
+			b.r.runRules(n, b.ctx.sc, b.r.anyRset.RulesByKind[kind])
+		} else if !b.rootLevel && b.r.localRset != nil {
 			b.r.runRules(n, b.ctx.sc, b.r.localRset.RulesByKind[kind])
 		}
 	}

--- a/src/linter/conf.go
+++ b/src/linter/conf.go
@@ -68,7 +68,7 @@ func NewConfig() *Config {
 	addBuiltinCheckers(reg)
 	return &Config{
 		SrcInput:       inputs.NewDefaultSourceInput(),
-		Rules:          &rules.Set{},
+		Rules:          rules.NewSet(),
 		MaxConcurrency: runtime.NumCPU(),
 		IsDiscardVar:   isUnderscore,
 		Checkers:       reg,

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -520,20 +520,20 @@ func binaryOpString(n ir.Node) string {
 }
 
 func cloneRulesForFile(filename string, ruleSet *rules.ScopedSet) *rules.ScopedSet {
-	if ruleSet == nil {
+	if ruleSet.CountRules == 0 {
 		return nil
 	}
 
 	var clone rules.ScopedSet
-	for i, list := range &ruleSet.RulesByKind {
-		res := make([]rules.Rule, 0, len(list))
-		for _, rule := range list {
+	for kind, ruleByKind := range &ruleSet.RulesByKind {
+		res := make([]rules.Rule, 0, len(ruleByKind))
+		for _, rule := range ruleByKind {
 			if !strings.Contains(filename, rule.Path) {
 				continue
 			}
 			res = append(res, rule)
 		}
-		clone.RulesByKind[i] = res
+		clone.Set(ir.NodeKind(kind), res)
 	}
 	return &clone
 }

--- a/src/linttest/linttest.go
+++ b/src/linttest/linttest.go
@@ -344,14 +344,16 @@ func FindPHPFiles(root string) ([]string, error) {
 func InitEmbeddedRules(config *linter.Config) error {
 	enableAllRules := func(_ rules.Rule) bool { return true }
 	p := rules.NewParser()
-	config.Rules = rules.NewSet()
-	ruleSets, err := cmd.InitEmbeddedRules(config, p, enableAllRules)
+
+	ruleSets, err := cmd.AddEmbeddedRules(config.Rules, p, enableAllRules)
 	if err != nil {
 		return fmt.Errorf("init embedded rules: %v", err)
 	}
+
 	for _, rset := range ruleSets {
 		config.Checkers.DeclareRules(rset)
 	}
+
 	return nil
 }
 

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -365,8 +365,7 @@ func (p *parser) parseRule(st ir.Node, proto *Rule) error {
 		st = st2.Expr
 	}
 	kind := ir.GetNodeKind(st)
-	dst.RulesByKind[kind] = append(dst.RulesByKind[kind], rule)
-
+	dst.Add(kind, rule)
 	return nil
 }
 

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -44,6 +44,17 @@ type Set struct {
 // Categories help to assign a better execution strategy for a rule.
 type ScopedSet struct {
 	RulesByKind [ir.NumKinds][]Rule
+	CountRules  int
+}
+
+func (s *ScopedSet) Add(kind ir.NodeKind, rule Rule) {
+	s.RulesByKind[kind] = append(s.RulesByKind[kind], rule)
+	s.CountRules++
+}
+
+func (s *ScopedSet) Set(kind ir.NodeKind, rules []Rule) {
+	s.RulesByKind[kind] = append(s.RulesByKind[kind], rules...)
+	s.CountRules += len(rules)
 }
 
 type RuleDoc struct {


### PR DESCRIPTION
The `Config.Rules` field is now fully initialized, including
the fields of the `rules.Set` structure. Thus, we got rid of the
need to initialize this field every time.

The `InitEmbeddedRules` function has been renamed to `AddEmbeddedRules`
and now accepts not the config, but the rules directly, as well
as for the `appendRuleSet` function.