### PR TITLE
linter: added classMembersOrder checker

### DIFF
--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -189,37 +189,37 @@ func (b *blockLinter) enterNode(n ir.Node) {
 
 func (b *blockLinter) checkClass(class *ir.ClassStmt) {
 	const classMethod = 0
-	const classOtherComp = 1
+	const classOtherMember = 1
 
-	var components = make([]int, 0, len(class.Stmts))
+	var members = make([]int, 0, len(class.Stmts))
 	for _, stmt := range class.Stmts {
 		switch stmt.(type) {
 		case *ir.ClassMethodStmt:
-			components = append(components, classMethod)
+			members = append(members, classMethod)
 		default:
-			components = append(components, classOtherComp)
+			members = append(members, classOtherMember)
 		}
 	}
 
 	var methodsBegin bool
-	for index, component := range components {
-		if component == classMethod {
+	for index, member := range members {
+		if member == classMethod {
 			methodsBegin = true
 		} else if methodsBegin {
-			comp := class.Stmts[index]
-			compType := ""
-			compName := ""
-			switch comp := comp.(type) {
+			stmt := class.Stmts[index]
+			memberType := ""
+			memberName := ""
+			switch stmt := stmt.(type) {
 			case *ir.ClassConstListStmt:
-				compType = "Constant"
-				compName = comp.Consts[0].(*ir.ConstantStmt).ConstantName.Value
+				memberType = "Constant"
+				memberName = stmt.Consts[0].(*ir.ConstantStmt).ConstantName.Value
 			case *ir.PropertyListStmt:
-				compType = "Property"
-				compName = "$" + comp.Properties[0].(*ir.PropertyStmt).Variable.Name
+				memberType = "Property"
+				memberName = "$" + stmt.Properties[0].(*ir.PropertyStmt).Variable.Name
 			default:
 				continue
 			}
-			b.report(comp, LevelError, "classCompOrder", "%s %s must go before methods in the class %s", compType, compName, class.ClassName.Value)
+			b.report(stmt, LevelError, "classMembersOrder", "%s %s must go before methods in the class %s", memberType, memberName, class.ClassName.Value)
 		}
 	}
 }

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -671,6 +671,23 @@ function f(array $a) {}`,
 			Before:   `strpos('/', $s);`,
 			After:    `strpos($s, '/');`,
 		},
+
+		{
+			Name:     "classCompOrder",
+			Default:  false,
+			Quickfix: false,
+			Comment:  `Report the wrong order of the class component.`,
+			Before: `class A {
+  public function func() {}
+  const B = 1;
+  public $c = 2;
+}`,
+			After: `class A {
+  const B = 1;
+  public $c = 2;
+  public function func() {}
+}`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -673,10 +673,10 @@ function f(array $a) {}`,
 		},
 
 		{
-			Name:     "classCompOrder",
+			Name:     "classMembersOrder",
 			Default:  false,
 			Quickfix: false,
-			Comment:  `Report the wrong order of the class component.`,
+			Comment:  `Report the wrong order of the class members.`,
 			Before: `class A {
   public function func() {}
   const B = 1;

--- a/src/tests/checkers/misspell_test.go
+++ b/src/tests/checkers/misspell_test.go
@@ -28,14 +28,14 @@ class c1 {
   const Foo = 0;
 
   /**
-   * This method is never called, this is why it's inexpencive.
-   */
-  private static function secret() {}
-
-  /**
    * This property is not inefficeint.
    */
   private $prop = 1;
+
+  /**
+   * This method is never called, this is why it's inexpencive.
+   */
+  private static function secret() {}
 }
 `)
 	test.Expect = []string{

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -1577,7 +1577,7 @@ class Foo3 {
 		`Property $a must go before methods in the class Foo3`,
 		`Constant A must go before methods in the class Foo3`,
 	}
-	linttest.RunFilterMatch(test, "classCompOrder")
+	linttest.RunFilterMatch(test, "classMembersOrder")
 }
 
 func TestClassComponentsOrderGood(t *testing.T) {

--- a/src/tests/golden/testdata/math/golden.txt
+++ b/src/tests/golden/testdata/math/golden.txt
@@ -16,3 +16,33 @@ MAYBE   trailingComma: last element in a multi-line array must have a trailing c
 MAYBE   trailingComma: last element in a multi-line array must have a trailing comma at testdata/math/src/Internal/Calculator/NativeCalculator.php:187
                     (string) $r
                     ^^^^^^^^^^^
+ERROR   classCompOrder: Constant UNNECESSARY must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:33
+    public const UNNECESSARY = 0;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:41
+    public const UP = 1;
+    ^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:49
+    public const DOWN = 2;
+    ^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:57
+    public const CEILING = 3;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:65
+    public const FLOOR = 4;
+    ^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant HALF_UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:73
+    public const HALF_UP = 5;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant HALF_DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:80
+    public const HALF_DOWN = 6;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant HALF_CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:87
+    public const HALF_CEILING = 7;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant HALF_FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:94
+    public const HALF_FLOOR = 8;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant HALF_EVEN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:106
+    public const HALF_EVEN = 9;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/math/golden.txt
+++ b/src/tests/golden/testdata/math/golden.txt
@@ -16,33 +16,33 @@ MAYBE   trailingComma: last element in a multi-line array must have a trailing c
 MAYBE   trailingComma: last element in a multi-line array must have a trailing comma at testdata/math/src/Internal/Calculator/NativeCalculator.php:187
                     (string) $r
                     ^^^^^^^^^^^
-ERROR   classCompOrder: Constant UNNECESSARY must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:33
+ERROR   classMembersOrder: Constant UNNECESSARY must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:33
     public const UNNECESSARY = 0;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:41
+ERROR   classMembersOrder: Constant UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:41
     public const UP = 1;
     ^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:49
+ERROR   classMembersOrder: Constant DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:49
     public const DOWN = 2;
     ^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:57
+ERROR   classMembersOrder: Constant CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:57
     public const CEILING = 3;
     ^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:65
+ERROR   classMembersOrder: Constant FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:65
     public const FLOOR = 4;
     ^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant HALF_UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:73
+ERROR   classMembersOrder: Constant HALF_UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:73
     public const HALF_UP = 5;
     ^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant HALF_DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:80
+ERROR   classMembersOrder: Constant HALF_DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:80
     public const HALF_DOWN = 6;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant HALF_CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:87
+ERROR   classMembersOrder: Constant HALF_CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:87
     public const HALF_CEILING = 7;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant HALF_FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:94
+ERROR   classMembersOrder: Constant HALF_FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:94
     public const HALF_FLOOR = 8;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant HALF_EVEN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:106
+ERROR   classMembersOrder: Constant HALF_EVEN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:106
     public const HALF_EVEN = 9;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -25,73 +25,73 @@ WARNING unused: Variable keystr is unused (use $_ to ignore this inspection) at 
 MAYBE   callSimplify: Could simplify to $id[0] at testdata/mustache/src/Mustache/Compiler.php:646
             if (substr($id, 0, 1) === '.') {
                 ^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant KLASS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:184
+ERROR   classMembersOrder: Constant KLASS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:184
     const KLASS = '<?php
     ^^^^^^^
-ERROR   classCompOrder: Constant KLASS_NO_LAMBDAS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:202
+ERROR   classMembersOrder: Constant KLASS_NO_LAMBDAS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:202
     const KLASS_NO_LAMBDAS = '<?php
     ^^^^^^^
-ERROR   classCompOrder: Constant STRICT_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:215
+ERROR   classMembersOrder: Constant STRICT_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:215
     const STRICT_CALLABLE = 'protected $strictCallables = true;';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant BLOCK_VAR must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:237
+ERROR   classMembersOrder: Constant BLOCK_VAR must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:237
     const BLOCK_VAR = '
     ^^
-ERROR   classCompOrder: Constant BLOCK_VAR_ELSE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:244
+ERROR   classMembersOrder: Constant BLOCK_VAR_ELSE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:244
     const BLOCK_VAR_ELSE = '} else {%s';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant BLOCK_ARG must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:271
+ERROR   classMembersOrder: Constant BLOCK_ARG must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:271
     const BLOCK_ARG = '%s => array($this, \'block%s\'),';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant BLOCK_FUNCTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:295
+ERROR   classMembersOrder: Constant BLOCK_FUNCTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:295
     const BLOCK_FUNCTION = '
     ^^
-ERROR   classCompOrder: Constant SECTION_CALL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:323
+ERROR   classMembersOrder: Constant SECTION_CALL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:323
     const SECTION_CALL = '
     ^^
-ERROR   classCompOrder: Constant SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:329
+ERROR   classMembersOrder: Constant SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:329
     const SECTION = '
     ^^
-ERROR   classCompOrder: Constant INVERTED_SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:398
+ERROR   classMembersOrder: Constant INVERTED_SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:398
     const INVERTED_SECTION = '
     ^^
-ERROR   classCompOrder: Constant PARTIAL_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:425
+ERROR   classMembersOrder: Constant PARTIAL_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:425
     const PARTIAL_INDENT = ', $indent . %s';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant PARTIAL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:426
+ERROR   classMembersOrder: Constant PARTIAL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:426
     const PARTIAL = '
     ^^
-ERROR   classCompOrder: Constant PARENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:456
+ERROR   classMembersOrder: Constant PARENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:456
     const PARENT = '
     ^^
-ERROR   classCompOrder: Constant PARENT_NO_CONTEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:465
+ERROR   classMembersOrder: Constant PARENT_NO_CONTEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:465
     const PARENT_NO_CONTEXT = '
     ^^
-ERROR   classCompOrder: Constant VARIABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:508
+ERROR   classMembersOrder: Constant VARIABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:508
     const VARIABLE = '
     ^^
-ERROR   classCompOrder: Constant FILTER must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:533
+ERROR   classMembersOrder: Constant FILTER must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:533
     const FILTER = '
     ^^
-ERROR   classCompOrder: Constant LINE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:564
+ERROR   classMembersOrder: Constant LINE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:564
     const LINE = '$buffer .= "\n";';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant TEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:565
+ERROR   classMembersOrder: Constant TEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:565
     const TEXT = '$buffer .= %s%s;';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant DEFAULT_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:607
+ERROR   classMembersOrder: Constant DEFAULT_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:607
     const DEFAULT_ESCAPE = 'htmlspecialchars(%s, %s, %s)';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant CUSTOM_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:608
+ERROR   classMembersOrder: Constant CUSTOM_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:608
     const CUSTOM_ESCAPE  = 'call_user_func($this->mustache->getEscape(), %s)';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:658
+ERROR   classMembersOrder: Constant IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:658
     const IS_CALLABLE        = '!is_string(%s) && is_callable(%s)';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant STRICT_IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:659
+ERROR   classMembersOrder: Constant STRICT_IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:659
     const STRICT_IS_CALLABLE = 'is_object(%s) && is_callable(%s)';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant LINE_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:675
+ERROR   classMembersOrder: Constant LINE_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:675
     const LINE_INDENT = '$indent . ';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   callSimplify: Could simplify to $this->stack[] = $value at testdata/mustache/src/Mustache/Context.php:39

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -25,6 +25,75 @@ WARNING unused: Variable keystr is unused (use $_ to ignore this inspection) at 
 MAYBE   callSimplify: Could simplify to $id[0] at testdata/mustache/src/Mustache/Compiler.php:646
             if (substr($id, 0, 1) === '.') {
                 ^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant KLASS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:184
+    const KLASS = '<?php
+    ^^^^^^^
+ERROR   classCompOrder: Constant KLASS_NO_LAMBDAS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:202
+    const KLASS_NO_LAMBDAS = '<?php
+    ^^^^^^^
+ERROR   classCompOrder: Constant STRICT_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:215
+    const STRICT_CALLABLE = 'protected $strictCallables = true;';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant BLOCK_VAR must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:237
+    const BLOCK_VAR = '
+    ^^
+ERROR   classCompOrder: Constant BLOCK_VAR_ELSE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:244
+    const BLOCK_VAR_ELSE = '} else {%s';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant BLOCK_ARG must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:271
+    const BLOCK_ARG = '%s => array($this, \'block%s\'),';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant BLOCK_FUNCTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:295
+    const BLOCK_FUNCTION = '
+    ^^
+ERROR   classCompOrder: Constant SECTION_CALL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:323
+    const SECTION_CALL = '
+    ^^
+ERROR   classCompOrder: Constant SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:329
+    const SECTION = '
+    ^^
+ERROR   classCompOrder: Constant INVERTED_SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:398
+    const INVERTED_SECTION = '
+    ^^
+ERROR   classCompOrder: Constant PARTIAL_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:425
+    const PARTIAL_INDENT = ', $indent . %s';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant PARTIAL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:426
+    const PARTIAL = '
+    ^^
+ERROR   classCompOrder: Constant PARENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:456
+    const PARENT = '
+    ^^
+ERROR   classCompOrder: Constant PARENT_NO_CONTEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:465
+    const PARENT_NO_CONTEXT = '
+    ^^
+ERROR   classCompOrder: Constant VARIABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:508
+    const VARIABLE = '
+    ^^
+ERROR   classCompOrder: Constant FILTER must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:533
+    const FILTER = '
+    ^^
+ERROR   classCompOrder: Constant LINE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:564
+    const LINE = '$buffer .= "\n";';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant TEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:565
+    const TEXT = '$buffer .= %s%s;';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant DEFAULT_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:607
+    const DEFAULT_ESCAPE = 'htmlspecialchars(%s, %s, %s)';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant CUSTOM_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:608
+    const CUSTOM_ESCAPE  = 'call_user_func($this->mustache->getEscape(), %s)';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:658
+    const IS_CALLABLE        = '!is_string(%s) && is_callable(%s)';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant STRICT_IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:659
+    const STRICT_IS_CALLABLE = 'is_object(%s) && is_callable(%s)';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant LINE_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:675
+    const LINE_INDENT = '$indent . ';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   callSimplify: Could simplify to $this->stack[] = $value at testdata/mustache/src/Mustache/Context.php:39
         array_push($this->stack, $value);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/parsedown/golden.txt
+++ b/src/tests/golden/testdata/parsedown/golden.txt
@@ -148,3 +148,57 @@ WARNING unused: Variable val is unused (use $_ to ignore this inspection) at tes
 MAYBE   typeHint: specify the type for the parameter $Element in phpdoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1900
     protected function filterUnsafeUrlInAttribute(array $Element, $attribute)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $breaksEnabled must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:66
+    protected $breaksEnabled;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $markupEscaped must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:75
+    protected $markupEscaped;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $urlsLinked must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:84
+    protected $urlsLinked = true;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $safeMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:93
+    protected $safeMode;
+    ^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $strictMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:102
+    protected $strictMode;
+    ^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $safeLinksWhitelist must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:104
+    protected $safeLinksWhitelist = array(
+    ^^
+ERROR   classCompOrder: Property $BlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:126
+    protected $BlockTypes = array(
+    ^^
+ERROR   classCompOrder: Property $unmarkedBlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:154
+    protected $unmarkedBlockTypes = array(
+    ^^
+ERROR   classCompOrder: Property $InlineTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1109
+    protected $InlineTypes = array(
+    ^^
+ERROR   classCompOrder: Property $inlineMarkerList must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1124
+    protected $inlineMarkerList = '!*_&[:<`~\\';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $instances must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1952
+    private static $instances = array();
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $DefinitionData must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1958
+    protected $DefinitionData;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $specialCharacters must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1963
+    protected $specialCharacters = array(
+    ^^
+ERROR   classCompOrder: Property $StrongRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1967
+    protected $StrongRegex = array(
+    ^^
+ERROR   classCompOrder: Property $EmRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1972
+    protected $EmRegex = array(
+    ^^
+ERROR   classCompOrder: Property $regexHtmlAttribute must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1977
+    protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*+(?:\s*+=\s*+(?:[^"\'=<>`\s]+|"[^"]*+"|\'[^\']*+\'))?+';
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $voidElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1979
+    protected $voidElements = array(
+    ^^
+ERROR   classCompOrder: Property $textLevelElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1983
+    protected $textLevelElements = array(
+    ^^

--- a/src/tests/golden/testdata/parsedown/golden.txt
+++ b/src/tests/golden/testdata/parsedown/golden.txt
@@ -148,57 +148,57 @@ WARNING unused: Variable val is unused (use $_ to ignore this inspection) at tes
 MAYBE   typeHint: specify the type for the parameter $Element in phpdoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1900
     protected function filterUnsafeUrlInAttribute(array $Element, $attribute)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $breaksEnabled must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:66
+ERROR   classMembersOrder: Property $breaksEnabled must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:66
     protected $breaksEnabled;
     ^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $markupEscaped must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:75
+ERROR   classMembersOrder: Property $markupEscaped must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:75
     protected $markupEscaped;
     ^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $urlsLinked must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:84
+ERROR   classMembersOrder: Property $urlsLinked must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:84
     protected $urlsLinked = true;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $safeMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:93
+ERROR   classMembersOrder: Property $safeMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:93
     protected $safeMode;
     ^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $strictMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:102
+ERROR   classMembersOrder: Property $strictMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:102
     protected $strictMode;
     ^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $safeLinksWhitelist must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:104
+ERROR   classMembersOrder: Property $safeLinksWhitelist must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:104
     protected $safeLinksWhitelist = array(
     ^^
-ERROR   classCompOrder: Property $BlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:126
+ERROR   classMembersOrder: Property $BlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:126
     protected $BlockTypes = array(
     ^^
-ERROR   classCompOrder: Property $unmarkedBlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:154
+ERROR   classMembersOrder: Property $unmarkedBlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:154
     protected $unmarkedBlockTypes = array(
     ^^
-ERROR   classCompOrder: Property $InlineTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1109
+ERROR   classMembersOrder: Property $InlineTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1109
     protected $InlineTypes = array(
     ^^
-ERROR   classCompOrder: Property $inlineMarkerList must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1124
+ERROR   classMembersOrder: Property $inlineMarkerList must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1124
     protected $inlineMarkerList = '!*_&[:<`~\\';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $instances must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1952
+ERROR   classMembersOrder: Property $instances must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1952
     private static $instances = array();
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $DefinitionData must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1958
+ERROR   classMembersOrder: Property $DefinitionData must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1958
     protected $DefinitionData;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $specialCharacters must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1963
+ERROR   classMembersOrder: Property $specialCharacters must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1963
     protected $specialCharacters = array(
     ^^
-ERROR   classCompOrder: Property $StrongRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1967
+ERROR   classMembersOrder: Property $StrongRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1967
     protected $StrongRegex = array(
     ^^
-ERROR   classCompOrder: Property $EmRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1972
+ERROR   classMembersOrder: Property $EmRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1972
     protected $EmRegex = array(
     ^^
-ERROR   classCompOrder: Property $regexHtmlAttribute must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1977
+ERROR   classMembersOrder: Property $regexHtmlAttribute must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1977
     protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*+(?:\s*+=\s*+(?:[^"\'=<>`\s]+|"[^"]*+"|\'[^\']*+\'))?+';
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $voidElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1979
+ERROR   classMembersOrder: Property $voidElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1979
     protected $voidElements = array(
     ^^
-ERROR   classCompOrder: Property $textLevelElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1983
+ERROR   classMembersOrder: Property $textLevelElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1983
     protected $textLevelElements = array(
     ^^

--- a/src/tests/golden/testdata/qrcode/golden.txt
+++ b/src/tests/golden/testdata/qrcode/golden.txt
@@ -64,3 +64,30 @@ MAYBE   callSimplify: Could simplify to $group[0] at testdata/qrcode/qrcode.php:
 MAYBE   callSimplify: Could simplify to $group[1] at testdata/qrcode/qrcode.php:449
       $c2    = ord(substr($group, 1, 1));
                    ^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $qr_capacity must go before methods in the class QRCode at testdata/qrcode/qrcode.php:890
+  private $qr_capacity = [
+  ^^
+ERROR   classCompOrder: Property $qr_ec_params must go before methods in the class QRCode at testdata/qrcode/qrcode.php:943
+  private $qr_ec_params = [
+  ^^
+ERROR   classCompOrder: Property $qr_ec_polynomials must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1106
+  private $qr_ec_polynomials = [
+  ^^
+ERROR   classCompOrder: Property $qr_log must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1162
+  private $qr_log = [
+  ^^
+ERROR   classCompOrder: Property $qr_exp must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1197
+  private $qr_exp = [
+  ^^
+ERROR   classCompOrder: Property $qr_remainder_bits must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1232
+  private $qr_remainder_bits = [
+  ^^
+ERROR   classCompOrder: Property $qr_alignment_patterns must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1237
+  private $qr_alignment_patterns = [
+  ^^
+ERROR   classCompOrder: Property $qr_format_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1282
+  private $qr_format_info = [
+  ^^
+ERROR   classCompOrder: Property $qr_version_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1318
+  private $qr_version_info = [
+  ^^

--- a/src/tests/golden/testdata/qrcode/golden.txt
+++ b/src/tests/golden/testdata/qrcode/golden.txt
@@ -64,30 +64,30 @@ MAYBE   callSimplify: Could simplify to $group[0] at testdata/qrcode/qrcode.php:
 MAYBE   callSimplify: Could simplify to $group[1] at testdata/qrcode/qrcode.php:449
       $c2    = ord(substr($group, 1, 1));
                    ^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $qr_capacity must go before methods in the class QRCode at testdata/qrcode/qrcode.php:890
+ERROR   classMembersOrder: Property $qr_capacity must go before methods in the class QRCode at testdata/qrcode/qrcode.php:890
   private $qr_capacity = [
   ^^
-ERROR   classCompOrder: Property $qr_ec_params must go before methods in the class QRCode at testdata/qrcode/qrcode.php:943
+ERROR   classMembersOrder: Property $qr_ec_params must go before methods in the class QRCode at testdata/qrcode/qrcode.php:943
   private $qr_ec_params = [
   ^^
-ERROR   classCompOrder: Property $qr_ec_polynomials must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1106
+ERROR   classMembersOrder: Property $qr_ec_polynomials must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1106
   private $qr_ec_polynomials = [
   ^^
-ERROR   classCompOrder: Property $qr_log must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1162
+ERROR   classMembersOrder: Property $qr_log must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1162
   private $qr_log = [
   ^^
-ERROR   classCompOrder: Property $qr_exp must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1197
+ERROR   classMembersOrder: Property $qr_exp must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1197
   private $qr_exp = [
   ^^
-ERROR   classCompOrder: Property $qr_remainder_bits must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1232
+ERROR   classMembersOrder: Property $qr_remainder_bits must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1232
   private $qr_remainder_bits = [
   ^^
-ERROR   classCompOrder: Property $qr_alignment_patterns must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1237
+ERROR   classMembersOrder: Property $qr_alignment_patterns must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1237
   private $qr_alignment_patterns = [
   ^^
-ERROR   classCompOrder: Property $qr_format_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1282
+ERROR   classMembersOrder: Property $qr_format_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1282
   private $qr_format_info = [
   ^^
-ERROR   classCompOrder: Property $qr_version_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1318
+ERROR   classMembersOrder: Property $qr_version_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1318
   private $qr_version_info = [
   ^^

--- a/src/tests/golden/testdata/underscore/golden.txt
+++ b/src/tests/golden/testdata/underscore/golden.txt
@@ -175,45 +175,45 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 ERROR   unused: foreach key $k is unused, can simplify $k => $v to just $v at testdata/underscore/underscore.php:1107
       foreach($caller_args as $k=>$v) {
                               ^^
-ERROR   classCompOrder: Property $_uniqueId must go before methods in the class __ at testdata/underscore/underscore.php:817
+ERROR   classMembersOrder: Property $_uniqueId must go before methods in the class __ at testdata/underscore/underscore.php:817
   public $_uniqueId = -1;
   ^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $_mixins must go before methods in the class __ at testdata/underscore/underscore.php:839
+ERROR   classMembersOrder: Property $_mixins must go before methods in the class __ at testdata/underscore/underscore.php:839
   private $_mixins = array();
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant TEMPLATE_OPEN_TAG must go before methods in the class __ at testdata/underscore/underscore.php:868
+ERROR   classMembersOrder: Constant TEMPLATE_OPEN_TAG must go before methods in the class __ at testdata/underscore/underscore.php:868
   const TEMPLATE_OPEN_TAG = '760e7dab2836853c63805033e514668301fa9c47';
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant TEMPLATE_CLOSE_TAG must go before methods in the class __ at testdata/underscore/underscore.php:869
+ERROR   classMembersOrder: Constant TEMPLATE_CLOSE_TAG must go before methods in the class __ at testdata/underscore/underscore.php:869
   const TEMPLATE_CLOSE_TAG= 'd228a8fa36bd7db108b01eddfb03a30899987a2b';
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant TEMPLATE_DEFAULT_EVALUATE must go before methods in the class __ at testdata/underscore/underscore.php:871
+ERROR   classMembersOrder: Constant TEMPLATE_DEFAULT_EVALUATE must go before methods in the class __ at testdata/underscore/underscore.php:871
   const TEMPLATE_DEFAULT_EVALUATE   = '/<%([\s\S]+?)%>/';
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant TEMPLATE_DEFAULT_INTERPOLATE must go before methods in the class __ at testdata/underscore/underscore.php:872
+ERROR   classMembersOrder: Constant TEMPLATE_DEFAULT_INTERPOLATE must go before methods in the class __ at testdata/underscore/underscore.php:872
   const TEMPLATE_DEFAULT_INTERPOLATE= '/<%=([\s\S]+?)%>/';
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Constant TEMPLATE_DEFAULT_ESCAPE must go before methods in the class __ at testdata/underscore/underscore.php:873
+ERROR   classMembersOrder: Constant TEMPLATE_DEFAULT_ESCAPE must go before methods in the class __ at testdata/underscore/underscore.php:873
   const TEMPLATE_DEFAULT_ESCAPE     = '/<%-([\s\S]+?)%>/';
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $_template_settings must go before methods in the class __ at testdata/underscore/underscore.php:874
+ERROR   classMembersOrder: Property $_template_settings must go before methods in the class __ at testdata/underscore/underscore.php:874
   public $_template_settings = array(
   ^^
-ERROR   classCompOrder: Property $_memoized must go before methods in the class __ at testdata/underscore/underscore.php:957
+ERROR   classMembersOrder: Property $_memoized must go before methods in the class __ at testdata/underscore/underscore.php:957
   public $_memoized = array();
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $_throttled must go before methods in the class __ at testdata/underscore/underscore.php:986
+ERROR   classMembersOrder: Property $_throttled must go before methods in the class __ at testdata/underscore/underscore.php:986
   public $_throttled = array();
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $_onced must go before methods in the class __ at testdata/underscore/underscore.php:1012
+ERROR   classMembersOrder: Property $_onced must go before methods in the class __ at testdata/underscore/underscore.php:1012
   public $_onced = array();
   ^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $_aftered must go before methods in the class __ at testdata/underscore/underscore.php:1057
+ERROR   classMembersOrder: Property $_aftered must go before methods in the class __ at testdata/underscore/underscore.php:1057
   public $_aftered = array();
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $_instance must go before methods in the class __ at testdata/underscore/underscore.php:1075
+ERROR   classMembersOrder: Property $_instance must go before methods in the class __ at testdata/underscore/underscore.php:1075
   private static $_instance;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-ERROR   classCompOrder: Property $_wrapped must go before methods in the class __ at testdata/underscore/underscore.php:1087
+ERROR   classMembersOrder: Property $_wrapped must go before methods in the class __ at testdata/underscore/underscore.php:1087
   public $_wrapped; // Value passed from one chained method to the next
   ^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/underscore/golden.txt
+++ b/src/tests/golden/testdata/underscore/golden.txt
@@ -175,3 +175,45 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 ERROR   unused: foreach key $k is unused, can simplify $k => $v to just $v at testdata/underscore/underscore.php:1107
       foreach($caller_args as $k=>$v) {
                               ^^
+ERROR   classCompOrder: Property $_uniqueId must go before methods in the class __ at testdata/underscore/underscore.php:817
+  public $_uniqueId = -1;
+  ^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $_mixins must go before methods in the class __ at testdata/underscore/underscore.php:839
+  private $_mixins = array();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant TEMPLATE_OPEN_TAG must go before methods in the class __ at testdata/underscore/underscore.php:868
+  const TEMPLATE_OPEN_TAG = '760e7dab2836853c63805033e514668301fa9c47';
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant TEMPLATE_CLOSE_TAG must go before methods in the class __ at testdata/underscore/underscore.php:869
+  const TEMPLATE_CLOSE_TAG= 'd228a8fa36bd7db108b01eddfb03a30899987a2b';
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant TEMPLATE_DEFAULT_EVALUATE must go before methods in the class __ at testdata/underscore/underscore.php:871
+  const TEMPLATE_DEFAULT_EVALUATE   = '/<%([\s\S]+?)%>/';
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant TEMPLATE_DEFAULT_INTERPOLATE must go before methods in the class __ at testdata/underscore/underscore.php:872
+  const TEMPLATE_DEFAULT_INTERPOLATE= '/<%=([\s\S]+?)%>/';
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Constant TEMPLATE_DEFAULT_ESCAPE must go before methods in the class __ at testdata/underscore/underscore.php:873
+  const TEMPLATE_DEFAULT_ESCAPE     = '/<%-([\s\S]+?)%>/';
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $_template_settings must go before methods in the class __ at testdata/underscore/underscore.php:874
+  public $_template_settings = array(
+  ^^
+ERROR   classCompOrder: Property $_memoized must go before methods in the class __ at testdata/underscore/underscore.php:957
+  public $_memoized = array();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $_throttled must go before methods in the class __ at testdata/underscore/underscore.php:986
+  public $_throttled = array();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $_onced must go before methods in the class __ at testdata/underscore/underscore.php:1012
+  public $_onced = array();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $_aftered must go before methods in the class __ at testdata/underscore/underscore.php:1057
+  public $_aftered = array();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $_instance must go before methods in the class __ at testdata/underscore/underscore.php:1075
+  private static $_instance;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ERROR   classCompOrder: Property $_wrapped must go before methods in the class __ at testdata/underscore/underscore.php:1087
+  public $_wrapped; // Value passed from one chained method to the next
+  ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
`classMembersOrder` checks that all constants and
properties of the class go before methods.