### PR TITLE
linter: improve oldStyleConstructor checker

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -902,10 +902,6 @@ func (d *rootWalker) checkOldStyleConstructor(meth *ir.ClassMethodStmt) {
 	if !inClass {
 		return
 	}
-	_, containsConstruct := d.getClass().Methods.Get(`__construct`)
-	if containsConstruct {
-		return
-	}
 
 	d.Report(meth.MethodName, LevelNotice, "oldStyleConstructor", "Old-style constructor usage, use __construct instead")
 }

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -890,7 +890,7 @@ func (d *rootWalker) enterClassConstList(list *ir.ClassConstListStmt) bool {
 }
 
 func (d *rootWalker) checkOldStyleConstructor(meth *ir.ClassMethodStmt) {
-	lastDelim := strings.IndexByte(d.ctx.st.CurrentClass, '\\')
+	lastDelim := strings.LastIndexByte(d.ctx.st.CurrentClass, '\\')
 	methodName := meth.MethodName.Value
 	className := d.ctx.st.CurrentClass[lastDelim+1:]
 

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -143,12 +143,12 @@ class t3 {
 }
 
 class ClassWithBackCompatibleConstructor {
-    public function __construct() {}
-	
-	/** back compatible constructor */
-    public function ClassWithBackCompatibleConstructor() {
-        $this->__construct();
-    }
+  public function __construct() {}
+
+  /** back compatible constructor */
+  public function ClassWithBackCompatibleConstructor() {
+    $this->__construct();
+  }
 }
 `)
 	test.Expect = []string{

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -141,6 +141,15 @@ class t3 {
   /** inverse of the T2 test case */
   public function T3() {}
 }
+
+class ClassWithBackCompatibleConstructor {
+    public function __construct() {}
+	
+	/** back compatible constructor */
+    public function ClassWithBackCompatibleConstructor() {
+        $this->__construct();
+    }
+}
 `)
 	test.Expect = []string{
 		`Old-style constructor usage, use __construct instead`,

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -150,8 +150,37 @@ class ClassWithBackCompatibleConstructor {
     $this->__construct();
   }
 }
+
+namespace SameWithNamespace {
+  class T1 {
+    /** simple constructor */
+    public function T1() {}
+  }
+  
+  class T2 {
+    /** constructor name is in lower case */
+    public function t2() {}
+  }
+  
+  class t3 {
+    /** inverse of the T2 test case */
+    public function T3() {}
+  }
+  
+  class ClassWithBackCompatibleConstructor {
+    public function __construct() {}
+  
+    /** back compatible constructor */
+    public function ClassWithBackCompatibleConstructor() {
+      $this->__construct();
+    }
+  }
+}
 `)
 	test.Expect = []string{
+		`Old-style constructor usage, use __construct instead`,
+		`Old-style constructor usage, use __construct instead`,
+		`Old-style constructor usage, use __construct instead`,
 		`Old-style constructor usage, use __construct instead`,
 		`Old-style constructor usage, use __construct instead`,
 		`Old-style constructor usage, use __construct instead`,

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -142,15 +142,6 @@ class t3 {
   public function T3() {}
 }
 
-class ClassWithBackCompatibleConstructor {
-  public function __construct() {}
-
-  /** back compatible constructor */
-  public function ClassWithBackCompatibleConstructor() {
-    $this->__construct();
-  }
-}
-
 trait TraitWithNameMatchingMethod {
   /** ok */
   public function TraitWithNameMatchingMethod() {}
@@ -175,15 +166,6 @@ namespace SameWithNamespace {
   class t3 {
     /** inverse of the T2 test case */
     public function T3() {}
-  }
-  
-  class ClassWithBackCompatibleConstructor {
-    public function __construct() {}
-  
-    /** back compatible constructor */
-    public function ClassWithBackCompatibleConstructor() {
-      $this->__construct();
-    }
   }
 
   trait TraitWithNameMatchingMethod {

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -151,6 +151,16 @@ class ClassWithBackCompatibleConstructor {
   }
 }
 
+trait TraitWithNameMatchingMethod {
+  /** ok */
+  public function TraitWithNameMatchingMethod() {}
+}
+
+interface InterfaceWithNameMatchingMethod {
+  /** ok */
+  public function InterfaceWithNameMatchingMethod();
+}
+
 namespace SameWithNamespace {
   class T1 {
     /** simple constructor */
@@ -174,6 +184,16 @@ namespace SameWithNamespace {
     public function ClassWithBackCompatibleConstructor() {
       $this->__construct();
     }
+  }
+
+  trait TraitWithNameMatchingMethod {
+    /** ok */
+    public function TraitWithNameMatchingMethod() {}
+  }
+  
+  interface InterfaceWithNameMatchingMethod {
+    /** ok */
+    public function InterfaceWithNameMatchingMethod();
   }
 }
 `)


### PR DESCRIPTION
Now the check does not work if there is a namespace. 
I think this can also be included in this PR, since this is 
also a kind of improvement 😄 