### PR TITLE
linter: fix cache error

### DIFF
--- a/src/linter/worker.go
+++ b/src/linter/worker.go
@@ -139,7 +139,6 @@ func (w *Worker) IndexFile(file workspace.FileInfo) error {
 		return err
 	}
 
-	var contents []byte
 	h := md5.New()
 
 	if file.Contents == nil {
@@ -153,7 +152,7 @@ func (w *Worker) IndexFile(file workspace.FileInfo) error {
 			return err
 		}
 		atomic.AddInt64(&initFileReadTime, int64(time.Since(start)))
-	} else if _, err := h.Write(contents); err != nil {
+	} else if _, err := h.Write(file.Contents); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Due to the fact that the hash of the file was calculated
using the `contents` variable (which was always empty), and
not by the required `file.Contents()`, the hash of the file
was always the same.

This led to a situation in which a change in the file (for
example, adding a constant to a class) did not change its
cached data (information about the class without a new constant
remained in the cached data), since due to the fact that the
 file with the cache for the current hash exists (that is,
 the file `test.php_<hash_val>` exists), then there was no
 repeated parsing of the file, which would update the data
 (add information about the constant) and write it to the
 cache.

In general, this was due to the fact that the function
signature changed from

```go
func IndexFile(filename string, contents []byte) error
```
to
```go
func IndexFile(file workspace.FileInfo) error
```

and instead of using `file.Contents()`, a variable `contents`
was created which was always empty and because of which the
hash for the file was always the same.