### PR TITLE
cmd: added Pure flag for cli.Command

### DIFF
--- a/src/cmd/cli.go
+++ b/src/cmd/cli.go
@@ -99,6 +99,10 @@ func (a *App) prepareCommands() {
 }
 
 func (a *App) addDefaultHelpCommand(command *Command) {
+	if command.Pure {
+		return
+	}
+
 	command.Commands = append(command.Commands, &Command{
 		Name:        "help",
 		Description: "The command to show help for " + command.Name + " command",
@@ -239,14 +243,25 @@ func (a *App) Run(cfg *MainConfig) (int, error) {
 
 	a.prepareCommands()
 
-	// replace -help with help command
-	for i := range os.Args {
-		if strings.HasSuffix(os.Args[i], "help") && strings.HasPrefix(os.Args[i], "-") {
-			os.Args[i] = "help"
+	// We do a pre-check by receiving the command only for the first argument.
+	command, found := a.getCommandByArgs(os.Args[:1], a.commands)
+	if !found {
+		a.showHelp()
+		return 0, nil
+	}
+
+	// And if this command is not pure, then only then do
+	// we turn the help flags into subcommand.
+	if !command.Pure {
+		// replace -help or --help with help subcommand
+		for i := range os.Args {
+			if strings.HasSuffix(os.Args[i], "help") && strings.HasPrefix(os.Args[i], "-") {
+				os.Args[i] = "help"
+			}
 		}
 	}
 
-	command, found := a.getCommandByArgs(os.Args, a.commands)
+	command, found = a.getCommandByArgs(os.Args, a.commands)
 	if !found {
 		a.showHelp()
 		return 0, nil
@@ -256,6 +271,13 @@ func (a *App) Run(cfg *MainConfig) (int, error) {
 		App:         a,
 		MainConfig:  cfg,
 		ParsedFlags: ParsedFlags{},
+	}
+
+	if command.Pure {
+		if command.RegisterFlags != nil {
+			return 0, fmt.Errorf("for a pure commands, flags are expected to be registered inside Action")
+		}
+		return command.Action(ctx)
 	}
 
 	var fs *flag.FlagSet
@@ -271,7 +293,18 @@ func (a *App) Run(cfg *MainConfig) (int, error) {
 		command.flagSet = fs
 		ctx.ParsedArgs = fs.Args()
 		ctx.FlagSet = fs
+	} else {
+		fs = flag.NewFlagSet("empty", flag.ContinueOnError)
 	}
+
+	err := fs.Parse(os.Args[1:])
+	if err != nil {
+		return 2, err
+	}
+
+	command.flagSet = fs
+	ctx.ParsedArgs = fs.Args()
+	ctx.FlagSet = fs
 
 	return command.Action(ctx)
 }

--- a/src/cmd/cli.go
+++ b/src/cmd/cli.go
@@ -22,6 +22,9 @@ type AppContext struct {
 }
 
 func (ctx *AppContext) FormatFlags() (res string) {
+	if ctx.FlagSet == nil {
+		return ""
+	}
 	ctx.FlagSet.VisitAll(func(f *flag.Flag) {
 		defaultVal := f.DefValue
 		if f.DefValue != "" {
@@ -33,6 +36,9 @@ func (ctx *AppContext) FormatFlags() (res string) {
 }
 
 func (ctx *AppContext) CountDefinedFlags() int {
+	if ctx.FlagSet == nil {
+		return 0
+	}
 	var res int
 	ctx.FlagSet.VisitAll(func(*flag.Flag) { res++ })
 	return res
@@ -257,17 +263,15 @@ func (a *App) Run(cfg *MainConfig) (int, error) {
 	if command.RegisterFlags != nil {
 		fs = command.RegisterFlags(ctx)
 		fs.Usage = nil
-	} else {
-		fs = flag.NewFlagSet("empty", flag.ContinueOnError)
-	}
 
-	err := fs.Parse(os.Args[1:])
-	if err != nil {
-		return 2, err
+		err := fs.Parse(os.Args[1:])
+		if err != nil {
+			return 2, err
+		}
+		command.flagSet = fs
+		ctx.ParsedArgs = fs.Args()
+		ctx.FlagSet = fs
 	}
-	command.flagSet = fs
-	ctx.ParsedArgs = fs.Args()
-	ctx.FlagSet = fs
 
 	return command.Action(ctx)
 }

--- a/src/cmd/command.go
+++ b/src/cmd/command.go
@@ -25,6 +25,11 @@ type Command struct {
 	RegisterFlags func(*AppContext) *flag.FlagSet
 	flagSet       *flag.FlagSet
 
+	// Pure flag defines the command, which itself is responsible
+	// for registering flags and arguments.
+	// For such a command, help subcommand is not automatically generated.
+	Pure bool
+
 	Commands []*Command
 	commands map[string]*Command
 }


### PR DESCRIPTION
This flag defines the command, which itself is responsible for registering flags and arguments.
For the command with this flag, the help subcommand is not automatically generated.