### PR TITLE
meta: add type inferring for not_null, not_false and create_vector from polyfills

### DIFF
--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -141,7 +141,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 5316
+		wantLen := 5339
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -150,7 +150,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "63e0138101dfef86e5fa6c4ba977e34846d92999f6f4248050f3f84bca820970dcbd447a0f044ede1f32ef1f4a04b4acb5c2fb4f13caf50de6220c05e7c1e1ef"
+		wantStrings := "58ee1b84015fd50ccc637e4af1149491004b90c5ad99e6f00f0fcc9b8f321ef1af7b3491f994d164a83bee7b3efbe99447fabe9ab979379f404b173e5d4485a1"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -141,7 +141,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 5339
+		wantLen := 5331
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -150,7 +150,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "58ee1b84015fd50ccc637e4af1149491004b90c5ad99e6f00f0fcc9b8f321ef1af7b3491f994d164a83bee7b3efbe99447fabe9ab979379f404b173e5d4485a1"
+		wantStrings := "f14ca782fcfec5965d9d51c1aa7c6007f37304baa8848d199a36eb0d74423b2effd06dfe3af8efd9b3ab97b04e7f13acacbe6237b0dddf718287df73dc223135"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/meta/info.go
+++ b/src/meta/info.go
@@ -228,7 +228,7 @@ func (i *Info) InitKphpStubs() {
 		ArgNum:       0,
 	}
 
-  i.internalFunctionOverrides[`\not_null`] = FuncInfoOverride{
+	i.internalFunctionOverrides[`\not_null`] = FuncInfoOverride{
 		OverrideType: OverrideArgType,
 		Properties:   NotNull,
 		ArgNum:       0,

--- a/src/meta/info.go
+++ b/src/meta/info.go
@@ -171,8 +171,8 @@ func (i *Info) InitKphpStubs() {
 		MinParamsCnt: 2,
 		Typ:          types.NewMap("object"),
 	}
-  
-  i.internalFunctions.H[`\not_null`] = FuncInfo{
+
+	i.internalFunctions.H[`\not_null`] = FuncInfo{
 		Name:         `\not_null`,
 		Params:       []FuncParam{{Name: "any_value"}},
 		MinParamsCnt: 1,

--- a/src/meta/info.go
+++ b/src/meta/info.go
@@ -208,19 +208,19 @@ func (i *Info) InitKphpStubs() {
 		ArgNum:       1,
 	}
 	i.internalFunctionOverrides[`\not_null`] = FuncInfoOverride{
-		OverrideType:       OverrideArgType,
-		AdditionalProperty: NotNull,
-		ArgNum:             0,
+		OverrideType: OverrideArgType,
+		Properties:   NotNull,
+		ArgNum:       0,
 	}
 	i.internalFunctionOverrides[`\not_false`] = FuncInfoOverride{
-		OverrideType:       OverrideArgType,
-		AdditionalProperty: NotFalse,
-		ArgNum:             0,
+		OverrideType: OverrideArgType,
+		Properties:   NotFalse,
+		ArgNum:       0,
 	}
 	i.internalFunctionOverrides[`\create_vector`] = FuncInfoOverride{
-		OverrideType:       OverrideArgType,
-		AdditionalProperty: ArrayOf,
-		ArgNum:             1,
+		OverrideType: OverrideArgType,
+		Properties:   ArrayOf,
+		ArgNum:       1,
 	}
 }
 

--- a/src/meta/info.go
+++ b/src/meta/info.go
@@ -177,6 +177,12 @@ func (i *Info) InitKphpStubs() {
 		MinParamsCnt: 1,
 		Typ:          types.NewMap("mixed"),
 	}
+	i.internalFunctions.H[`\create_vector`] = FuncInfo{
+		Name:         `\create_vector`,
+		Params:       []FuncParam{{Name: "count"}, {Name: "el"}},
+		MinParamsCnt: 2,
+		Typ:          types.NewMap("mixed[]"),
+	}
 
 	i.internalFunctionOverrides[`\array_first_element`] = FuncInfoOverride{
 		OverrideType: OverrideElementType,
@@ -199,6 +205,11 @@ func (i *Info) InitKphpStubs() {
 		OverrideType:       OverrideArgType,
 		AdditionalProperty: NotFalse,
 		ArgNum:             0,
+	}
+	i.internalFunctionOverrides[`\create_vector`] = FuncInfoOverride{
+		OverrideType:       OverrideArgType,
+		AdditionalProperty: ArrayOf,
+		ArgNum:             1,
 	}
 }
 

--- a/src/meta/info.go
+++ b/src/meta/info.go
@@ -165,6 +165,18 @@ func (i *Info) InitKphpStubs() {
 		MinParamsCnt: 2,
 		Typ:          types.NewMap("object|null"),
 	}
+	i.internalFunctions.H[`\not_null`] = FuncInfo{
+		Name:         `\not_null`,
+		Params:       []FuncParam{{Name: "any_value"}},
+		MinParamsCnt: 1,
+		Typ:          types.NewMap("mixed"),
+	}
+	i.internalFunctions.H[`\not_false`] = FuncInfo{
+		Name:         `\not_false`,
+		Params:       []FuncParam{{Name: "any_value"}},
+		MinParamsCnt: 1,
+		Typ:          types.NewMap("mixed"),
+	}
 
 	i.internalFunctionOverrides[`\array_first_element`] = FuncInfoOverride{
 		OverrideType: OverrideElementType,
@@ -177,6 +189,16 @@ func (i *Info) InitKphpStubs() {
 	i.internalFunctionOverrides[`\instance_deserialize`] = FuncInfoOverride{
 		OverrideType: OverrideClassType,
 		ArgNum:       1,
+	}
+	i.internalFunctionOverrides[`\not_null`] = FuncInfoOverride{
+		OverrideType:       OverrideArgType,
+		AdditionalProperty: NotNull,
+		ArgNum:             0,
+	}
+	i.internalFunctionOverrides[`\not_false`] = FuncInfoOverride{
+		OverrideType:       OverrideArgType,
+		AdditionalProperty: NotFalse,
+		ArgNum:             0,
 	}
 }
 

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -86,7 +86,7 @@ type AdditionalProperty int
 const (
 	// NotNull means that the null type will be removed from the resulting type.
 	NotNull AdditionalProperty = (iota + 1) << 1
-	// NotFalse means that the null type will be removed from the resulting type.
+	// NotFalse means that the false type will be removed from the resulting type.
 	NotFalse
 )
 

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -81,11 +81,21 @@ const (
 	OverrideClassType
 )
 
+type AdditionalProperty int
+
+const (
+	// NotNull means that the null type will be removed from the resulting type.
+	NotNull AdditionalProperty = (iota + 1) << 1
+	// NotFalse means that the null type will be removed from the resulting type.
+	NotFalse
+)
+
 // FuncInfoOverride defines return type overrides based on their parameter types.
 // For example, \array_slice($arr) returns type of element (OverrideElementType) of the ArgNum=0
 type FuncInfoOverride struct {
-	OverrideType OverrideType
-	ArgNum       int
+	OverrideType       OverrideType
+	AdditionalProperty AdditionalProperty
+	ArgNum             int
 }
 
 type PropertyInfo struct {

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -88,6 +88,8 @@ const (
 	NotNull AdditionalProperty = (iota + 1) << 1
 	// NotFalse means that the false type will be removed from the resulting type.
 	NotFalse
+	// ArrayOf means that the type will be converted to an array of elements of that type.
+	ArrayOf
 )
 
 // FuncInfoOverride defines return type overrides based on their parameter types.

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -83,11 +83,11 @@ const (
 	OverrideNullableClassType
 )
 
-type AdditionalProperty int
+type OverrideProperties int
 
 const (
 	// NotNull means that the null type will be removed from the resulting type.
-	NotNull AdditionalProperty = (iota + 1) << 1
+	NotNull OverrideProperties = 1 << iota
 	// NotFalse means that the false type will be removed from the resulting type.
 	NotFalse
 	// ArrayOf means that the type will be converted to an array of elements of that type.
@@ -97,9 +97,9 @@ const (
 // FuncInfoOverride defines return type overrides based on their parameter types.
 // For example, \array_slice($arr) returns type of element (OverrideElementType) of the ArgNum=0
 type FuncInfoOverride struct {
-	OverrideType       OverrideType
-	AdditionalProperty AdditionalProperty
-	ArgNum             int
+	OverrideType OverrideType
+	Properties   OverrideProperties
+	ArgNum       int
 }
 
 type PropertyInfo struct {

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -280,6 +280,8 @@ func internalFuncType(nm string, sc *meta.Scope, cs *meta.ClassParseState, c *ir
 		typ = typ.Filter(func(s string) bool {
 			return s != "false"
 		})
+	case meta.ArrayOf:
+		typ = typ.Map(types.WrapArrayOf)
 	default:
 		return typ, true
 	}

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -265,13 +265,18 @@ func internalFuncType(nm string, sc *meta.Scope, cs *meta.ClassParseState, c *ir
 		if !ok {
 			return types.NewMap("mixed"), true
 		}
-		typ = types.NewMap(className + "|null")
+
+		if override.OverrideType == meta.OverrideNullableClassType {
+			typ = types.NewMap(className + "|null")
+		} else {
+			typ = types.NewMap(className)
+		}
 
 	default:
 		log.Printf("Internal error: unexpected override type %d for function %s", override.OverrideType, nm)
 	}
 
-	switch override.AdditionalProperty {
+	switch override.Properties {
 	case meta.NotNull:
 		typ = typ.Filter(func(s string) bool {
 			return s != "null"

--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -287,8 +287,6 @@ func internalFuncType(nm string, sc *meta.Scope, cs *meta.ClassParseState, c *ir
 		})
 	case meta.ArrayOf:
 		typ = typ.Map(types.WrapArrayOf)
-	default:
-		return typ, true
 	}
 
 	return typ, !typ.IsEmpty()

--- a/src/tests/exprtype/kphp_test.go
+++ b/src/tests/exprtype/kphp_test.go
@@ -169,6 +169,7 @@ function f() {
 	exprtype(instance_cast($foo, 10), "mixed");
 	exprtype(instance_cast($foo, $className), "mixed");
 	exprtype(instance_cast($foo, CLASS_NAME), "mixed");
+}
 `
 	runKPHPExprTypeTest(t, &exprTypeTestParams{code: code, stubs: "<?php /* no code */"})
 }

--- a/src/tests/exprtype/kphp_test.go
+++ b/src/tests/exprtype/kphp_test.go
@@ -217,6 +217,39 @@ function f() {
 	runKPHPExprTypeTest(t, &exprTypeTestParams{code: code, stubs: "<?php /* no code */"})
 }
 
+func TestCreateVector(t *testing.T) {
+	code := `<?php
+class Foo {}
+
+/**
+ * @return int
+ */ 
+function retInt() { return 0; }
+
+/**
+ * @return int|string
+ */ 
+function retIntAndString() { return 0; }
+
+/**
+ * @return Foo
+ */ 
+function retFoo() { return 0; }
+
+function f() {
+	exprtype(create_vector(10, new Foo), "\Foo[]");
+	exprtype(create_vector(10, 1), "int[]");
+	exprtype(create_vector(10, 1.5), "float[]");
+	exprtype(create_vector(10, "22"), "string[]");
+	exprtype(create_vector(10, true ? 1 : "22"), "int[]|string[]");
+	exprtype(create_vector(10, retInt()), "int[]");
+	exprtype(create_vector(10, retIntAndString()), "int[]|string[]");
+	exprtype(create_vector(10, retFoo()), "\Foo[]");
+}
+`
+	runKPHPExprTypeTest(t, &exprTypeTestParams{code: code, stubs: "<?php /* no code */"})
+}
+
 func runKPHPExprTypeTest(t *testing.T, params *exprTypeTestParams) {
 	exprTypeTestImpl(t, params, true)
 }

--- a/src/tests/exprtype/kphp_test.go
+++ b/src/tests/exprtype/kphp_test.go
@@ -141,6 +141,82 @@ function f1() {
 	runKPHPExprTypeTest(t, &exprTypeTestParams{code: code, stubs: "<?php /* no code */"})
 }
 
+func TestNotNull(t *testing.T) {
+	code := `<?php
+class Foo {}
+
+/**
+ * @return int|null
+ */
+function f1(): int {
+	return 0;
+}
+
+function f() {
+	$a = new Foo;
+	if (1) {
+		$a = null;
+	}
+
+	exprtype(not_null($a), "\Foo");
+
+	$b = 100;
+	exprtype(not_null($b), "int");
+
+	$c = [1,2,3];
+	exprtype(not_null($c), "int[]");
+
+	$d = [1,2,3];
+	if (1) {
+		$d = null;
+	}
+	exprtype(not_null($d), "int[]");
+
+	$e = f1();
+	exprtype(not_null($e), "int|null"); // not work properly with function call type
+}
+`
+	runKPHPExprTypeTest(t, &exprTypeTestParams{code: code, stubs: "<?php /* no code */"})
+}
+
+func TestNotFalse(t *testing.T) {
+	code := `<?php
+class Foo {}
+
+/**
+ * @return int|false
+ */
+function f1(): int {
+	return 0;
+}
+
+function f() {
+	$a = new Foo;
+	if (1) {
+		$a = false;
+	}
+
+	exprtype(not_false($a), "\Foo|bool");
+
+	$b = 100;
+	exprtype(not_false($b), "int");
+
+	$c = [1,2,3];
+	exprtype(not_false($c), "int[]");
+
+	$d = [1,2,3];
+	if (1) {
+		$d = false;
+	}
+	exprtype(not_false($d), "bool|int[]");
+
+	$e = f1();
+	exprtype(not_false($e), "false|int"); // not work properly with function call type
+}
+`
+	runKPHPExprTypeTest(t, &exprTypeTestParams{code: code, stubs: "<?php /* no code */"})
+}
+
 func runKPHPExprTypeTest(t *testing.T, params *exprTypeTestParams) {
 	exprTypeTestImpl(t, params, true)
 }

--- a/src/types/typesmap.go
+++ b/src/types/typesmap.go
@@ -81,6 +81,18 @@ func (m Map) Map(fn func(string) string) Map {
 	return NewMapFromMap(mapped)
 }
 
+// Filter returns a new types map with the types of m for which fn returns true.
+// The result type map is never marked as precise.
+func (m Map) Filter(fn func(string) bool) Map {
+	mapped := make(map[string]struct{}, len(m.m))
+	for typ := range m.m {
+		if fn(typ) {
+			mapped[typ] = struct{}{}
+		}
+	}
+	return NewMapFromMap(mapped)
+}
+
 // NewEmptyMap creates new type map that has no types in it
 func NewEmptyMap(cap int) Map {
 	return Map{m: make(map[string]struct{}, cap)}

--- a/src/types/typesmap.go
+++ b/src/types/typesmap.go
@@ -84,13 +84,13 @@ func (m Map) Map(fn func(string) string) Map {
 // Filter returns a new types map with the types of m for which fn returns true.
 // The result type map is never marked as precise.
 func (m Map) Filter(fn func(string) bool) Map {
-	mapped := make(map[string]struct{}, len(m.m))
+	filtered := make(map[string]struct{}, len(m.m))
 	for typ := range m.m {
 		if fn(typ) {
-			mapped[typ] = struct{}{}
+			filtered[typ] = struct{}{}
 		}
 	}
-	return NewMapFromMap(mapped)
+	return NewMapFromMap(filtered)
 }
 
 // NewEmptyMap creates new type map that has no types in it


### PR DESCRIPTION
Since type inference occurs before lazy types are resolved, 
this does not work entirely for function return types.

Perhaps we should add the ability to add a lazy type, which 
would say that when resolving types, need to remove a certain 
type, for example, `false` or `null`.

#977