### PR TITLE
linter: fixed false positive of parentConstructor

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -804,7 +804,9 @@ func (b *blockWalker) handleMethodCall(e *ir.MethodCallExpr) bool {
 
 func (b *blockWalker) handleStaticCall(e *ir.StaticCallExpr) bool {
 	call := resolveStaticMethodCall(b.r.ctx.st, e)
-	b.callsParentConstructor = call.isCallsParentConstructor
+	if !b.callsParentConstructor {
+		b.callsParentConstructor = call.isCallsParentConstructor
+	}
 
 	e.Class.Walk(b)
 	e.Call.Walk(b)

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -74,6 +74,33 @@ class Bad2 extends WithTwoParams {
 	test.RunAndMatch()
 }
 
+func TestParentConstructorCallWithOtherStaticCall(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+class Foo {
+	public function __construct(int $a) {}
+}
+
+class Boo extends Foo {
+  /** doc */
+  public static function getId(): int {}
+
+  public function __construct() {
+    parent::__construct(self::getId());
+  }
+}
+
+class Goo extends Foo {
+  /** doc */
+  public static function getId(): int {}
+
+  public function __construct() {
+    parent::__construct(100);
+    $_ = self::getId();
+  }
+}
+`)
+}
+
 func TestNewAbstract(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
Since the presence of the parent construct during the
traversal of the function is in `blockWalker`, during
the processing of each static call `blockWalker.callsParentConstructor`
was overwritten, which led to a situation when there
is a call to the parent constructor, but another static
call (including in the arguments when calling the parent
constructor) overwritten the value to `false`.