### PR TITLE
ir: refactor ir

### DIFF
--- a/src/ir/get_first_token.go
+++ b/src/ir/get_first_token.go
@@ -130,8 +130,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignBitwiseAnd:
 		if n.Variable != nil {
@@ -140,8 +140,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignBitwiseOr:
 		if n.Variable != nil {
@@ -150,8 +150,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignBitwiseXor:
 		if n.Variable != nil {
@@ -160,8 +160,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignCoalesce:
 		if n.Variable != nil {
@@ -170,8 +170,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignConcat:
 		if n.Variable != nil {
@@ -180,8 +180,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignDiv:
 		if n.Variable != nil {
@@ -190,8 +190,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignMinus:
 		if n.Variable != nil {
@@ -200,8 +200,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignMod:
 		if n.Variable != nil {
@@ -210,8 +210,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignMul:
 		if n.Variable != nil {
@@ -220,8 +220,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignPlus:
 		if n.Variable != nil {
@@ -230,8 +230,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignPow:
 		if n.Variable != nil {
@@ -240,8 +240,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignReference:
 		if n.Variable != nil {
@@ -250,8 +250,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignShiftLeft:
 		if n.Variable != nil {
@@ -260,8 +260,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *AssignShiftRight:
 		if n.Variable != nil {
@@ -270,8 +270,8 @@ func GetFirstToken(n Node) *token.Token {
 		if n.EqualTkn != nil {
 			return n.EqualTkn
 		}
-		if n.Expression != nil {
-			return GetFirstToken(n.Expression)
+		if n.Expr != nil {
+			return GetFirstToken(n.Expr)
 		}
 	case *BadString:
 		if n.MinusTkn != nil {

--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -70,14 +70,14 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 
 		// hack for expressions like:
 		// /**
 		//  * @param Boo $x
 		//  */
 		// $_ = fn($x) => $x->b();
-		if arrowFn, ok := out.Expression.(*ir.ArrowFunctionExpr); ok {
+		if arrowFn, ok := out.Expr.(*ir.ArrowFunctionExpr); ok {
 			doc, found := irutil.FindPhpDoc(out.Variable)
 			if found {
 				arrowFn.PhpDocComment = doc
@@ -95,7 +95,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignBitwiseOr:
@@ -106,7 +106,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignBitwiseXor:
@@ -117,7 +117,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignCoalesce:
@@ -128,7 +128,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignConcat:
@@ -139,7 +139,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignDiv:
@@ -150,7 +150,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignMinus:
@@ -161,7 +161,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignMod:
@@ -172,7 +172,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignMul:
@@ -183,7 +183,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignPlus:
@@ -194,7 +194,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignPow:
@@ -205,7 +205,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignReference:
@@ -216,7 +216,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignShiftLeft:
@@ -227,7 +227,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprAssignShiftRight:
@@ -238,7 +238,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.Position = n.Position
 		out.EqualTkn = n.EqualTkn
 		out.Variable = c.convNode(n.Var)
-		out.Expression = c.convNode(n.Expr)
+		out.Expr = c.convNode(n.Expr)
 		return out
 
 	case *ast.ExprBinaryBitwiseAnd:

--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -2267,12 +2267,14 @@ func convString(n *ast.ScalarString) ir.Node {
 	s, err := interpretString(unquoted, quote)
 	if err != nil {
 		return &ir.BadString{
-			MinusTkn:     n.MinusTkn,
-			StringTkn:    n.StringTkn,
-			Position:     n.Position,
-			Value:        string(unquoted),
-			Error:        err.Error(),
-			DoubleQuotes: out.DoubleQuotes,
+			String: ir.String{
+				MinusTkn:     n.MinusTkn,
+				StringTkn:    n.StringTkn,
+				Position:     n.Position,
+				Value:        string(unquoted),
+				DoubleQuotes: out.DoubleQuotes,
+			},
+			Error: err.Error(),
 		}
 	}
 	out.Value = s

--- a/src/ir/irfmt/printer.go
+++ b/src/ir/irfmt/printer.go
@@ -564,85 +564,85 @@ func (p *PrettyPrinter) printScalarMagicConstant(n *ir.MagicConstant) {
 func (p *PrettyPrinter) printAssign(n *ir.Assign) {
 	p.Print(n.Variable)
 	writeString(p.w, " = ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printReference(n *ir.AssignReference) {
 	p.Print(n.Variable)
 	writeString(p.w, " =& ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignBitwiseAnd(n *ir.AssignBitwiseAnd) {
 	p.Print(n.Variable)
 	writeString(p.w, " &= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignBitwiseOr(n *ir.AssignBitwiseOr) {
 	p.Print(n.Variable)
 	writeString(p.w, " |= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignBitwiseXor(n *ir.AssignBitwiseXor) {
 	p.Print(n.Variable)
 	writeString(p.w, " ^= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignConcat(n *ir.AssignConcat) {
 	p.Print(n.Variable)
 	writeString(p.w, " .= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignDiv(n *ir.AssignDiv) {
 	p.Print(n.Variable)
 	writeString(p.w, " /= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignMinus(n *ir.AssignMinus) {
 	p.Print(n.Variable)
 	writeString(p.w, " -= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignMod(n *ir.AssignMod) {
 	p.Print(n.Variable)
 	writeString(p.w, " %= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignMul(n *ir.AssignMul) {
 	p.Print(n.Variable)
 	writeString(p.w, " *= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignPlus(n *ir.AssignPlus) {
 	p.Print(n.Variable)
 	writeString(p.w, " += ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignPow(n *ir.AssignPow) {
 	p.Print(n.Variable)
 	writeString(p.w, " **= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignShiftLeft(n *ir.AssignShiftLeft) {
 	p.Print(n.Variable)
 	writeString(p.w, " <<= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 func (p *PrettyPrinter) printAssignShiftRight(n *ir.AssignShiftRight) {
 	p.Print(n.Variable)
 	writeString(p.w, " >>= ")
-	p.Print(n.Expression)
+	p.Print(n.Expr)
 }
 
 // binary

--- a/src/ir/irutil/clone.go
+++ b/src/ir/irutil/clone.go
@@ -65,8 +65,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignBitwiseAnd:
@@ -74,8 +74,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignBitwiseOr:
@@ -83,8 +83,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignBitwiseXor:
@@ -92,8 +92,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignCoalesce:
@@ -101,8 +101,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignConcat:
@@ -110,8 +110,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignDiv:
@@ -119,8 +119,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignMinus:
@@ -128,8 +128,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignMod:
@@ -137,8 +137,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignMul:
@@ -146,8 +146,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignPlus:
@@ -155,8 +155,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignPow:
@@ -164,8 +164,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignReference:
@@ -173,8 +173,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignShiftLeft:
@@ -182,8 +182,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.AssignShiftRight:
@@ -191,8 +191,8 @@ func NodeClone(x ir.Node) ir.Node {
 		if x.Variable != nil {
 			clone.Variable = NodeClone(x.Variable)
 		}
-		if x.Expression != nil {
-			clone.Expression = NodeClone(x.Expression)
+		if x.Expr != nil {
+			clone.Expr = NodeClone(x.Expr)
 		}
 		return &clone
 	case *ir.BadString:

--- a/src/ir/irutil/equal.go
+++ b/src/ir/irutil/equal.go
@@ -1429,9 +1429,6 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
-		if x.PhpDocComment != y.PhpDocComment {
-			return false
-		}
 		return true
 	case *ir.ReferenceExpr:
 		y, ok := y.(*ir.ReferenceExpr)

--- a/src/ir/irutil/equal.go
+++ b/src/ir/irutil/equal.go
@@ -117,7 +117,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -129,7 +129,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -141,7 +141,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -153,7 +153,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -165,7 +165,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -177,7 +177,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -189,7 +189,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -201,7 +201,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -213,7 +213,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -225,7 +225,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -237,7 +237,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -249,7 +249,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -261,7 +261,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -273,7 +273,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true
@@ -285,7 +285,7 @@ func NodeEqual(x, y ir.Node) bool {
 		if !NodeEqual(x.Variable, y.Variable) {
 			return false
 		}
-		if !NodeEqual(x.Expression, y.Expression) {
+		if !NodeEqual(x.Expr, y.Expr) {
 			return false
 		}
 		return true

--- a/src/ir/node_types.go
+++ b/src/ir/node_types.go
@@ -867,7 +867,6 @@ type Lnumber struct {
 }
 
 // MagicConstant is a special PHP constant like __FILE__ or __CLASS__.
-// TODO: do we really need a separate node for these constants?
 type MagicConstant struct {
 	Position      *position.Position
 	MagicConstTkn *token.Token

--- a/src/ir/node_types.go
+++ b/src/ir/node_types.go
@@ -9,122 +9,122 @@ import (
 
 // Assign is a `$Variable = $Expression` expression.
 type Assign struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignBitwiseAnd is a `$Variable &= $Expression` expression.
 type AssignBitwiseAnd struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignBitwiseOr is a `$Variable |= $Expression` expression.
 type AssignBitwiseOr struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignBitwiseXor is a `$Variable ^= $Expression` expression.
 type AssignBitwiseXor struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignCoalesce is a `$Variable ??= $Expression` expression.
 type AssignCoalesce struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignConcat is a `$Variable .= $Expression` expression.
 type AssignConcat struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignDiv is a `$Variable /= $Expression` expression.
 type AssignDiv struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignMinus is a `$Variable -= $Expression` expression.
 type AssignMinus struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignMod is a `$Variable %= $Expression` expression.
 type AssignMod struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignMul is a `$Variable *= $Expression` expression.
 type AssignMul struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignPlus is a `$Variable += $Expression` expression.
 type AssignPlus struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignPow is a `$Variable **= $Expression` expression.
 type AssignPow struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignReference is a `$Variable &= $Expression` expression.
 type AssignReference struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignShiftLeft is a `$Variable <<= $Expression` expression.
 type AssignShiftLeft struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AssignShiftRight is a `$Variable >>= $Expression` expression.
 type AssignShiftRight struct {
-	Position   *position.Position
-	Variable   Node
-	EqualTkn   *token.Token
-	Expression Node
+	Position *position.Position
+	Variable Node
+	EqualTkn *token.Token
+	Expr     Node
 }
 
 // AnonClassExpr is an anonymous class expression.

--- a/src/ir/node_types.go
+++ b/src/ir/node_types.go
@@ -1007,7 +1007,7 @@ type ConstantStmt struct {
 	Expr         Node
 }
 
-// ContinueStmt is a `continue $Expe` statement.
+// ContinueStmt is a `continue $Expr` statement.
 type ContinueStmt struct {
 	Position     *position.Position
 	ContinueTkn  *token.Token

--- a/src/ir/node_types.go
+++ b/src/ir/node_types.go
@@ -1309,8 +1309,6 @@ type PropertyStmt struct {
 	Variable *SimpleVar
 	EqualTkn *token.Token
 	Expr     Node
-
-	Doc
 }
 
 // PropertyListStmt is a `$Modifiers $Type $Properties` statement.

--- a/src/ir/node_types.go
+++ b/src/ir/node_types.go
@@ -1189,7 +1189,6 @@ type GotoStmt struct {
 
 // GroupUseStmt is a `use $UseType $Prefix\{ $UseList }` statement.
 // $UseType is a "function" or "const".
-// TODO: change $UseType type to *Identifier?
 type GroupUseStmt struct {
 	Position              *position.Position
 	UseTkn                *token.Token

--- a/src/ir/node_types.go
+++ b/src/ir/node_types.go
@@ -890,15 +890,9 @@ type String struct {
 // BadString is a string that we couldn't interpret correctly.
 // The $Value contains uninterpreted (raw) string bytes.
 // $Error contains the reason why this string is "bad".
-//
-// TODO: Maybe make String + Error field
 type BadString struct {
-	Position     *position.Position
-	MinusTkn     *token.Token
-	StringTkn    *token.Token
-	Value        string
-	DoubleQuotes bool
-	Error        string
+	String
+	Error string
 }
 
 // BreakStmt is a `break $Expr` statement.

--- a/src/ir/normalize/normalize.go
+++ b/src/ir/normalize/normalize.go
@@ -97,8 +97,8 @@ func (norm *normalizer) sortStatements(statements []ir.Node) []ir.Node {
 			return sortKey(n.Expr)
 		case *ir.Assign:
 			_, ok := n.Variable.(*ir.SimpleVar)
-			if ok && simpleExpr(n.Expression) {
-				return irfmt.Node(n.Expression)
+			if ok && simpleExpr(n.Expr) {
+				return irfmt.Node(n.Expr)
 			}
 		}
 		return ""
@@ -165,13 +165,13 @@ func (norm *normalizer) EnterNode(n ir.Node) bool {
 		n.Expr = norm.normalizedStmtExpr(n.Expr)
 
 	case *ir.Assign:
-		n.Expression = norm.normalizedExpr(n.Expression)
+		n.Expr = norm.normalizedExpr(n.Expr)
 		n.Variable = norm.normalizedExpr(n.Variable)
 	case *ir.AssignPlus:
-		n.Expression = norm.normalizedExpr(n.Expression)
+		n.Expr = norm.normalizedExpr(n.Expr)
 		n.Variable = norm.normalizedExpr(n.Variable)
 	case *ir.AssignConcat:
-		n.Expression = norm.normalizedExpr(n.Expression)
+		n.Expr = norm.normalizedExpr(n.Expr)
 		n.Variable = norm.normalizedExpr(n.Variable)
 
 	case *ir.StaticPropertyFetchExpr:
@@ -238,7 +238,7 @@ func (norm *normalizer) normalizedStmtExpr(e ir.Node) ir.Node {
 				Variable: &ir.ArrayDimFetchExpr{
 					Variable: norm.normalizedExpr(a),
 				},
-				Expression: norm.normalizedExpr(e),
+				Expr: norm.normalizedExpr(e),
 			}
 		}
 	}
@@ -364,29 +364,29 @@ func (norm *normalizer) normalizedExpr(e ir.Node) ir.Node {
 			break
 		}
 		// `$x = $x <op> $y` => `$x <op>= $y`
-		switch rhs := e.Expression.(type) {
+		switch rhs := e.Expr.(type) {
 		case *ir.PlusExpr:
 			if irutil.NodeEqual(e.Variable, rhs.Left) {
-				return &ir.AssignPlus{Variable: e.Variable, Expression: rhs.Right}
+				return &ir.AssignPlus{Variable: e.Variable, Expr: rhs.Right}
 			}
 		case *ir.MinusExpr:
 			if irutil.NodeEqual(e.Variable, rhs.Left) {
-				return &ir.AssignMinus{Variable: e.Variable, Expression: rhs.Right}
+				return &ir.AssignMinus{Variable: e.Variable, Expr: rhs.Right}
 			}
 		case *ir.ConcatExpr:
 			if irutil.NodeEqual(e.Variable, rhs.Left) {
-				return &ir.AssignConcat{Variable: e.Variable, Expression: rhs.Right}
+				return &ir.AssignConcat{Variable: e.Variable, Expr: rhs.Right}
 			}
 		}
 
 	case *ir.AssignPlus:
 		// `$x += 1` => `++$x`
-		if literalValue(e.Expression) == `1` {
+		if literalValue(e.Expr) == `1` {
 			return &ir.PreIncExpr{Variable: e.Variable}
 		}
 	case *ir.AssignMinus:
 		// `$x -= 1` => `--$x`
-		if literalValue(e.Expression) == `1` {
+		if literalValue(e.Expr) == `1` {
 			return &ir.PreDecExpr{Variable: e.Variable}
 		}
 

--- a/src/ir/walk.go
+++ b/src/ir/walk.go
@@ -89,8 +89,8 @@ func (n *Assign) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -102,8 +102,8 @@ func (n *AssignBitwiseAnd) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -115,8 +115,8 @@ func (n *AssignBitwiseOr) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -128,8 +128,8 @@ func (n *AssignBitwiseXor) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -141,8 +141,8 @@ func (n *AssignCoalesce) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -154,8 +154,8 @@ func (n *AssignConcat) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -167,8 +167,8 @@ func (n *AssignDiv) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -180,8 +180,8 @@ func (n *AssignMinus) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -193,8 +193,8 @@ func (n *AssignMod) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -206,8 +206,8 @@ func (n *AssignMul) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -219,8 +219,8 @@ func (n *AssignPlus) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -232,8 +232,8 @@ func (n *AssignPow) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -245,8 +245,8 @@ func (n *AssignReference) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -258,8 +258,8 @@ func (n *AssignShiftLeft) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }
@@ -271,8 +271,8 @@ func (n *AssignShiftRight) Walk(v Visitor) {
 	if n.Variable != nil {
 		n.Variable.Walk(v)
 	}
-	if n.Expression != nil {
-		n.Expression.Walk(v)
+	if n.Expr != nil {
+		n.Expr.Walk(v)
 	}
 	v.LeaveNode(n)
 }

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1519,10 +1519,10 @@ func (b *blockWalker) handleAssignReference(a *ir.AssignReference) bool {
 	switch v := a.Variable.(type) {
 	case *ir.ArrayDimFetchExpr:
 		b.handleAndCheckDimFetchLValue(v, "assign_array", meta.MixedType)
-		a.Expression.Walk(b)
+		a.Expr.Walk(b)
 		return false
 	case *ir.Var, *ir.SimpleVar:
-		b.addVar(v, solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, a.Expression), "assign", meta.VarAlwaysDefined)
+		b.addVar(v, solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, a.Expr), "assign", meta.VarAlwaysDefined)
 		b.addNonLocalVar(v, varRef)
 	case *ir.ListExpr:
 		// TODO: figure out whether this case is reachable.
@@ -1533,7 +1533,7 @@ func (b *blockWalker) handleAssignReference(a *ir.AssignReference) bool {
 		a.Variable.Walk(b)
 	}
 
-	a.Expression.Walk(b)
+	a.Expr.Walk(b)
 	return false
 }
 
@@ -1631,24 +1631,24 @@ func (b *blockWalker) paramClobberCheck(v *ir.SimpleVar) {
 func (b *blockWalker) handleAssign(a *ir.Assign) bool {
 	b.handleComments(a.Variable)
 
-	a.Expression.Walk(b)
+	a.Expr.Walk(b)
 
 	switch v := a.Variable.(type) {
 	case *ir.ArrayDimFetchExpr:
-		typ := solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, a.Expression)
+		typ := solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, a.Expr)
 		b.handleAndCheckDimFetchLValue(v, "assign_array", typ)
 		return false
 	case *ir.SimpleVar:
 		b.paramClobberCheck(v)
-		b.replaceVar(v, solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, a.Expression), "assign", meta.VarAlwaysDefined)
+		b.replaceVar(v, solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, a.Expr), "assign", meta.VarAlwaysDefined)
 	case *ir.Var:
-		b.replaceVar(v, solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, a.Expression), "assign", meta.VarAlwaysDefined)
+		b.replaceVar(v, solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, a.Expr), "assign", meta.VarAlwaysDefined)
 	case *ir.ListExpr:
 		if !b.isIndexingComplete() {
 			return true
 		}
 
-		b.handleAssignList(v, a.Expression)
+		b.handleAssignList(v, a.Expr)
 	case *ir.PropertyFetchExpr:
 		v.Property.Walk(b)
 		sv, ok := v.Variable.(*ir.SimpleVar)
@@ -1675,7 +1675,7 @@ func (b *blockWalker) handleAssign(a *ir.Assign) bool {
 		cls := b.r.getClass()
 
 		p := cls.Properties[propertyName.Value]
-		p.Typ = p.Typ.Append(solver.ExprTypeLocalCustom(b.ctx.sc, b.r.ctx.st, a.Expression, b.ctx.customTypes))
+		p.Typ = p.Typ.Append(solver.ExprTypeLocalCustom(b.ctx.sc, b.r.ctx.st, a.Expr, b.ctx.customTypes))
 		cls.Properties[propertyName.Value] = p
 	case *ir.StaticPropertyFetchExpr:
 		sv, ok := v.Property.(*ir.SimpleVar)
@@ -1697,7 +1697,7 @@ func (b *blockWalker) handleAssign(a *ir.Assign) bool {
 		cls := b.r.getClass()
 
 		p := cls.Properties["$"+sv.Name]
-		p.Typ = p.Typ.Append(solver.ExprTypeLocalCustom(b.ctx.sc, b.r.ctx.st, a.Expression, b.ctx.customTypes))
+		p.Typ = p.Typ.Append(solver.ExprTypeLocalCustom(b.ctx.sc, b.r.ctx.st, a.Expr, b.ctx.customTypes))
 		cls.Properties["$"+sv.Name] = p
 	default:
 		a.Variable.Walk(b)
@@ -1714,28 +1714,28 @@ func (b *blockWalker) handleAssignOp(assign ir.Node) {
 	case *ir.AssignPlus:
 		e := &ir.PlusExpr{
 			Left:  assign.Variable,
-			Right: assign.Expression,
+			Right: assign.Expr,
 		}
 		v = assign.Variable
 		typ = solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, e)
 	case *ir.AssignMinus:
 		e := &ir.MinusExpr{
 			Left:  assign.Variable,
-			Right: assign.Expression,
+			Right: assign.Expr,
 		}
 		v = assign.Variable
 		typ = solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, e)
 	case *ir.AssignMul:
 		e := &ir.MulExpr{
 			Left:  assign.Variable,
-			Right: assign.Expression,
+			Right: assign.Expr,
 		}
 		v = assign.Variable
 		typ = solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, e)
 	case *ir.AssignDiv:
 		e := &ir.DivExpr{
 			Left:  assign.Variable,
-			Right: assign.Expression,
+			Right: assign.Expr,
 		}
 		v = assign.Variable
 		typ = solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, e)
@@ -1752,7 +1752,7 @@ func (b *blockWalker) handleAssignOp(assign ir.Node) {
 	case *ir.AssignCoalesce:
 		e := &ir.CoalesceExpr{
 			Left:  assign.Variable,
-			Right: assign.Expression,
+			Right: assign.Expr,
 		}
 		v = assign.Variable
 		typ = solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, e)

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -212,7 +212,7 @@ func (b *blockLinter) checkCoalesceExpr(n *ir.CoalesceExpr) {
 }
 
 func (b *blockLinter) checkAssign(a *ir.Assign) {
-	b.checkVoidType(a.Expression)
+	b.checkVoidType(a.Expr)
 }
 
 func (b *blockLinter) checkTryStmt(s *ir.TryStmt) {

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -261,7 +261,7 @@ func (d *rootWalker) EnterNode(n ir.Node) (res bool) {
 			break
 		}
 
-		d.scope().AddVar(v, solver.ExprTypeLocal(d.scope(), d.ctx.st, n.Expression), "global variable", meta.VarAlwaysDefined)
+		d.scope().AddVar(v, solver.ExprTypeLocal(d.scope(), d.ctx.st, n.Expr), "global variable", meta.VarAlwaysDefined)
 	case *ir.FunctionStmt:
 		res = d.enterFunction(n)
 		d.checkKeywordCase(n, "function")

--- a/src/phpgrep/matcher.go
+++ b/src/phpgrep/matcher.go
@@ -405,49 +405,49 @@ func (m *matcher) eqNode(state *matcherState, x, y ir.Node) bool {
 
 	case *ir.Assign:
 		y, ok := y.(*ir.Assign)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignPlus:
 		y, ok := y.(*ir.AssignPlus)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignReference:
 		y, ok := y.(*ir.AssignReference)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignBitwiseAnd:
 		y, ok := y.(*ir.AssignBitwiseAnd)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignBitwiseOr:
 		y, ok := y.(*ir.AssignBitwiseOr)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignBitwiseXor:
 		y, ok := y.(*ir.AssignBitwiseXor)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignConcat:
 		y, ok := y.(*ir.AssignConcat)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignCoalesce:
 		y, ok := y.(*ir.AssignCoalesce)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignDiv:
 		y, ok := y.(*ir.AssignDiv)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignMinus:
 		y, ok := y.(*ir.AssignMinus)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignMod:
 		y, ok := y.(*ir.AssignMod)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignMul:
 		y, ok := y.(*ir.AssignMul)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignPow:
 		y, ok := y.(*ir.AssignPow)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignShiftLeft:
 		y, ok := y.(*ir.AssignShiftLeft)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.AssignShiftRight:
 		y, ok := y.(*ir.AssignShiftRight)
-		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expression, y.Expression)
+		return ok && m.eqNode(state, x.Variable, y.Variable) && m.eqNode(state, x.Expr, y.Expr)
 
 	case *ir.ArrayDimFetchExpr:
 		y, ok := y.(*ir.ArrayDimFetchExpr)

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -143,7 +143,7 @@ func exprTypeLocalCustom(sc *meta.Scope, cs *meta.ClassParseState, n ir.Node, cu
 	case *ir.ParenExpr:
 		return ExprTypeLocalCustom(sc, cs, n.Expr, custom)
 	case *ir.Assign:
-		return ExprTypeLocalCustom(sc, cs, n.Expression, custom)
+		return ExprTypeLocalCustom(sc, cs, n.Expr, custom)
 	case *ir.AssignConcat:
 		return meta.PreciseStringType
 	case *ir.AssignShiftLeft, *ir.AssignShiftRight:


### PR DESCRIPTION
- delete `Doc` from `PropertyStmt`
- rename all `Expression` to `Expr`
- removed a comment asking about the need for a separate node for magic constants
- `BadString` now consists of a `String` and an `Error` field
- fix typo in comment for `ContinueStmt`
- removed deprecated comment for `GroupUseStmt`

#866