### PR TITLE
linter: fixed a bug for `@see CONSTANT_NAME`

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1129,10 +1129,14 @@ func (d *rootWalker) isValidPHPDocRef(n ir.Node, ref string) bool {
 	isValidSymbol := func(ref string) bool {
 		if !strings.HasPrefix(ref, `\`) {
 			if d.currentClassNode != nil {
-				if _, ok := solver.FindMethod(d.metaInfo(), d.ctx.st.CurrentClass, ref); ok {
+				className := d.ctx.st.CurrentClass
+				if _, ok := solver.FindMethod(d.metaInfo(), className, ref); ok {
 					return true // OK: class method reference
 				}
-				if classHasProp(d.ctx.st, d.ctx.st.CurrentClass, ref) {
+				if _, _, ok := solver.FindConstant(d.metaInfo(), className, ref); ok {
+					return true // OK: class constant reference
+				}
+				if classHasProp(d.ctx.st, className, ref) {
 					return true // OK: class prop reference
 				}
 			}

--- a/src/tests/checkers/phpdoc_test.go
+++ b/src/tests/checkers/phpdoc_test.go
@@ -140,6 +140,49 @@ class BadClass {
 	linttest.RunFilterMatch(test, "phpdocRef")
 }
 
+func TestPHPDocRefForConstantInClass(t *testing.T) {
+	test := linttest.NewSuite(t)
+
+	test.AddFile(`<?php
+const TYPE_TEXT_GLOBAL = 0;
+
+class FooAbstract {
+  /** Text headers */
+  const TYPE_TEXT_PARENT = 2;
+}
+
+class Foo extends FooAbstract {
+  const TYPE_TEXT = 2;
+
+  /**
+   * Get the type of Header that this instance represents.
+   *
+   * @see TYPE_TEXT
+   * @see TYPE_TEXT_PARENT
+   * @see TYPE_TEXT_UNDEFINED
+   * @see TYPE_TEXT_GLOBAL
+   *
+   * @return int
+   */
+  public function getFieldType()
+  {
+    return self::TYPE_TEXT;
+  }
+}
+
+/**
+ * @see TYPE_TEXT
+ * @see TYPE_TEXT_GLOBAL
+ */
+function f() {}
+`)
+	test.Expect = []string{
+		`line 6: @see tag refers to unknown symbol TYPE_TEXT_UNDEFINED`,
+		`line 2: @see tag refers to unknown symbol TYPE_TEXT`,
+	}
+	linttest.RunFilterMatch(test, "phpdocRef")
+}
+
 func TestBadParamName(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
Fixed a bug where `@see CONSTANT_NAME` was given an 
error even if a constant was defined in the class.

PHPStorm correctly detects such a link.

Fixes #1016 