### PR TITLE
linter: added getter for `fileMeta`

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -54,7 +54,7 @@ var (
 	initCacheReadTime int64
 )
 
-type fileMeta struct {
+type FileMeta struct {
 	Scope             *meta.Scope
 	Classes           meta.ClassesMap
 	Traits            meta.ClassesMap
@@ -115,7 +115,7 @@ func createMetaCacheFile(filename, cacheFile string, root *rootWalker) error {
 	return nil
 }
 
-func readMetaCache(r io.Reader, cachers []MetaCacher, filename string, dst *fileMeta) error {
+func readMetaCache(r io.Reader, cachers []MetaCacher, filename string, dst *FileMeta) error {
 	bufrd := bufio.NewReader(r)
 	if err := readMetaCacheHeader(cachers, bufrd); err != nil {
 		return err
@@ -132,7 +132,7 @@ func readMetaCache(r io.Reader, cachers []MetaCacher, filename string, dst *file
 }
 
 func restoreMetaFromCache(info *meta.Info, cachers []MetaCacher, filename string, rd io.Reader) error {
-	var m fileMeta
+	var m FileMeta
 	if err := readMetaCache(rd, cachers, filename, &m); err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func restoreMetaFromCache(info *meta.Info, cachers []MetaCacher, filename string
 	return nil
 }
 
-func updateMetaInfo(info *meta.Info, filename string, m *fileMeta) {
+func updateMetaInfo(info *meta.Info, filename string, m *FileMeta) {
 	if info.IsIndexingComplete() {
 		panic("Trying to update meta info when not indexing")
 	}

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -150,7 +150,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "da6be70c8ce8a5df3c063b9768859727f1648d516f33fd39f0c52bb91dfee858120cbca279d9a8b9664d48c543ee98b490de2ab12b4c46ab168c459f0aaab897"
+		wantStrings := "c81e9d2cfd86aa07f20857ca81ee2cac0b31d4a5717273827f85c26b23e658060fa5f1715f2a2ecb37981b3b3ac98c056f53852539b61c8a2b20d0be92d92b9f"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)
@@ -160,7 +160,7 @@ main();
 		//
 		// If it fails, encoding and/or decoding is broken.
 		encodedMeta := &result.walker.meta
-		decodedMeta := &fileMeta{}
+		decodedMeta := &FileMeta{}
 		if err := readMetaCache(bytes.NewReader(buf.Bytes()), nil, "", decodedMeta); err != nil {
 			t.Errorf("decoding failed: %v", err)
 		} else {

--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -154,6 +154,11 @@ func (ctx *RootContext) Scope() *meta.Scope {
 	return ctx.w.scope()
 }
 
+// Meta returns current meta data.
+func (ctx *RootContext) Meta() *FileMeta {
+	return &ctx.w.meta
+}
+
 // ClassParseState returns class parse state (namespace, class, etc).
 func (ctx *RootContext) ClassParseState() *meta.ClassParseState {
 	return ctx.w.ctx.st

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -54,7 +54,7 @@ type rootWalker struct {
 	reVet        *regexpVet
 
 	// internal state
-	meta fileMeta
+	meta FileMeta
 
 	currentClassNode ir.Node
 


### PR DESCRIPTION
Sometimes external tools need access to the current meta information, 
for example, to get a class and add a default constructor to it.