### PR TITLE
cmd: -rules flag can now accept folders

### DIFF
--- a/docs/dynamic-rules.md
+++ b/docs/dynamic-rules.md
@@ -41,7 +41,7 @@ The **rule file** is a set of rules or, technically speaking, a sequence of PHP 
 
 Because a rule file is a valid PHP file, you can use IDE like [PhpStorm](https://www.jetbrains.com/phpstorm/) to work with them.
 
-NoVerify accepts such files with `-rules` command-line argument. If several files are specified, they are merged.
+NoVerify accepts such files with `-rules` command-line argument. If several files are specified, they are merged. If a folder is specified, all rules from it will be added (not recursive, only the rules that are directly in the folder are added).
 
 A single rules file can look like this:
 


### PR DESCRIPTION
`-rules` flag can now accept folders, in which case all files from it will be added to the rules

Please note that if there is another folder in the specified
folder and there are rules in it, these rules will **NOT** be added.
Only rules that are directly in the specified folder are added.