### PR TITLE
cmd: updated version handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-NOW=`date +%Y%m%d%H%M%S`
+NOW=`date '+%Y.%m.%d %H:%M:%S'`
 OS=`uname -n -m`
 AFTER_COMMIT=`git rev-parse HEAD`
 GOPATH_DIR=`go env GOPATH`
+PKG=github.com/VKCOM/noverify/src/cmd
+VERSION=0.3.0
 
 install:
-	go install -ldflags "-X 'main.BuildTime=$(NOW)' -X 'main.BuildOSUname=$(OS)' -X 'main.BuildCommit=$(AFTER_COMMIT)'" .
+	go install -ldflags "-X '$(PKG).BuildVersion=$(VERSION)' -X '$(PKG).BuildTime=$(NOW)' -X '$(PKG).BuildOSUname=$(OS)' -X '$(PKG).BuildCommit=$(AFTER_COMMIT)'" .
 
 build-release:
-	go run ./_script/release.go -build-time="$(NOW)" -build-uname="$(OS)" -build-commit="$(AFTER_COMMIT)"
+	go run ./_script/release.go -build-version="$(VERSION)" -build-time="$(NOW)" -build-uname="$(OS)" -build-commit="$(AFTER_COMMIT)"
 
 check:
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v1.39.0

--- a/_script/release.go
+++ b/_script/release.go
@@ -10,9 +10,10 @@ import (
 )
 
 type arguments struct {
-	commit string
-	uname  string
-	time   string
+	commit  string
+	uname   string
+	time    string
+	version string
 }
 
 type platformInfo struct {
@@ -29,6 +30,7 @@ func main() {
 	flag.StringVar(&args.commit, "build-commit", "", "build commit hash")
 	flag.StringVar(&args.uname, "build-uname", "", "build uname information")
 	flag.StringVar(&args.time, "build-time", "", "build time information string")
+	flag.StringVar(&args.version, "build-version", "", "Build version information string")
 	flag.Parse()
 
 	platforms := []platformInfo{
@@ -51,8 +53,11 @@ func prepareArchive(args arguments, platform platformInfo) error {
 	if platform.goos == "windows" {
 		binaryExt = ".exe"
 	}
-	ldFlags := fmt.Sprintf(`-X 'main.BuildTime=%s' -X 'main.BuildOSUname=%s' -X 'main.BuildCommit=%s'`,
-		args.time, args.uname, args.commit)
+
+	pack := "github.com/VKCOM/noverify/src/cmd"
+
+	ldFlags := fmt.Sprintf(`-X '%[1]s.BuildVersion=%[2]s' -X '%[1]s.BuildTime=%[3]s' -X '%[1]s.BuildOSUname=%[4]s' -X '%[1]s.BuildCommit=%[5]s'`,
+		pack, args.version, args.time, args.uname, args.commit)
 	binaryName := filepath.Join("build", "noverify"+binaryExt)
 	buildCmd := exec.Command("go", "build",
 		"-o", binaryName,

--- a/main.go
+++ b/main.go
@@ -6,28 +6,10 @@ import (
 	"github.com/VKCOM/noverify/src/cmd"
 )
 
-// Build* are initialized during the build via -ldflags
-var (
-	BuildTime    string
-	BuildOSUname string
-	BuildCommit  string
-)
-
-func printVersion() {
-	if BuildCommit == "" {
-		log.Printf("built without version info (try using 'make install'?)")
-	} else {
-		log.Printf("built on: %s OS: %s Commit: %s\n", BuildTime, BuildOSUname, BuildCommit)
-	}
-}
-
 func main() {
 	log.SetFlags(log.Flags() | log.Ltime)
 
 	// You can register your own rules here, see src/linter/custom.go
 
-	printVersion()
-	cmd.Main(&cmd.MainConfig{
-		LinterVersion: BuildCommit,
-	})
+	cmd.Main(nil)
 }

--- a/src/cmd/flags.go
+++ b/src/cmd/flags.go
@@ -12,8 +12,6 @@ const AllNonNoticeChecks = "<all-non-notice>"
 const AllChecks = "<all>"
 
 type ParsedFlags struct {
-	Version bool
-
 	PprofHost string
 
 	CPUProfile string
@@ -160,7 +158,6 @@ func RegisterCheckFlags(ctx *AppContext) *flag.FlagSet {
 
 	fs.StringVar(&ctx.ParsedFlags.UnusedVarPattern, "unused-var-regex", `^_$`,
 		"Variables that match such regexp are marked as discarded; not reported as unused, but should not be used as values")
-	fs.BoolVar(&ctx.ParsedFlags.Version, "version", false, "Show version info and exit")
 
 	fs.StringVar(&ctx.ParsedFlags.CPUProfile, "cpuprofile", "", "Write cpu profile to `file`")
 	fs.StringVar(&ctx.ParsedFlags.MemProfile, "memprofile", "", "Write memory profile to `file`")

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -61,6 +61,15 @@ func registerMainApp() *App {
 				},
 				Action: Checkers,
 			},
+
+			{
+				Name:        "version",
+				Description: "The command to output the tool version",
+				Action: func(ctx *AppContext) (int, error) {
+					printVersion()
+					return 0, nil
+				},
+			},
 		},
 	}
 }
@@ -77,6 +86,10 @@ func registerMainApp() *App {
 func Run(cfg *MainConfig) (int, error) {
 	if cfg == nil {
 		cfg = &MainConfig{}
+	}
+
+	if cfg.LinterVersion == "" {
+		cfg.LinterVersion = BuildCommit
 	}
 
 	config := cfg.LinterConfig
@@ -126,11 +139,6 @@ func Main(cfg *MainConfig) {
 //
 // We don't want os.Exit to be inserted randomly to avoid defer cancellation.
 func mainNoExit(ctx *AppContext) (int, error) {
-	if ctx.ParsedFlags.Version {
-		// Version is already printed. Can exit here.
-		return 0, nil
-	}
-
 	if ctx.ParsedFlags.PprofHost != "" {
 		go func() {
 			err := http.ListenAndServe(ctx.ParsedFlags.PprofHost, nil)

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+)
+
+// Build* are initialized during the build via -ldflags
+var (
+	BuildVersion string
+	BuildTime    string
+	BuildOSUname string
+	BuildCommit  string
+)
+
+func printVersion() {
+	fmt.Print("NoVerify, ")
+	if BuildCommit == "" {
+		fmt.Printf("version %s: built without additional version info (try use `make install`)\n", BuildVersion)
+	} else {
+		fmt.Printf("version %s: built on: %s OS: %s Commit: %s\n", BuildVersion, BuildTime, BuildOSUname, BuildCommit)
+	}
+}


### PR DESCRIPTION
- Added the `version` command to replace the `--version` flag
  for the `check` command;

- Removed `--version` flag;

- Added a new field for version, now the `version` command
  will also show the NoVerify version number;

- Build time will now be shown with delimiters.

- Variables for version, commit, etc. those set at compile-time 
  have been moved to the `cmd` package, otherwise the `version`
  command would be too difficult to do.

Before:
```
2021/07/03 12:55:42 built on: 20210703124446 OS: x86_64 Commit: 6a7e948f75816c274a98dfb5e35e00f97933bd14
```

After:
```
NoVerify, version 0.3.0: built on: 2021.07.03 12:44:46 OS: x86_64 Commit: 6a7e948f75816c274a98dfb5e35e00f97933bd14
```

