### PR TITLE
linter: added order check in nested ternary operator

### DIFF
--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -434,22 +434,8 @@ func (b *blockLinter) checkTernary(e *ir.TernaryExpr) {
 		return // Skip `$x ?: $y` expressions
 	}
 
-	// containsParenTernary checks if a node is a parenthesized ternary operator.
-	containsParenTernary := func(n ir.Node) (containsTernary, hasBracket bool) {
-		switch n := n.(type) {
-		case *ir.ParenExpr:
-			_, containsTernary = n.Expr.(*ir.TernaryExpr)
-			return containsTernary, true
-
-		case *ir.TernaryExpr:
-			return true, false
-		}
-
-		return false, false
-	}
-
-	containsTernary, hasBracket := containsParenTernary(e.Condition)
-	if !hasBracket && containsTernary {
+	_, nestedTernary := e.Condition.(*ir.TernaryExpr)
+	if nestedTernary {
 		b.report(e.Condition, LevelWarning, "nestedTernary", "in ternary operators, you must explicitly use parentheses to specify the order of operations")
 	}
 

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -450,7 +450,7 @@ func (b *blockLinter) checkTernary(e *ir.TernaryExpr) {
 
 	containsTernary, hasBracket := containsParenTernary(e.Condition)
 	if !hasBracket && containsTernary {
-		b.report(e.Condition, LevelWarning, "ternaryOrder", "in ternary operators, you must explicitly use parentheses to specify the order of operations")
+		b.report(e.Condition, LevelWarning, "nestedTernary", "in ternary operators, you must explicitly use parentheses to specify the order of operations")
 	}
 
 	// Check for `$cond ? $x : $x` which makes no sense.

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -628,6 +628,17 @@ echo $someVal;`,
 	20,
 ]`,
 		},
+
+		{
+			Name:     "ternaryOrder",
+			Default:  false,
+			Quickfix: true,
+			Comment:  `Report an unspecified order in a nested ternary operator.`,
+			Before:   `$_ = 1 ? 2 : 3 ? 4 : 5;`,
+			After: `$_ = (1 ? 2 : 3) ? 4 : 5;
+// or
+$_ = 1 ? 2 : (3 ? 4 : 5);`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -630,7 +630,7 @@ echo $someVal;`,
 		},
 
 		{
-			Name:     "ternaryOrder",
+			Name:     "nestedTernary",
 			Default:  false,
 			Quickfix: true,
 			Comment:  `Report an unspecified order in a nested ternary operator.`,

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -2127,7 +2127,7 @@ function f() {
 	test.RunAndMatch()
 }
 
-func TestTernaryOrder(t *testing.T) {
+func TestNestedTernary(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
 function f() {

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -2126,3 +2126,32 @@ function f() {
 	}
 	test.RunAndMatch()
 }
+
+func TestTernaryOrder(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function f() {
+    $_ = 1 ? 2 : 3 ? 4 : 5; // error
+	//   |_______|
+
+    $_ = 1 ? 2 : 3 ? 4 : 1 ? 2 : 3; // error
+	//   |_______|       |
+	//   |_______________|
+
+	$_ = (1 ? 2 : 3) ? 4 : 5; // ok
+	//   |_________|
+
+	$_ = 1 ? 2 : (3 ? 4 : 5); // ok
+	//           |_________|
+
+	$_ = 1 ? 2 ? 3 : 4 : 5; // ok, ternary in middle
+	//       |_______|
+}
+`)
+	test.Expect = []string{
+		`in ternary operators, you must explicitly use parentheses to specify the order of operations`,
+		`in ternary operators, you must explicitly use parentheses to specify the order of operations`,
+		`in ternary operators, you must explicitly use parentheses to specify the order of operations`,
+	}
+	test.RunAndMatch()
+}


### PR DESCRIPTION
See [deprecated core nested-ternary](https://www.php.net/manual/ru/migration74.deprecated.php#migration74.deprecated.core.nested-ternary).