### PR TITLE
added commandline arguments number check before using them

### DIFF
--- a/src/cmd/cli.go
+++ b/src/cmd/cli.go
@@ -241,6 +241,12 @@ func (a *App) getCommandByArgs(args []string, commands map[string]*Command) (*Co
 func (a *App) Run(cfg *MainConfig) (int, error) {
 	os.Args = os.Args[1:]
 
+	// Show help when no commandline arguments
+	if len(os.Args) < 1 {
+		a.showHelp()
+		return 0, nil
+	}
+
 	a.prepareCommands()
 
 	// We do a pre-check by receiving the command only for the first argument.


### PR DESCRIPTION
Fixed panic that happens when no commandline arguments are given, arguments number check added before using them.