### PR TITLE
linter: added `*FromAnnotation` value for `meta.PropertyFlags` and `meta.FuncFlags`

### DIFF
--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -45,7 +45,7 @@ import (
 //     47 - forced cache version invalidation due to the #921
 //     48 - renamed meta.TypesMap to types.Map; this affects gob encoding
 //     49 - for shape, names are now generated using the keys that make up this shape
-//     50 - added FromAnnotation field for meta.FuncInfo and meta.PropertyInfo
+//     50 - added Flags field for meta.PropertyInfo
 const cacheVersion = 50
 
 var (

--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -45,7 +45,8 @@ import (
 //     47 - forced cache version invalidation due to the #921
 //     48 - renamed meta.TypesMap to types.Map; this affects gob encoding
 //     49 - for shape, names are now generated using the keys that make up this shape
-const cacheVersion = 49
+//     50 - added FromAnnotation field for meta.FuncInfo and meta.PropertyInfo
+const cacheVersion = 50
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -141,7 +141,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 5348
+		wantLen := 5387
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -150,7 +150,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "da6be70c8ce8a5df3c063b9768859727f1648d516f33fd39f0c52bb91dfee858120cbca279d9a8b9664d48c543ee98b490de2ab12b4c46ab168c459f0aaab897"
+		wantStrings := "bfbd3226c24e9a1ed38b3c1cb43fffb5024f3dc7eb085d8296401d144b1c9fe972008f14be00a717d5b55cca88971a463f96ae5dd4ae2f3fa1ff9f85738dccac"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -141,7 +141,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 5387
+		wantLen := 5358
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -150,7 +150,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "bfbd3226c24e9a1ed38b3c1cb43fffb5024f3dc7eb085d8296401d144b1c9fe972008f14be00a717d5b55cca88971a463f96ae5dd4ae2f3fa1ff9f85738dccac"
+		wantStrings := "ac764c2a270fca7341a4650318480a67cb02e1fad8c9f0036c35fade2bf2f22cae76f3de8d200a1d03581565b9e86ea9c6b18108e4f48366359b916769c141f8"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/linter/phpdoc_util.go
+++ b/src/linter/phpdoc_util.go
@@ -66,11 +66,12 @@ func parseClassPHPDocMethod(ctx *rootContext, result *classPhpDocParseResult, pa
 		funcFlags |= meta.FuncStatic
 	}
 	result.methods.Set(methodName, meta.FuncInfo{
-		Typ:          newTypesMap(ctx, types),
-		Name:         methodName,
-		Flags:        funcFlags,
-		MinParamsCnt: 0, // TODO: parse signature and assign a proper value
-		AccessLevel:  meta.Public,
+		Typ:            newTypesMap(ctx, types),
+		Name:           methodName,
+		Flags:          funcFlags,
+		MinParamsCnt:   0, // TODO: parse signature and assign a proper value
+		AccessLevel:    meta.Public,
+		FromAnnotation: true,
 	})
 }
 
@@ -99,8 +100,9 @@ func parseClassPHPDocProperty(ctx *rootContext, result *classPhpDocParseResult, 
 	}
 
 	result.properties[part.Var[len("$"):]] = meta.PropertyInfo{
-		Typ:         newTypesMap(ctx, types),
-		AccessLevel: meta.Public,
+		Typ:            newTypesMap(ctx, types),
+		AccessLevel:    meta.Public,
+		FromAnnotation: true,
 	}
 }
 

--- a/src/linter/phpdoc_util.go
+++ b/src/linter/phpdoc_util.go
@@ -65,13 +65,13 @@ func parseClassPHPDocMethod(ctx *rootContext, result *classPhpDocParseResult, pa
 	if static {
 		funcFlags |= meta.FuncStatic
 	}
+	funcFlags |= meta.FuncFromAnnotation
 	result.methods.Set(methodName, meta.FuncInfo{
-		Typ:            newTypesMap(ctx, types),
-		Name:           methodName,
-		Flags:          funcFlags,
-		MinParamsCnt:   0, // TODO: parse signature and assign a proper value
-		AccessLevel:    meta.Public,
-		FromAnnotation: true,
+		Typ:          newTypesMap(ctx, types),
+		Name:         methodName,
+		Flags:        funcFlags,
+		MinParamsCnt: 0, // TODO: parse signature and assign a proper value
+		AccessLevel:  meta.Public,
 	})
 }
 
@@ -100,9 +100,9 @@ func parseClassPHPDocProperty(ctx *rootContext, result *classPhpDocParseResult, 
 	}
 
 	result.properties[part.Var[len("$"):]] = meta.PropertyInfo{
-		Typ:            newTypesMap(ctx, types),
-		AccessLevel:    meta.Public,
-		FromAnnotation: true,
+		Typ:         newTypesMap(ctx, types),
+		AccessLevel: meta.Public,
+		Flags:       meta.PropFromAnnotation,
 	}
 }
 

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -75,9 +75,10 @@ type FuncInfo struct {
 	Doc          PhpDocInfo
 }
 
-func (info *FuncInfo) IsStatic() bool   { return info.Flags&FuncStatic != 0 }
-func (info *FuncInfo) IsAbstract() bool { return info.Flags&FuncAbstract != 0 }
-func (info *FuncInfo) IsPure() bool     { return info.Flags&FuncPure != 0 }
+func (info *FuncInfo) IsStatic() bool       { return info.Flags&FuncStatic != 0 }
+func (info *FuncInfo) IsAbstract() bool     { return info.Flags&FuncAbstract != 0 }
+func (info *FuncInfo) IsPure() bool         { return info.Flags&FuncPure != 0 }
+func (info *FuncInfo) FromAnnotation() bool { return info.Flags&FuncFromAnnotation != 0 }
 
 type OverrideType int
 
@@ -117,6 +118,8 @@ type PropertyInfo struct {
 	AccessLevel AccessLevel
 	Flags       PropertyFlags
 }
+
+func (info *PropertyInfo) FromAnnotation() bool { return info.Flags&PropFromAnnotation != 0 }
 
 type ConstInfo struct {
 	Pos         ElementPosition

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -55,15 +55,16 @@ type FuncParam struct {
 }
 
 type FuncInfo struct {
-	Pos          ElementPosition
-	Name         string
-	Params       []FuncParam
-	MinParamsCnt int
-	Typ          types.Map
-	AccessLevel  AccessLevel
-	Flags        FuncFlags
-	ExitFlags    int // if function has exit/die/throw, then ExitFlags will be <> 0
-	Doc          PhpDocInfo
+	Pos            ElementPosition
+	Name           string
+	Params         []FuncParam
+	MinParamsCnt   int
+	Typ            types.Map
+	AccessLevel    AccessLevel
+	Flags          FuncFlags
+	ExitFlags      int  // if function has exit/die/throw, then ExitFlags will be <> 0
+	FromAnnotation bool // if the method is described in the annotation for the class
+	Doc            PhpDocInfo
 }
 
 func (info *FuncInfo) IsStatic() bool   { return info.Flags&FuncStatic != 0 }
@@ -103,9 +104,10 @@ type FuncInfoOverride struct {
 }
 
 type PropertyInfo struct {
-	Pos         ElementPosition
-	Typ         types.Map
-	AccessLevel AccessLevel
+	Pos            ElementPosition
+	Typ            types.Map
+	AccessLevel    AccessLevel
+	FromAnnotation bool // if the property is described in the annotation for the class
 }
 
 type ConstInfo struct {

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -75,10 +75,10 @@ type FuncInfo struct {
 	Doc          PhpDocInfo
 }
 
-func (info *FuncInfo) IsStatic() bool       { return info.Flags&FuncStatic != 0 }
-func (info *FuncInfo) IsAbstract() bool     { return info.Flags&FuncAbstract != 0 }
-func (info *FuncInfo) IsPure() bool         { return info.Flags&FuncPure != 0 }
-func (info *FuncInfo) FromAnnotation() bool { return info.Flags&FuncFromAnnotation != 0 }
+func (info *FuncInfo) IsStatic() bool         { return info.Flags&FuncStatic != 0 }
+func (info *FuncInfo) IsAbstract() bool       { return info.Flags&FuncAbstract != 0 }
+func (info *FuncInfo) IsPure() bool           { return info.Flags&FuncPure != 0 }
+func (info *FuncInfo) IsFromAnnotation() bool { return info.Flags&FuncFromAnnotation != 0 }
 
 type OverrideType int
 
@@ -119,7 +119,7 @@ type PropertyInfo struct {
 	Flags       PropertyFlags
 }
 
-func (info *PropertyInfo) FromAnnotation() bool { return info.Flags&PropFromAnnotation != 0 }
+func (info *PropertyInfo) IsFromAnnotation() bool { return info.Flags&PropFromAnnotation != 0 }
 
 type ConstInfo struct {
 	Pos         ElementPosition

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -12,6 +12,15 @@ const (
 	FuncPure
 	FuncAbstract
 	FuncFinal
+	// FuncFromAnnotation is set if the function is described in the class annotation.
+	FuncFromAnnotation
+)
+
+type PropertyFlags uint8
+
+const (
+	// PropFromAnnotation is set if the property is described in the class annotation.
+	PropFromAnnotation PropertyFlags = 1 << iota
 )
 
 type PhpDocInfo struct {
@@ -55,16 +64,15 @@ type FuncParam struct {
 }
 
 type FuncInfo struct {
-	Pos            ElementPosition
-	Name           string
-	Params         []FuncParam
-	MinParamsCnt   int
-	Typ            types.Map
-	AccessLevel    AccessLevel
-	Flags          FuncFlags
-	ExitFlags      int  // if function has exit/die/throw, then ExitFlags will be <> 0
-	FromAnnotation bool // if the method is described in the annotation for the class
-	Doc            PhpDocInfo
+	Pos          ElementPosition
+	Name         string
+	Params       []FuncParam
+	MinParamsCnt int
+	Typ          types.Map
+	AccessLevel  AccessLevel
+	Flags        FuncFlags
+	ExitFlags    int // if function has exit/die/throw, then ExitFlags will be <> 0
+	Doc          PhpDocInfo
 }
 
 func (info *FuncInfo) IsStatic() bool   { return info.Flags&FuncStatic != 0 }
@@ -104,10 +112,10 @@ type FuncInfoOverride struct {
 }
 
 type PropertyInfo struct {
-	Pos            ElementPosition
-	Typ            types.Map
-	AccessLevel    AccessLevel
-	FromAnnotation bool // if the property is described in the annotation for the class
+	Pos         ElementPosition
+	Typ         types.Map
+	AccessLevel AccessLevel
+	Flags       PropertyFlags
 }
 
 type ConstInfo struct {


### PR DESCRIPTION
These values are needed in order to distinguish between
methods and properties that are actually in the class and
which are defined in the annotation for the class.