### PR TITLE
linter: added support for @noinspection PhpUnreachableStatementInspection 

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1,6 +1,7 @@
 package linter
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -148,6 +149,11 @@ func (b *blockWalker) reportDeadCode(n ir.Node) {
 		return
 	}
 
+	if b.containsDisableInspection(n, "PhpUnreachableStatementInspection") {
+		b.ctx.deadCodeReported = true
+		return
+	}
+
 	switch n.(type) {
 	case *ir.BreakStmt, *ir.ReturnStmt, *ir.ExitExpr, *ir.ThrowStmt:
 		// Allow to break code flow more than once.
@@ -166,6 +172,37 @@ func (b *blockWalker) reportDeadCode(n ir.Node) {
 
 	b.ctx.deadCodeReported = true
 	b.r.Report(n, LevelWarning, "deadCode", "Unreachable code")
+}
+
+func (b *blockWalker) containsDisableInspection(n ir.Node, needInspection string) bool {
+	firstTkn := ir.GetFirstToken(n)
+	for _, tkn := range firstTkn.FreeFloating {
+		if !phpdoc.IsPHPDocToken(tkn) {
+			continue
+		}
+
+		if !bytes.Contains(tkn.Value, []byte("@noinspection")) {
+			continue
+		}
+
+		parsed := phpdoc.Parse(b.r.ctx.phpdocTypeParser, string(tkn.Value))
+		for _, p := range parsed.Parsed {
+			part, ok := p.(*phpdoc.RawCommentPart)
+			if !ok {
+				continue
+			}
+
+			if part.Name() == "noinspection" {
+				inspection := part.Params[0]
+
+				if inspection == needInspection {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }
 
 func (b *blockWalker) handleComments(n ir.Node) {

--- a/src/tests/checkers/disable_inspection_test.go
+++ b/src/tests/checkers/disable_inspection_test.go
@@ -10,38 +10,63 @@ func TestDisableDeadCode(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 function f() {
 #ifndef KPHP
-    return 1;
+  return 1;
 #endif
 
-    /** @noinspection PhpUnreachableStatementInspection */
-    return 10;
+  /** @noinspection PhpUnreachableStatementInspection */
+  return 10;
 }
 
 function f1() {
 #ifndef KPHP
-    return 1;
+  return 1;
 #endif
 
-    /** @noinspection PhpUnreachableStatementInspection */
-	$a = 100;
+  /** @noinspection PhpUnreachableStatementInspection */
+  $a = 100;
 
-    return $a;
+  return $a;
 }
 
 function f2() {
 #ifndef KPHP
-    return 1;
+  return 1;
 #endif
 
 #ifndef KPHP2
-	/** @noinspection PhpUnreachableStatementInspection */
-    return 1;
+  /** @noinspection PhpUnreachableStatementInspection */
+  return 1;
 #endif
 
-    /** @noinspection PhpUnreachableStatementInspection */
-	$a = 100;
+  /** @noinspection PhpUnreachableStatementInspection */
+  $a = 100;
 
-    return $a;
+  return $a;
+}
+
+function f3() {
+#ifndef KPHP
+  return 1;
+#endif
+
+  /* @noinspection PhpUnreachableStatementInspection */
+  $a = 100;
+
+  return $a;
+}
+
+function f4() {
+#ifndef KPHP
+  return 1;
+#endif
+
+  /**
+   * @noinspection PhpUnreachableStatementInspection 
+   * Some comment
+   */
+  $a = 100;
+
+  return $a;
 }
 `)
 }

--- a/src/tests/checkers/disable_inspection_test.go
+++ b/src/tests/checkers/disable_inspection_test.go
@@ -1,0 +1,47 @@
+package checkers
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestDisableDeadCode(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+function f() {
+#ifndef KPHP
+    return 1;
+#endif
+
+    /** @noinspection PhpUnreachableStatementInspection */
+    return 10;
+}
+
+function f1() {
+#ifndef KPHP
+    return 1;
+#endif
+
+    /** @noinspection PhpUnreachableStatementInspection */
+	$a = 100;
+
+    return $a;
+}
+
+function f2() {
+#ifndef KPHP
+    return 1;
+#endif
+
+#ifndef KPHP2
+	/** @noinspection PhpUnreachableStatementInspection */
+    return 1;
+#endif
+
+    /** @noinspection PhpUnreachableStatementInspection */
+	$a = 100;
+
+    return $a;
+}
+`)
+}


### PR DESCRIPTION
`@noinspection PhpUnreachableStatementInspection` 
annotation disable deadCode checking.