### PR TITLE
linter: added check for repeated nullable type

### DIFF
--- a/src/linter/types.go
+++ b/src/linter/types.go
@@ -23,7 +23,19 @@ func typesFromPHPDoc(ctx *rootContext, typ phpdoc.Type) ([]types.Type, warningSt
 	conv := phpdocTypeConverter{ctx: ctx}
 	result := conv.mapType(typ.Expr)
 	if conv.nullable {
-		result = append(result, types.Type{Elem: "null"})
+		alreadyHasNull := false
+
+		for _, tp := range result {
+			if tp.Elem == "null" {
+				alreadyHasNull = true
+				conv.warning = "twice nullable doesn't make sense"
+				break
+			}
+		}
+
+		if !alreadyHasNull {
+			result = append(result, types.Type{Elem: "null"})
+		}
 	}
 	return result, conv.warning
 }
@@ -167,6 +179,7 @@ func (conv *phpdocTypeConverter) mapShapeType(params []phpdoc.TypeExpr) []types.
 				Elem: "null",
 				Dims: 0,
 			})
+			conv.nullable = false
 		}
 
 		props = append(props, autogen.ShapeTypeProp{

--- a/src/linter/types.go
+++ b/src/linter/types.go
@@ -28,7 +28,7 @@ func typesFromPHPDoc(ctx *rootContext, typ phpdoc.Type) ([]types.Type, warningSt
 		for _, tp := range result {
 			if tp.Elem == "null" {
 				alreadyHasNull = true
-				conv.warning = "twice nullable doesn't make sense"
+				conv.warning = "repeated nullable doesn't make sense"
 				break
 			}
 		}

--- a/src/tests/checkers/phpdoc_test.go
+++ b/src/tests/checkers/phpdoc_test.go
@@ -498,10 +498,10 @@ function f($a, $b, $c, $d) {
 }
 `)
 	test.Expect = []string{
-		`twice nullable doesn't make sense`,
-		`twice nullable doesn't make sense`,
-		`twice nullable doesn't make sense`,
-		`twice nullable doesn't make sense`,
+		`repeated nullable doesn't make sense`,
+		`repeated nullable doesn't make sense`,
+		`repeated nullable doesn't make sense`,
+		`repeated nullable doesn't make sense`,
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/checkers/phpdoc_test.go
+++ b/src/tests/checkers/phpdoc_test.go
@@ -478,3 +478,30 @@ function f2($a) {
 	}
 	test.RunAndMatch()
 }
+
+func TestPhpdocTwiceNullableTypes(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+/**
+ * @param ?int|null $a
+ * @param ?string[]|null $b
+ * @param ?Foo|null $c
+ * @param shape(name: ?string, age: int)|null $d
+ * @return ?int|null
+ */
+function f($a, $b, $c, $d) {
+  echo $a;
+  echo $b;
+  echo $c;
+  echo $d;
+  return null;
+}
+`)
+	test.Expect = []string{
+		`twice nullable doesn't make sense`,
+		`twice nullable doesn't make sense`,
+		`twice nullable doesn't make sense`,
+		`twice nullable doesn't make sense`,
+	}
+	test.RunAndMatch()
+}


### PR DESCRIPTION
Also fixed a bug where a nullable field in shape
caused the entire shape to become nullable.