### PR TITLE
linter: treat trigger_error($msg, E_USER_ERROR) as exit()

### DIFF
--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -179,10 +179,10 @@ func bindFlags(config *linter.Config, ruleSets []*rules.Set, args *cmdlineArgume
 	flag.StringVar(&config.StubsDir, "stubs-dir", "", "Directory with phpstorm-stubs")
 	flag.StringVar(&config.CacheDir, "cache-dir", DefaultCacheDir(), "Directory for linter cache (greatly improves indexing speed)")
 	flag.BoolVar(&args.disableCache, "disable-cache", false, "If set, cache is not used and cache-dir is ignored")
+	flag.BoolVar(&config.IgnoreTriggerError, "ignore-trigger-error", false, "If set, trigger_error control flow will be ignored")
 
 	flag.StringVar(&args.unusedVarPattern, "unused-var-regex", `^_$`,
 		"Variables that match such regexp are marked as discarded; not reported as unused, but should not be used as values")
-
 	flag.BoolVar(&args.version, "version", false, "Show version info and exit")
 
 	flag.StringVar(&args.cpuProfile, "cpuprofile", "", "Write cpu profile to `file`")

--- a/src/linter/conf.go
+++ b/src/linter/conf.go
@@ -59,6 +59,8 @@ type Config struct {
 	PhpExtensions []string
 
 	Checkers *CheckersRegistry
+
+	IgnoreTriggerError bool
 }
 
 func NewConfig() *Config {

--- a/src/tests/checkers/trigger_error_test.go
+++ b/src/tests/checkers/trigger_error_test.go
@@ -1,0 +1,68 @@
+package checkers_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestTriggerNonError(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+trigger_error('notice');
+trigger_error('also notice', E_USER_NOTICE);
+trigger_error('a warning', E_USER_WARNING);
+`)
+}
+
+func TestTriggerErrorFQN(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+\trigger_error('error', E_USER_ERROR);
+echo 'unreachable';
+`)
+	test.Expect = []string{
+		`Unreachable code`,
+	}
+	test.RunAndMatch()
+}
+
+func TestTriggerError(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+trigger_error('error', E_USER_ERROR);
+echo 'unreachable';
+`)
+	test.Expect = []string{
+		`Unreachable code`,
+	}
+	test.RunAndMatch()
+}
+
+func TestTriggerErrorTransitive(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function f($msg) {
+  trigger_error($msg, E_USER_ERROR);
+}
+
+f('error');
+echo 'unreachable';
+`)
+	test.Expect = []string{
+		`Unreachable code`,
+	}
+	test.RunAndMatch()
+}
+
+func TestUserError(t *testing.T) {
+	// user_error is a trigger_error alias.
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+user_error('error', E_USER_ERROR);
+echo 'unreachable';
+`)
+	test.Expect = []string{
+		`Unreachable code`,
+	}
+	test.RunAndMatch()
+}


### PR DESCRIPTION
Since some projects may use some recovery with set_error_handler,
there is a `-ignore-trigger-error` flag to disable this behavior.