### PR TITLE
linter: fixed a bug with a tuple containing an array

### DIFF
--- a/src/linter/types.go
+++ b/src/linter/types.go
@@ -318,6 +318,7 @@ var trivialTypes = map[string]bool{
 	"string":   true,
 	"void":     true,
 	"iterable": true,
+	"array":    true,
 
 	"null":  true,
 	"true":  true,

--- a/src/linter/types.go
+++ b/src/linter/types.go
@@ -160,8 +160,6 @@ func (conv *phpdocTypeConverter) mapShapeType(params []phpdoc.TypeExpr) []meta.T
 			}
 
 			if typ.Elem == "array" {
-				types[i].Elem = "mixed"
-				types[i].Dims = 1
 				continue
 			}
 

--- a/src/linter/types.go
+++ b/src/linter/types.go
@@ -159,6 +159,12 @@ func (conv *phpdocTypeConverter) mapShapeType(params []phpdoc.TypeExpr) []meta.T
 				continue
 			}
 
+			if typ.Elem == "array" {
+				types[i].Elem = "mixed"
+				types[i].Dims = 1
+				continue
+			}
+
 			className, ok := solver.GetClassName(conv.ctx.st, &ir.Name{Value: typ.Elem})
 			if !ok {
 				continue
@@ -318,7 +324,6 @@ var trivialTypes = map[string]bool{
 	"string":   true,
 	"void":     true,
 	"iterable": true,
-	"array":    true,
 
 	"null":  true,
 	"true":  true,

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -2844,8 +2844,8 @@ function f() {
     return [[],[]];
 }
 
-exprtype(f()[0], "array");
-exprtype(f()[1], "array");
+exprtype(f()[0], "mixed[]");
+exprtype(f()[1], "mixed[]");
 `
 	runExprTypeTest(t, &exprTypeTestParams{code: code})
 }

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -2835,6 +2835,21 @@ namespace Foo {
 	runExprTypeTest(t, &exprTypeTestParams{code: code})
 }
 
+func TestTupleWithArray(t *testing.T) {
+	code := `<?php
+/**
+ * @return tuple(array, array)
+ */
+function f() {
+    return [[],[]];
+}
+
+exprtype(f()[0], "array");
+exprtype(f()[1], "array");
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func runExprTypeTest(t *testing.T, params *exprTypeTestParams) {
 	exprTypeTestImpl(t, params, false)
 }


### PR DESCRIPTION
The array type in tuple was resolved as `\array`, not `array`.