### PR TITLE
linter: improved type inference for multidimensional arrays

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1478,11 +1478,12 @@ func (b *blockWalker) handleAndCheckDimFetchLValue(e *ir.ArrayDimFetchExpr, reas
 
 	switch v := e.Variable.(type) {
 	case *ir.Var, *ir.SimpleVar:
-		arrTyp := typ.Map(types.WrapArrayOf)
-		b.addVar(v, arrTyp, reason, meta.VarAlwaysDefined)
+		arrayOfType := typ.Map(types.WrapArrayOf)
+		b.addVar(v, arrayOfType, reason, meta.VarAlwaysDefined)
 		b.handleVariable(v)
 	case *ir.ArrayDimFetchExpr:
-		b.handleAndCheckDimFetchLValue(v, reason, types.MixedType)
+		arrayOfType := typ.Map(types.WrapArrayOf)
+		b.handleAndCheckDimFetchLValue(v, reason, arrayOfType)
 	default:
 		// probably not assignable?
 		v.Walk(b)
@@ -1525,7 +1526,8 @@ func (b *blockWalker) checkArrayDimFetch(s *ir.ArrayDimFetchExpr) {
 func (b *blockWalker) handleAssignReference(a *ir.AssignReference) bool {
 	switch v := a.Variable.(type) {
 	case *ir.ArrayDimFetchExpr:
-		b.handleAndCheckDimFetchLValue(v, "assign_array", types.MixedType)
+		typ := solver.ExprTypeLocal(b.ctx.sc, b.r.ctx.st, a.Expr)
+		b.handleAndCheckDimFetchLValue(v, "assign_array", typ)
 		a.Expr.Walk(b)
 		return false
 	case *ir.Var, *ir.SimpleVar:

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -684,9 +684,9 @@ function assign_ref_dim_fetch3() {
 }
 
 exprtype($v =& $ints[0], 'mixed');
-exprtype(assign_ref_dim_fetch1(), 'mixed[]');
-exprtype(assign_ref_dim_fetch2(), 'mixed[]');
-exprtype(assign_ref_dim_fetch3(), 'mixed[]');
+exprtype(assign_ref_dim_fetch1(), 'int[][]');
+exprtype(assign_ref_dim_fetch2(), 'int[]');
+exprtype(assign_ref_dim_fetch3(), 'int[][]');
 `
 	runExprTypeTest(t, &exprTypeTestParams{code: code})
 }
@@ -2847,6 +2847,41 @@ function f() {
 
 exprtype(f()[0], "mixed[]");
 exprtype(f()[1], "mixed[]");
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
+func TestMultiDimensionalArray(t *testing.T) {
+	code := `<?php
+class Foo {
+	public function f(): self {}
+}
+
+function f() {
+	$a = [];    
+	
+	$a[] = [1,2,3];
+	$a[] = ["1","2","3"];
+	exprtype($a, "int[][]|string[][]");
+
+	foreach ($a as $val) {
+		exprtype($val, "int[]|string[]");
+		foreach ($val as $val2) {
+			exprtype($val2, "int|string");
+		}
+	}
+
+	$a[1][2] = new Foo;
+
+	foreach ($a as $val) {
+		exprtype($val, "\Foo[]|int[]|string[]");
+		foreach ($val as $val2) {
+			exprtype($val2, "\Foo|int|string");
+			$a = $val2->f();
+			exprtype($a, "\Foo");
+		}
+	}
+}
 `
 	runExprTypeTest(t, &exprTypeTestParams{code: code})
 }


### PR DESCRIPTION
Now, any addition to a one-dimensional array is handled 
correctly, but in the case of multidimensional arrays, a simple 
replacement with mixed occurs and as a result, the type is 
deduced as `mixed[]`.

In this PR, I made the same behavior as for one-dimensional 
arrays, so now multidimensional arrays will be processed more 
correctly and do not require additional type annotations for 
variables.