### PR TITLE
linter: fixed error with define call

### DIFF
--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -2244,3 +2244,13 @@ function f() {
 	}
 	test.RunAndMatch()
 }
+
+func TestDefineWithTrailingSlash(t *testing.T) {
+	linttest.SimpleNegativeTest(t, `<?php
+\define('ONE', 1);
+define('TWO', 1);
+
+echo ONE;
+echo TWO;
+`)
+}


### PR DESCRIPTION
Fixed error when calling the define function with a slash at the beginning 
(`\define("One", 1)`) did not create a constant.

Fixed #1018 