### PR TITLE
linter: add stripTags checker

### DIFF
--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -17,6 +17,15 @@ const (
 func addBuiltinCheckers(reg *CheckersRegistry) {
 	allChecks := []CheckerInfo{
 		{
+			Name:     "stripTags",
+			Default:  true,
+			Quickfix: false,
+			Comment:  `Report invalid strip_tags function usage.`,
+			Before:   `$s = strip_tags($s, '<br/>')`,
+			After:    `$s = strip_tags($s, '<br>')`,
+		},
+
+		{
 			Name:     "emptyStmt",
 			Default:  true,
 			Quickfix: false,

--- a/src/tests/checkers/stripTags_test.go
+++ b/src/tests/checkers/stripTags_test.go
@@ -1,0 +1,71 @@
+package checkers_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestStripTagsGood(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{"stubs/phpstorm-stubs/standard/standard_1.php"}
+	test.AddFile(`<?php
+function f(string $s) {
+  $_ = strip_tags($s, ['br', 'a']);
+  $_ = strip_tags($s, ['BR']);
+
+  $_ = strip_tags($s, ' <a><br><html> ');
+  $_ = strip_tags($s, '<br>');
+}
+`)
+	test.RunAndMatch()
+}
+
+func TestStripTagsArray(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{"stubs/phpstorm-stubs/standard/standard_1.php"}
+	test.AddFile(`<?php
+function f(string $s) {
+  return strip_tags($s, ['<br>', 'a', 'A']);
+}
+`)
+	test.Expect = []string{
+		`$allowed_tags argument: '<' and '>' are not needed for tags when using array argument`,
+		`$allowed_tags argument: tag 'A' is duplicated, previously spelled as 'a'`,
+	}
+	test.RunAndMatch()
+}
+
+func TestStripTagsString1(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{"stubs/phpstorm-stubs/standard/standard_1.php"}
+	test.AddFile(`<?php
+function f1(string $s) {
+  return strip_tags($s, '<a href="#">');
+}
+function f2(string $s) {
+  return strip_tags($s, "<a href='#'>");
+}
+`)
+	test.Expect = []string{
+		`$allowed_tags argument: using values/attrs is an error; they make matching always fail`,
+		`$allowed_tags argument: using values/attrs is an error; they make matching always fail`,
+	}
+	test.RunAndMatch()
+}
+
+func TestStripTagsString2(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{"stubs/phpstorm-stubs/standard/standard_1.php"}
+	test.AddFile(`<?php
+function f(string $s) {
+  return strip_tags($s, '<a ><br/><br>');
+}
+`)
+	test.Expect = []string{
+		`$allowed_tags argument: tag '<a >' should not contain spaces`,
+		`$allowed_tags argument: '<br/>' should be written as '<br>'`,
+		`$allowed_tags argument: tag '<br>' is duplicated, previously spelled as '<br/>'`,
+	}
+	test.RunAndMatch()
+}


### PR DESCRIPTION
Reports suspicious usage of `string_tags()` function.
More precisely, it checks that `$allowed_tags` argument is valid.

There are many ways to use this function incorrectly.
This checker tries to find the most common mistakes.