### PR TITLE
phpgrep: implement partially normalized (fuzzy) matching

### DIFF
--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -238,12 +238,14 @@ function offBy1() {
   /**
    * @warning probably intended to use count-1 as an index
    * @fix     $a[count($a) - 1]
+   * @strict-syntax
    */
   $a[count($a)];
 
   /**
    * @warning probably intended to use sizeof-1 as an index
    * @fix     $a[sizeof($a) - 1]
+   * @strict-syntax
    */
   $a[sizeof($a)];
 }

--- a/src/ir/normalize/normalize.go
+++ b/src/ir/normalize/normalize.go
@@ -10,6 +10,7 @@ import (
 	"github.com/VKCOM/noverify/src/ir"
 	"github.com/VKCOM/noverify/src/ir/irfmt"
 	"github.com/VKCOM/noverify/src/ir/irutil"
+	"github.com/VKCOM/noverify/src/ir/phpcore"
 	"github.com/VKCOM/noverify/src/meta"
 )
 
@@ -354,10 +355,7 @@ func (norm *normalizer) normalizedExpr(e ir.Node) ir.Node {
 		}
 
 		// Replace aliased functions.
-		alias, ok := funcAliases[funcName.Value]
-		if ok {
-			e.Function = alias
-		}
+		e.Function = phpcore.ResolveAlias(funcName)
 
 	case *ir.Assign:
 		if !sideEffectFree(e.Variable) {
@@ -445,31 +443,6 @@ var (
 	nullConstNode   = &ir.ConstFetchExpr{Constant: &ir.Name{Value: "null"}}
 	emptyStringNode = &ir.String{}
 )
-
-var funcAliases = map[string]*ir.Name{
-	// See https://www.php.net/manual/ru/aliases.php
-
-	`doubleval`: {Value: `floatval`},
-
-	`ini_alter`:    {Value: `ini_set`},
-	`is_integer`:   {Value: `is_int`},
-	`is_long`:      {Value: `is_int`},
-	`is_real`:      {Value: `is_float`},
-	`is_double`:    {Value: `is_float`},
-	`is_writeable`: {Value: `is_writable`},
-
-	`join`:       {Value: `implode`},
-	`chop`:       {Value: `rtrim`},
-	`strchr`:     {Value: `strstr`},
-	`pos`:        {Value: `current`},
-	`key_exists`: {Value: `array_key_exists`},
-	`sizeof`:     {Value: `count`},
-
-	`close`:                {Value: `closedir`},
-	`fputs`:                {Value: `fwrite`},
-	`magic_quotes_runtime`: {Value: `set_magic_quotes_runtime`},
-	`show_source`:          {Value: `highlight_file`},
-}
 
 func literalValue(e ir.Node) string {
 	switch e := e.(type) {

--- a/src/ir/phpcore/phpcore.go
+++ b/src/ir/phpcore/phpcore.go
@@ -1,0 +1,42 @@
+package phpcore
+
+import (
+	"github.com/VKCOM/noverify/src/ir"
+)
+
+func ResolveAlias(function ir.Node) ir.Node {
+	nm, ok := function.(*ir.Name)
+	if !ok {
+		return function
+	}
+	alias, ok := funcAliases[nm.Value]
+	if ok {
+		return alias
+	}
+	return function
+}
+
+var funcAliases = map[string]*ir.Name{
+	// See https://www.php.net/manual/ru/aliases.php
+
+	`doubleval`: {Value: `floatval`},
+
+	`ini_alter`:    {Value: `ini_set`},
+	`is_integer`:   {Value: `is_int`},
+	`is_long`:      {Value: `is_int`},
+	`is_real`:      {Value: `is_float`},
+	`is_double`:    {Value: `is_float`},
+	`is_writeable`: {Value: `is_writable`},
+
+	`join`:       {Value: `implode`},
+	`chop`:       {Value: `rtrim`},
+	`strchr`:     {Value: `strstr`},
+	`pos`:        {Value: `current`},
+	`key_exists`: {Value: `array_key_exists`},
+	`sizeof`:     {Value: `count`},
+
+	`close`:                {Value: `closedir`},
+	`fputs`:                {Value: `fwrite`},
+	`magic_quotes_runtime`: {Value: `set_magic_quotes_runtime`},
+	`show_source`:          {Value: `highlight_file`},
+}

--- a/src/phpgrep/doc.go
+++ b/src/phpgrep/doc.go
@@ -17,8 +17,6 @@ package phpgrep
 //
 // - Replace functionality.
 //
-// - Handle case sensitivity carefully (provide an option?).
-//
 // - stmt.Expression vs normal expressions named captures (should they match?).
 //
 // - Multi-statements matching.

--- a/src/phpgrep/phpgrep.go
+++ b/src/phpgrep/phpgrep.go
@@ -13,6 +13,10 @@ type Compiler struct {
 	// case sensitivity is set to true, compiled matcher will reject
 	// any spelling mismatches.
 	CaseSensitive bool
+
+	// FuzzyMatching enables some forms of normalization to the
+	// pattern so `[$x]` matches `array($x)` too.
+	FuzzyMatching bool
 }
 
 // Compile compiler a given pattern into a matcher.

--- a/src/phpgrep/utils.go
+++ b/src/phpgrep/utils.go
@@ -1,10 +1,28 @@
 package phpgrep
 
 import (
+	"strconv"
+
 	"github.com/z7zmey/php-parser/pkg/position"
 
 	"github.com/VKCOM/noverify/src/ir"
 )
+
+func normalizedIntValue(s string) string {
+	v, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return s
+	}
+	return strconv.FormatInt(v, 10)
+}
+
+func normalizedFloatValue(s string) string {
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return s
+	}
+	return strconv.FormatFloat(v, 'f', -1, 64)
+}
 
 func findNamed(capture []CapturedNode, name string) (ir.Node, bool) {
 	for _, c := range capture {

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -205,6 +205,9 @@ func (p *parser) parseRuleInfo(st ir.Node, proto *Rule) (Rule, error) {
 			rule.Level = lintapi.LevelNotice
 			rule.Message = part.ParamsText
 
+		case "strict-syntax":
+			rule.StrictSyntax = true
+
 		case "fix":
 			if rule.Fix != "" {
 				return rule, p.errorf(st, "duplicated @fix")
@@ -352,6 +355,7 @@ func (p *parser) parseRule(st ir.Node, proto *Rule) error {
 	}
 
 	pos := ir.GetPosition(st)
+	p.compiler.FuzzyMatching = !rule.StrictSyntax
 	m, err := p.compiler.Compile(p.sources[pos.StartPos-1 : pos.EndPos])
 	if err != nil {
 		return p.errorf(st, "pattern compilation error: %v", err)

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -81,6 +81,9 @@ type Rule struct {
 	// Level is a severity level that is used during report generation.
 	Level int
 
+	// StrictSyntax determines whether phpgrep fuzzy search should not be used.
+	StrictSyntax bool
+
 	// Message is a report text that is printed when this rule matches.
 	Message string
 


### PR DESCRIPTION
Dynamic rules will use this feature by default.
There is `@strict-syntax` attribute to disable this behavior explicitly.