### PR TITLE
linter: fixed different report messages

### DIFF
--- a/docs/linter-usage.md
+++ b/docs/linter-usage.md
@@ -99,7 +99,7 @@ $ noverify check hello.php
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at /home/quasilyte/CODE/php/hello.php:3
 $x = array($v, 2);
      ^^^^^^^^^^^^
-ERROR   undefined: Undefined variable: v at /home/quasilyte/CODE/php/hello.php:3
+ERROR   undefined: Undefined variable $v at /home/quasilyte/CODE/php/hello.php:3
 $x = array($v, 2);
            ^^
 ```

--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -12,32 +12,32 @@
  */
 function ternarySimplify() {
   /**
-   * @maybe could replace the ternary with just $cond
+   * @maybe Could replace the ternary with just $cond
    * @type bool $cond
    */
   $cond ? true : false;
 
   /**
-   * @maybe could rewrite as `(bool)$cond`
+   * @maybe Could rewrite as `(bool)$cond`
    * @type  !bool $cond
    */
   $cond ? true : false;
 
   /**
-   * @maybe could rewrite as `$x ?: $y`
+   * @maybe Could rewrite as `$x ?: $y`
    * @fix $x ?: $y
    * @pure $x
    */
   $x ? $x : $y;
 
   /**
-   * @maybe could rewrite as `$x ?? $y`
+   * @maybe Could rewrite as `$x ?? $y`
    * @fix $x ?? $y
    */
   isset($x) ? $x : $y;
 
   /**
-   * @maybe could rewrite as `$x[$i] ?? $y`
+   * @maybe Could rewrite as `$x[$i] ?? $y`
    * @pure $i
    */
   any_indexing: {
@@ -48,7 +48,7 @@ function ternarySimplify() {
   }
 
   /**
-   * @maybe could rewrite as `$x[$i] ?? $y`
+   * @maybe Could rewrite as `$x[$i] ?? $y`
    * @pure $i
    */
   any_array_key_exists: {
@@ -145,84 +145,84 @@ function precedence() {
  */
 function assignOp() {
   /**
-   * @maybe could rewrite as `$x += $y`
+   * @maybe Could rewrite as `$x += $y`
    * @fix $x += $y
    * @pure $x
    */
   $x = $x + $y;
 
   /**
-   * @maybe could rewrite as `$x -= $y`
+   * @maybe Could rewrite as `$x -= $y`
    * @fix $x -= $y
    * @pure $x
    */
   $x = $x - $y;
 
   /**
-   * @maybe could rewrite as `$x *= $y`
+   * @maybe Could rewrite as `$x *= $y`
    * @fix $x *= $y
    * @pure $x
    */
   $x = $x * $y;
 
   /**
-   * @maybe could rewrite as `$x /= $y`
+   * @maybe Could rewrite as `$x /= $y`
    * @fix $x /= $y
    * @pure $x
    */
   $x = $x / $y;
 
   /**
-   * @maybe could rewrite as `$x %= $y`
+   * @maybe Could rewrite as `$x %= $y`
    * @fix $x %= $y
    * @pure $x
    */
   $x = $x % $y;
 
   /**
-   * @maybe could rewrite as `$x &= $y`
+   * @maybe Could rewrite as `$x &= $y`
    * @fix $x &= $y
    * @pure $x
    */
   $x = $x & $y;
 
   /**
-   * @maybe could rewrite as `$x |= $y`
+   * @maybe Could rewrite as `$x |= $y`
    * @fix $x |= $y
    * @pure $x
    */
   $x = $x | $y;
 
   /**
-   * @maybe could rewrite as `$x ^= $y`
+   * @maybe Could rewrite as `$x ^= $y`
    * @fix $x ^= $y
    * @pure $x
    */
   $x = $x ^ $y;
 
   /**
-   * @maybe could rewrite as `$x <<= $y`
+   * @maybe Could rewrite as `$x <<= $y`
    * @fix $x <<= $y
    * @pure $x
    */
   $x = $x << $y;
 
   /**
-   * @maybe could rewrite as `$x >>= $y`
+   * @maybe Could rewrite as `$x >>= $y`
    * @fix $x >>= $y
    * @pure $x
    */
   $x = $x >> $y;
 
   /**
-   * @maybe could rewrite as `$x .= $y`
+   * @maybe Could rewrite as `$x .= $y`
    * @fix $x .= $y
    * @pure $x
    */
   $x = $x . $y;
 
   /**
-   * @maybe could rewrite as `$x ??= $y`
+   * @maybe Could rewrite as `$x ??= $y`
    * @fix $x ??= $y
    * @pure $x
    */
@@ -236,14 +236,14 @@ function assignOp() {
  */
 function offBy1() {
   /**
-   * @warning probably intended to use count-1 as an index
+   * @warning Probably intended to use count-1 as an index
    * @fix     $a[count($a) - 1]
    * @strict-syntax
    */
   $a[count($a)];
 
   /**
-   * @warning probably intended to use sizeof-1 as an index
+   * @warning Probably intended to use sizeof-1 as an index
    * @fix     $a[sizeof($a) - 1]
    * @strict-syntax
    */
@@ -255,7 +255,7 @@ function offBy1() {
  */
 function argsOrder() {
   /**
-   * @warning potentially incorrect haystack and needle arguments order
+   * @warning Potentially incorrect haystack and needle arguments order
    */
   any_haystack_needle: {
     strpos(${"char"}, ${"*"});
@@ -265,12 +265,12 @@ function argsOrder() {
   }
 
   /**
-   * @warning potentially incorrect replacement and subject arguments order
+   * @warning Potentially incorrect replacement and subject arguments order
    */
   preg_replace($_, $_, ${"str"}, ${"*"});
 
   /**
-   * @warning potentially incorrect replace and string arguments order
+   * @warning Potentially incorrect replace and string arguments order
    */
   any_str_replace: {
     str_replace($_, $_, ${"char"}, ${"*"});
@@ -278,7 +278,7 @@ function argsOrder() {
   }
 
   /**
-   * @warning potentially incorrect delimiter and string arguments order
+   * @warning Potentially incorrect delimiter and string arguments order
    */
   explode($_, ${"char"}, ${"*"});
 }
@@ -336,7 +336,7 @@ function callSimplify() {
  */
 function strictCmp() {
     /**
-     * @warning non-strict comparison (use ===)
+     * @warning Non-strict comparison (use ===)
      */
     any_equal: {
         $_ == true;
@@ -348,14 +348,14 @@ function strictCmp() {
     }
 
     /**
-     * @warning non-strict string comparison (use ===)
+     * @warning Non-strict string comparison (use ===)
      * @type string $x
      * @type string $y
      */
      $x == $y;
 
     /**
-     * @warning non-strict comparison (use !==)
+     * @warning Non-strict comparison (use !==)
      */
     any_not_equal: {
         $_ != true;
@@ -367,7 +367,7 @@ function strictCmp() {
     }
 
     /**
-     * @warning non-strict string comparison (use !==)
+     * @warning Non-strict string comparison (use !==)
      * @type string $x
      * @type string $y
      */
@@ -406,7 +406,7 @@ function indexingSyntax() {
  */
 function intNeedle() {
     /**
-     * @warning since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call
+     * @warning Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call
      * @type int $x
      */
     any: {
@@ -426,12 +426,12 @@ function intNeedle() {
  */
 function langDeprecated() {
     /**
-     * @warning since PHP 7.3.0, the definition of case insensitive constants has been deprecated
+     * @warning Since PHP 7.3, the definition of case insensitive constants has been deprecated
      */
     define($_, $_, true);
 
     /**
-     * @warning define defaults to a case sensitive constant, the third argument can be removed
+     * @warning Define defaults to a case sensitive constant, the third argument can be removed
      * @fix     define($_, $_);
      */
     define($_, $_, false);
@@ -444,7 +444,7 @@ function langDeprecated() {
  */
 function strangeCast() {
     /**
-     * @warning concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string
+     * @warning Concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string
      */
     any_string_cast: {
         $x . "";
@@ -454,7 +454,7 @@ function strangeCast() {
     }
 
     /**
-     * @warning addition with zero, possible type cast, use an explicit cast to int or float instead of zero addition
+     * @warning Addition with zero, possible type cast, use an explicit cast to int or float instead of zero addition
      */
     any_number_cast: {
         0 + $x;
@@ -462,7 +462,7 @@ function strangeCast() {
     }
 
     /**
-     * @warning unary plus, possible type cast, use an explicit cast to int or float instead of using the unary plus
+     * @warning Unary plus, possible type cast, use an explicit cast to int or float instead of using the unary plus
      */
     +$x;
 }
@@ -474,7 +474,7 @@ function strangeCast() {
  */
 function emptyStringCheck() {
     /**
-     * @warning use '$x !== ""' instead
+     * @warning Use '$x !== ""' instead
      */
     any_not_equal: {
         if (strlen($x)) { $_; }
@@ -483,7 +483,7 @@ function emptyStringCheck() {
     }
 
     /**
-     * @warning use '$x === ""' instead
+     * @warning Use '$x === ""' instead
      */
     any_equal: {
         if (!strlen($x)) { $_; }
@@ -498,7 +498,7 @@ function emptyStringCheck() {
  */
 function returnAssign() {
     /**
-     * @warning don't use assignment in the return statement
+     * @warning Don't use assignment in the return statement
      */
     any: {
         return $_ = $_;

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1200,7 +1200,7 @@ func (b *blockWalker) enterClosure(fun *ir.ClosureExpr, haveThis bool, thisType 
 		}
 
 		if !b.ctx.sc.HaveVar(v) && !byRef {
-			b.r.Report(v, LevelWarning, "undefined", "Undefined variable %s", v.Name)
+			b.r.Report(v, LevelWarning, "undefined", "Undefined variable $%s", v.Name)
 		}
 
 		typ, ok := b.ctx.sc.GetVarNameType(v.Name)
@@ -1340,7 +1340,7 @@ func (b *blockWalker) handleVariable(v ir.Node) bool {
 			}
 		}
 		if b.r.config.IsDiscardVar(varName) && !isSuperGlobal(varName) {
-			b.r.Report(v, LevelError, "discardVar", "Used var $%s that is supposed to be unused (rename variable if it's intended)", varName)
+			b.r.Report(v, LevelError, "discardVar", "Used var $%s that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)", varName)
 		}
 
 		b.untrackVarName(varName)
@@ -1974,7 +1974,7 @@ func (b *blockWalker) flushUnused() {
 			}
 
 			visitedMap[n] = struct{}{}
-			b.r.Report(n, LevelWarning, "unused", `Variable %s is unused (use $_ to ignore this inspection)`, name)
+			b.r.Report(n, LevelWarning, "unused", `Variable $%s is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`, name)
 		}
 	}
 }

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -504,9 +504,9 @@ func (d *rootWalker) reportUndefinedVariable(v ir.Node, maybeHave bool) {
 	}
 
 	if maybeHave {
-		d.Report(sv, LevelWarning, "undefined", "Variable might have not been defined: %s", sv.Name)
+		d.Report(sv, LevelWarning, "undefined", "Variable $%s might have not been defined", sv.Name)
 	} else {
-		d.Report(sv, LevelError, "undefined", "Undefined variable: %s", sv.Name)
+		d.Report(sv, LevelError, "undefined", "Undefined variable $%s", sv.Name)
 	}
 }
 

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -168,9 +168,9 @@ foreach ($xs as $x) {
 $_ = [$x]; // Bad
 `)
 	test.Expect = []string{
-		`Variable might have not been defined: k`,
-		`Variable might have not been defined: v`,
-		`Variable might have not been defined: x`,
+		`Variable $k might have not been defined`,
+		`Variable $v might have not been defined`,
+		`Variable $x might have not been defined`,
 	}
 	test.RunAndMatch()
 }
@@ -704,8 +704,8 @@ class Foo {
 `)
 
 	test.Expect = []string{
-		"Undefined variable: argv",
-		"Undefined variable: argc",
+		"Undefined variable $argv",
+		"Undefined variable $argc",
 	}
 
 	linttest.RunFilterMatch(test, "undefined")
@@ -848,10 +848,10 @@ var_dump($_global);
 `)
 
 	test.Expect = []string{
-		`Used var $_a that is supposed to be unused (rename variable if it's intended)`,
-		`Used var $_global that is supposed to be unused (rename variable if it's intended)`,
-		`Used var $_FOO that is supposed to be unused (rename variable if it's intended)`,
-		`Used var $_global that is supposed to be unused (rename variable if it's intended)`,
+		`Used var $_a that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
+		`Used var $_global that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
+		`Used var $_FOO that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
+		`Used var $_global that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
 	}
 
 	test.RunAndMatch()
@@ -875,12 +875,12 @@ var_dump($_); // 6. Also forbidden in global scope
 `)
 
 	test.Expect = []string{
-		`Used var $_ that is supposed to be unused (rename variable if it's intended)`,
-		`Used var $_ that is supposed to be unused (rename variable if it's intended)`,
-		`Used var $_ that is supposed to be unused (rename variable if it's intended)`,
-		`Used var $_ that is supposed to be unused (rename variable if it's intended)`,
-		`Used var $_ that is supposed to be unused (rename variable if it's intended)`,
-		`Used var $_ that is supposed to be unused (rename variable if it's intended)`,
+		`Used var $_ that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
+		`Used var $_ that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
+		`Used var $_ that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
+		`Used var $_ that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
+		`Used var $_ that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
+		`Used var $_ that is supposed to be unused (rename variable if it's intended or respecify --unused-var-regex flag)`,
 	}
 
 	test.RunAndMatch()
@@ -932,8 +932,8 @@ func TestOrDie2(t *testing.T) {
 $undef1 or die($undef2);
 `)
 	test.Expect = []string{
-		"Undefined variable: undef1",
-		"Undefined variable: undef2",
+		"Undefined variable $undef1",
+		"Undefined variable $undef2",
 	}
 	test.RunAndMatch()
 }
@@ -1009,8 +1009,8 @@ function foo() {
 }
 `)
 	test.Expect = []string{
-		`Variable x is unused`,
-		`Undefined variable: y`,
+		`Variable $x is unused`,
+		`Undefined variable $y`,
 	}
 	test.RunAndMatch()
 }
@@ -1071,7 +1071,7 @@ func TestUnusedInSwitch(t *testing.T) {
 		}
 		return 20;
 	}`)
-	test.Expect = []string{`Variable x is unused`}
+	test.Expect = []string{`Variable $x is unused`}
 	linttest.RunFilterMatch(test, "unused")
 }
 
@@ -1231,7 +1231,7 @@ func TestFunctionReferenceParamsInAnonymousFunction(t *testing.T) {
 			$result = 1;
 		};
 	}`)
-	test.Expect = []string{"Undefined variable a"}
+	test.Expect = []string{"Undefined variable $a"}
 	test.RunAndMatch()
 }
 
@@ -1461,8 +1461,8 @@ func TestEmptyVar(t *testing.T) {
 		return $x2;
 	}`)
 	test.Expect = []string{
-		`Undefined variable: x1`,
-		`Undefined variable: x2`,
+		`Undefined variable $x1`,
+		`Undefined variable $x2`,
 	}
 	test.RunAndMatch()
 }
@@ -1479,7 +1479,7 @@ function f() {
   echo $y; // But should be undefined here.
 }
 `)
-	test.Expect = []string{`Undefined variable: y`}
+	test.Expect = []string{`Undefined variable $y`}
 	test.RunAndMatch()
 }
 
@@ -1508,9 +1508,9 @@ func TestUnused(t *testing.T) {
 		}
 	}`)
 	test.Expect = []string{
-		"Variable g is unused",
-		"Variable a is unused",
-		"Variable v is unused",
+		"Variable $g is unused",
+		"Variable $a is unused",
+		"Variable $v is unused",
 	}
 	test.RunAndMatch()
 }
@@ -1679,17 +1679,17 @@ func TestArrowFunction(t *testing.T) {
 		echo $w; // Undefined $w
 	}`)
 	test.Expect = []string{
-		`Undefined variable: undefined_variable`,
-		`Variable might have not been defined: maybe_defined`,
-		`Variable a is unused (use $_ to ignore this inspection)`,
-		`Variable a is unused (use $_ to ignore this inspection)`,
-		`Variable a is unused (use $_ to ignore this inspection)`,
-		`Variable a is unused (use $_ to ignore this inspection)`,
-		`Undefined variable: a`,
-		`Undefined variable: x`,
-		`Undefined variable: y`,
-		`Undefined variable: w`,
-		`Variable might have not been defined: maybe_defined`,
+		`Undefined variable $undefined_variable`,
+		`Variable $maybe_defined might have not been defined`,
+		`Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
+		`Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
+		`Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
+		`Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
+		`Undefined variable $a`,
+		`Undefined variable $x`,
+		`Undefined variable $y`,
+		`Undefined variable $w`,
+		`Variable $maybe_defined might have not been defined`,
 	}
 	test.RunAndMatch()
 }
@@ -2057,8 +2057,8 @@ function f() {
 	`)
 
 	test.Expect = []string{
-		"Undefined variable: x",
-		"Undefined variable: y",
+		"Undefined variable $x",
+		"Undefined variable $y",
 	}
 	linttest.RunFilterMatch(test, "undefined")
 }

--- a/src/tests/checkers/catch_test.go
+++ b/src/tests/checkers/catch_test.go
@@ -157,9 +157,9 @@ function f() {
 }
 `)
 	test.Expect = []string{
-		`Variable might have not been defined: c`,
-		`Variable might have not been defined: d`,
-		`Variable might have not been defined: f`,
+		`Variable $c might have not been defined`,
+		`Variable $d might have not been defined`,
+		`Variable $f might have not been defined`,
 	}
 	test.RunAndMatch()
 }
@@ -214,11 +214,11 @@ function f() {
 }
 `)
 	test.Expect = []string{
-		`Variable might have not been defined: b`,
+		`Variable $b might have not been defined`,
 		`Unreachable code`,
-		`Undefined variable: d`,
-		`Undefined variable: e`,
-		`Variable might have not been defined: g`,
+		`Undefined variable $d`,
+		`Undefined variable $e`,
+		`Variable $g might have not been defined`,
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -757,7 +757,7 @@ func TestClosureLateBinding(t *testing.T) {
 	})();
 	`)
 	test.Expect = []string{
-		"Undefined variable: a",
+		"Undefined variable $a",
 		"Call to undefined method {undefined}->method()",
 	}
 	linttest.RunFilterMatch(test, "undefined")

--- a/src/tests/golden/testdata/embeddedrules/golden.txt
+++ b/src/tests/golden/testdata/embeddedrules/golden.txt
@@ -1,61 +1,61 @@
-WARNING argsOrder: potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:5
+WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:5
   $_ = strpos('/', $s);
        ^^^^^^^^^^^^^^^
-WARNING argsOrder: potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:6
+WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:6
   $_ = strpos("/", $s);
        ^^^^^^^^^^^^^^^
-WARNING argsOrder: potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:21
+WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:21
   $_ = stripos('/', $s);
        ^^^^^^^^^^^^^^^^
-WARNING argsOrder: potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:22
+WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:22
   $_ = stripos("/", $s);
        ^^^^^^^^^^^^^^^^
-WARNING argsOrder: potentially incorrect replacement and subject arguments order at testdata/embeddedrules/argsOrder.php:32
+WARNING argsOrder: Potentially incorrect replacement and subject arguments order at testdata/embeddedrules/argsOrder.php:32
   $_ = preg_replace($pat, $subj, 'replacement');
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING argsOrder: potentially incorrect delimiter and string arguments order at testdata/embeddedrules/argsOrder.php:41
+WARNING argsOrder: Potentially incorrect delimiter and string arguments order at testdata/embeddedrules/argsOrder.php:41
   $_ = explode($s, '/');
        ^^^^^^^^^^^^^^^^
-WARNING argsOrder: potentially incorrect replace and string arguments order at testdata/embeddedrules/argsOrder.php:50
+WARNING argsOrder: Potentially incorrect replace and string arguments order at testdata/embeddedrules/argsOrder.php:50
   $_ = str_replace($search, $subj, ' ');
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING argsOrder: potentially incorrect replace and string arguments order at testdata/embeddedrules/argsOrder.php:51
+WARNING argsOrder: Potentially incorrect replace and string arguments order at testdata/embeddedrules/argsOrder.php:51
   $_ = str_replace($search, $subj, '');
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a += $b` at testdata/embeddedrules/assignOp.php:6
+MAYBE   assignOp: Could rewrite as `$a += $b` at testdata/embeddedrules/assignOp.php:6
   $a = $a + $b; // Could rewrite
   ^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a -= $b` at testdata/embeddedrules/assignOp.php:13
+MAYBE   assignOp: Could rewrite as `$a -= $b` at testdata/embeddedrules/assignOp.php:13
   $a = $a - $b; // Could rewrite
   ^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a *= $b` at testdata/embeddedrules/assignOp.php:20
+MAYBE   assignOp: Could rewrite as `$a *= $b` at testdata/embeddedrules/assignOp.php:20
   $a = $a * $b; // Could rewrite
   ^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a /= $b` at testdata/embeddedrules/assignOp.php:27
+MAYBE   assignOp: Could rewrite as `$a /= $b` at testdata/embeddedrules/assignOp.php:27
   $a = $a / $b; // Could rewrite
   ^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a %= $b` at testdata/embeddedrules/assignOp.php:34
+MAYBE   assignOp: Could rewrite as `$a %= $b` at testdata/embeddedrules/assignOp.php:34
   $a = $a % $b; // Could rewrite
   ^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a .= $b` at testdata/embeddedrules/assignOp.php:41
+MAYBE   assignOp: Could rewrite as `$a .= $b` at testdata/embeddedrules/assignOp.php:41
   $a = $a . $b; // Could rewrite
   ^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a &= $b` at testdata/embeddedrules/assignOp.php:48
+MAYBE   assignOp: Could rewrite as `$a &= $b` at testdata/embeddedrules/assignOp.php:48
   $a = $a & $b; // Could rewrite
   ^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a |= $b` at testdata/embeddedrules/assignOp.php:55
+MAYBE   assignOp: Could rewrite as `$a |= $b` at testdata/embeddedrules/assignOp.php:55
   $a = $a | $b; // Could rewrite
   ^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a ^= $b` at testdata/embeddedrules/assignOp.php:62
+MAYBE   assignOp: Could rewrite as `$a ^= $b` at testdata/embeddedrules/assignOp.php:62
   $a = $a ^ $b; // Could rewrite
   ^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a <<= $b` at testdata/embeddedrules/assignOp.php:69
+MAYBE   assignOp: Could rewrite as `$a <<= $b` at testdata/embeddedrules/assignOp.php:69
   $a = $a << $b; // Could rewrite
   ^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a >>= $b` at testdata/embeddedrules/assignOp.php:76
+MAYBE   assignOp: Could rewrite as `$a >>= $b` at testdata/embeddedrules/assignOp.php:76
   $a = $a >> $b; // Could rewrite
   ^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$a ??= $b` at testdata/embeddedrules/assignOp.php:83
+MAYBE   assignOp: Could rewrite as `$a ??= $b` at testdata/embeddedrules/assignOp.php:83
   $a = $a ?? $b; // Could rewrite
   ^^^^^^^^^^^^^
 WARNING bitwiseOps: Used & bitwise operator over bool operands, perhaps && is intended? at testdata/embeddedrules/bitwiseOps.php:8
@@ -94,67 +94,67 @@ $_ = $b{0};
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:7
 $_ = $b[0]{0};
      ^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:21
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:21
 $_ = strpos($str, 10);
      ^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:22
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:22
 $_ = strpos($str, getInt());
      ^^^^^^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:27
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:27
 $_ = strrpos($str, 10);
      ^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:28
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:28
 $_ = strrpos($str, getInt());
      ^^^^^^^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:33
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:33
 $_ = stripos($str, 10);
      ^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:34
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:34
 $_ = stripos($str, getInt());
      ^^^^^^^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:39
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:39
 $_ = strripos($str, 10);
      ^^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:40
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:40
 $_ = strripos($str, getInt());
      ^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:45
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:45
 $_ = strstr($str, 10);
      ^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:46
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:46
 $_ = strstr($str, getInt());
      ^^^^^^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:51
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:51
 $_ = strchr($str, 10);
      ^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:52
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:52
 $_ = strchr($str, getInt());
      ^^^^^^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:57
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:57
 $_ = strrchr($str, 10);
      ^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:58
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:58
 $_ = strrchr($str, getInt());
      ^^^^^^^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:63
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:63
 $_ = stristr($str, 10);
      ^^^^^^^^^^^^^^^^^
-WARNING intNeedle: since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:64
+WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:64
 $_ = stristr($str, getInt());
      ^^^^^^^^^^^^^^^^^^^^^^^
-WARNING langDeprecated: since PHP 7.3.0, the definition of case insensitive constants has been deprecated at testdata/embeddedrules/langDeprecated.php:3
+WARNING langDeprecated: Since PHP 7.3, the definition of case insensitive constants has been deprecated at testdata/embeddedrules/langDeprecated.php:3
 define("Z_CONST", 1, true);
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING langDeprecated: define defaults to a case sensitive constant, the third argument can be removed at testdata/embeddedrules/langDeprecated.php:4
+WARNING langDeprecated: Define defaults to a case sensitive constant, the third argument can be removed at testdata/embeddedrules/langDeprecated.php:4
 define("Z_CONST1", 2, false);
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING offBy1: probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:11
+WARNING offBy1: Probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:11
   $_ = $xs[count($xs)];
        ^^^^^^^^^^^^^^^
-WARNING offBy1: probably intended to use sizeof-1 as an index at testdata/embeddedrules/offBy1.php:12
+WARNING offBy1: Probably intended to use sizeof-1 as an index at testdata/embeddedrules/offBy1.php:12
   $_ = $xs[sizeof($xs)];
        ^^^^^^^^^^^^^^^^
-WARNING offBy1: probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:14
+WARNING offBy1: Probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:14
   if ($tabs[count($tabs)] == "") {
       ^^^^^^^^^^^^^^^^^^^
 WARNING precedence: == has higher precedence than & at testdata/embeddedrules/precedence.php:4
@@ -229,22 +229,22 @@ WARNING precedence: === has higher precedence than | at testdata/embeddedrules/p
 WARNING precedence: !== has higher precedence than | at testdata/embeddedrules/precedence.php:33
   $_ = $x | $mask !== 0;
        ^^^^^^^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:6
+WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:6
   $_ = ($x == false);
         ^^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:7
+WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:7
   $_ = (false == $x);
         ^^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:8
+WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:8
   $_ = ($x == true);
         ^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:9
+WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:9
   $_ = (true == $x);
         ^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:10
+WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:10
   $_ = ($x == null);
         ^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:11
+WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:11
   $_ = (null == $x);
         ^^^^^^^^^^
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/embeddedrules/strictCmp.php:25
@@ -259,54 +259,54 @@ WARNING strictCmp: 3rd argument of array_search must be true when comparing stri
 WARNING strictCmp: 3rd argument of array_search must be true when comparing strings at testdata/embeddedrules/strictCmp.php:28
   $_ = array_search(retString(), $a);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:15
+WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:15
 $_ = (nonStrictComparison(0) != false);
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:16
+WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:16
 $_ = (false != nonStrictComparison(0));
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:17
+WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:17
 $_ = (nonStrictComparison(0) != true);
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:18
+WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:18
 $_ = (true != nonStrictComparison(0));
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:19
+WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:19
 $_ = (nonStrictComparison(0) != null);
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING strictCmp: non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:20
+WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:20
 $_ = (null != nonStrictComparison(0));
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `(bool)$x` at testdata/embeddedrules/ternarySimplify.php:6
+MAYBE   ternarySimplify: Could rewrite as `(bool)$x` at testdata/embeddedrules/ternarySimplify.php:6
     sink($x ? true : false);
          ^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could replace the ternary with just $x > $y at testdata/embeddedrules/ternarySimplify.php:9
+MAYBE   ternarySimplify: Could replace the ternary with just $x > $y at testdata/embeddedrules/ternarySimplify.php:9
     sink($x > $y ? true : false);
          ^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$x ?: $y` at testdata/embeddedrules/ternarySimplify.php:12
+MAYBE   ternarySimplify: Could rewrite as `$x ?: $y` at testdata/embeddedrules/ternarySimplify.php:12
     sink($x ? $x : $y);
          ^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$x[1] ?? $y` at testdata/embeddedrules/ternarySimplify.php:15
+MAYBE   ternarySimplify: Could rewrite as `$x[1] ?? $y` at testdata/embeddedrules/ternarySimplify.php:15
     sink(isset($x[1]) ? $x[1] : $y);
          ^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:22
+MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:22
     sink($x_arr[10] !== null ? $x_arr[10] : $y);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:23
+MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:23
     sink(null !== $x_arr[10] ? $x_arr[10] : $y);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:24
+MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:24
     sink($x_arr[10] === null ? $y : $x_arr[10]);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:25
+MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:25
     sink(null === $x_arr[10] ? $y : $x_arr[10]);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$x_arr[10] ?? null` at testdata/embeddedrules/ternarySimplify.php:27
+MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? null` at testdata/embeddedrules/ternarySimplify.php:27
     sink(array_key_exists(10, $x_arr) ? $x_arr[10] : null);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$x_arr[10] ?? null` at testdata/embeddedrules/ternarySimplify.php:28
+MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? null` at testdata/embeddedrules/ternarySimplify.php:28
     sink(! array_key_exists(10, $x_arr) ? null : $x_arr[10]);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `(bool)($flags & SOME_MASK)` at testdata/embeddedrules/ternarySimplify.php:46
+MAYBE   ternarySimplify: Could rewrite as `(bool)($flags & SOME_MASK)` at testdata/embeddedrules/ternarySimplify.php:46
     sink(($flags & SOME_MASK) ? true : false);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/flysystem/golden.txt
+++ b/src/tests/golden/testdata/flysystem/golden.txt
@@ -7,7 +7,7 @@ MAYBE   callSimplify: Could simplify to $permissions[0] at testdata/flysystem/sr
 MAYBE   regexpSimplify: May re-write '/^total [0-9]*$/' as '/^total \d*$/' at testdata/flysystem/src/Adapter/Ftp.php:407
         if (preg_match('/^total [0-9]*$/', $listing[0])) {
                        ^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$mkdirError['message'] ?? ''` at testdata/flysystem/src/Adapter/Local.php:111
+MAYBE   ternarySimplify: Could rewrite as `$mkdirError['message'] ?? ''` at testdata/flysystem/src/Adapter/Local.php:111
                 $errorMessage = isset($mkdirError['message']) ? $mkdirError['message'] : '';
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/flysystem/src/Adapter/Local.php:324
@@ -46,22 +46,22 @@ MAYBE   typeHint: specify the type for the parameter $config in phpdoc, 'array' 
 MAYBE   typeHint: specify the type for the parameter $config in phpdoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:257
     public function createDir($dirname, array $config = [])
                     ^^^^^^^^^
-WARNING unused: Variable e is unused (use $_ to ignore this inspection) at testdata/flysystem/src/Handler.php:129
+WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Handler.php:129
         } catch (BadMethodCallException $e) {
                                         ^^
-WARNING unused: Variable e is unused (use $_ to ignore this inspection) at testdata/flysystem/src/MountManager.php:275
+WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/MountManager.php:275
         } catch (PluginNotFoundException $e) {
                                          ^^
 MAYBE   deprecated: Call to deprecated method {\League\Flysystem\FilesystemInterface}->get() at testdata/flysystem/src/MountManager.php:646
         return $this->getFilesystem($prefix)->get($path);
                                               ^^^
-WARNING unused: Variable e is unused (use $_ to ignore this inspection) at testdata/flysystem/src/Plugin/ForcedCopy.php:33
+WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Plugin/ForcedCopy.php:33
         } catch (FileNotFoundException $e) {
                                        ^^
-WARNING unused: Variable e is unused (use $_ to ignore this inspection) at testdata/flysystem/src/Plugin/ForcedRename.php:33
+WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Plugin/ForcedRename.php:33
         } catch (FileNotFoundException $e) {
                                        ^^
-WARNING unused: Variable e is unused (use $_ to ignore this inspection) at testdata/flysystem/src/Plugin/PluggableTrait.php:89
+WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Plugin/PluggableTrait.php:89
         } catch (PluginNotFoundException $e) {
                                          ^^
 MAYBE   phpdoc: Missing PHPDoc for "storeSafely" public method at testdata/flysystem/src/SafeStorage.php:23
@@ -85,9 +85,9 @@ MAYBE   regexpSimplify: May re-write '#^[a-zA-Z]{1}:$#' as '#^[a-zA-Z]:$#' at te
 MAYBE   typeHint: specify the type for the parameter $entry in phpdoc, 'array' type hint too generic at testdata/flysystem/src/Util/ContentListingFormatter.php:52
     private function addPathInfo(array $entry)
                      ^^^^^^^^^^^
-WARNING unused: Variable e is unused (use $_ to ignore this inspection) at testdata/flysystem/src/Util/MimeType.php:208
+WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Util/MimeType.php:208
         } catch (ErrorException $e) {
                                 ^^
-MAYBE   ternarySimplify: could rewrite as `static::$extensionToMimeTypeMap[$extension] ?? 'text/plain'` at testdata/flysystem/src/Util/MimeType.php:222
+MAYBE   ternarySimplify: Could rewrite as `static::$extensionToMimeTypeMap[$extension] ?? 'text/plain'` at testdata/flysystem/src/Util/MimeType.php:222
         return isset(static::$extensionToMimeTypeMap[$extension])
                ^^^^^^^^^^^

--- a/src/tests/golden/testdata/idn/golden.txt
+++ b/src/tests/golden/testdata/idn/golden.txt
@@ -31,15 +31,15 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 MAYBE   redundantCast: expression already has int type at testdata/idn/idn.php:233
             $delta = (int) ($delta / 35);
                            ^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$k += 36` at testdata/idn/idn.php:234
+MAYBE   assignOp: Could rewrite as `$k += 36` at testdata/idn/idn.php:234
             $k = $k + 36;
             ^^^^^^^^^^^^
 MAYBE   redundantCast: expression already has int type at testdata/idn/idn.php:237
         return $k + (int) (36 * $delta / ($delta + 38));
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$n += (int) ($i / $outputLength)` at testdata/idn/idn.php:274
+MAYBE   assignOp: Could rewrite as `$n += (int) ($i / $outputLength)` at testdata/idn/idn.php:274
             $n = $n + (int) ($i / $outputLength);
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$i %= $outputLength` at testdata/idn/idn.php:275
+MAYBE   assignOp: Could rewrite as `$i %= $outputLength` at testdata/idn/idn.php:275
             $i = $i % $outputLength;
             ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/math/golden.txt
+++ b/src/tests/golden/testdata/math/golden.txt
@@ -1,13 +1,13 @@
-WARNING unused: Variable a is unused (use $_ to ignore this inspection) at testdata/math/src/BigDecimal.php:292
+WARNING unused: Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/math/src/BigDecimal.php:292
         [$a, $b] = $this->scaleValues($this, $that);
          ^^
 MAYBE   trailingComma: last element in a multi-line array must have a trailing comma at testdata/math/src/BigInteger.php:435
             new BigInteger($remainder)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$matches['fractional'] ?? ''` at testdata/math/src/BigNumber.php:90
+MAYBE   ternarySimplify: Could rewrite as `$matches['fractional'] ?? ''` at testdata/math/src/BigNumber.php:90
             $fractional = isset($matches['fractional']) ? $matches['fractional'] : '';
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   assignOp: could rewrite as `$number ^= $xor` at testdata/math/src/Internal/Calculator.php:622
+MAYBE   assignOp: Could rewrite as `$number ^= $xor` at testdata/math/src/Internal/Calculator.php:622
         $number = $number ^ $xor;
         ^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   trailingComma: last element in a multi-line array must have a trailing comma at testdata/math/src/Internal/Calculator/GmpCalculator.php:67

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -1,25 +1,25 @@
-MAYBE   ternarySimplify: could rewrite as `$baseDir ?: 0` at testdata/mustache/src/Mustache/Autoloader.php:56
+MAYBE   ternarySimplify: Could rewrite as `$baseDir ?: 0` at testdata/mustache/src/Mustache/Autoloader.php:56
         $key = $baseDir ? $baseDir : 0;
                ^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$this->fileMode ?? (0666 & ~umask())` at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:142
+MAYBE   ternarySimplify: Could rewrite as `$this->fileMode ?? (0666 & ~umask())` at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:142
                 $mode = isset($this->fileMode) ? $this->fileMode : (0666 & ~umask());
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:99
+MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:99
                         isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:112
+MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:112
                         isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$node[Mustache_Tokenizer::INDENT] ?? ''` at testdata/mustache/src/Mustache/Compiler.php:120
+MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::INDENT] ?? ''` at testdata/mustache/src/Mustache/Compiler.php:120
                         isset($node[Mustache_Tokenizer::INDENT]) ? $node[Mustache_Tokenizer::INDENT] : '',
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$node[Mustache_Tokenizer::INDENT] ?? ''` at testdata/mustache/src/Mustache/Compiler.php:128
+MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::INDENT] ?? ''` at testdata/mustache/src/Mustache/Compiler.php:128
                         isset($node[Mustache_Tokenizer::INDENT]) ? $node[Mustache_Tokenizer::INDENT] : '',
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:166
+MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:166
                         isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING unused: Variable keystr is unused (use $_ to ignore this inspection) at testdata/mustache/src/Mustache/Compiler.php:289
+WARNING unused: Variable $keystr is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/mustache/src/Mustache/Compiler.php:289
         $keystr = var_export($key, true);
         ^^^^^^^
 MAYBE   callSimplify: Could simplify to $id[0] at testdata/mustache/src/Mustache/Compiler.php:646
@@ -100,7 +100,7 @@ MAYBE   callSimplify: Could simplify to $this->stack[] = $value at testdata/must
 MAYBE   callSimplify: Could simplify to $this->blockStack[] = $value at testdata/mustache/src/Mustache/Context.php:49
         array_push($this->blockStack, $value);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$options['cache_file_mode'] ?? null` at testdata/mustache/src/Mustache/Engine.php:156
+MAYBE   ternarySimplify: Could rewrite as `$options['cache_file_mode'] ?? null` at testdata/mustache/src/Mustache/Engine.php:156
                 $mode  = isset($options['cache_file_mode']) ? $options['cache_file_mode'] : null;
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   misspellComment: "entitity" is a misspelling of "entity" at testdata/mustache/src/Mustache/Engine.php:254
@@ -118,7 +118,7 @@ ERROR   undefined: Call to undefined method {\Mustache_Cache}->getLogger() at te
 ERROR   undefined: Call to undefined method {\Mustache_Cache}->setLogger() at testdata/mustache/src/Mustache/Engine.php:562
             $cache->setLogger($this->getLogger());
                     ^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$this->delimiters ?: '{{ }}'` at testdata/mustache/src/Mustache/Engine.php:628
+MAYBE   ternarySimplify: Could rewrite as `$this->delimiters ?: '{{ }}'` at testdata/mustache/src/Mustache/Engine.php:628
             'delimiters'      => $this->delimiters ? $this->delimiters : '{{ }}',
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   phpdoc: Missing PHPDoc for "getFilterName" public method at testdata/mustache/src/Mustache/Exception/UnknownFilterException.php:34
@@ -133,6 +133,6 @@ MAYBE   phpdoc: Missing PHPDoc for "getTemplateName" public method at testdata/m
 WARNING regexpVet: '\w' intersects with '\d' in [\w\d\.] at testdata/mustache/src/Mustache/Loader/InlineLoader.php:115
             foreach (preg_split("/^@@(?= [\w\d\.]+$)/m", $data, -1) as $chunk) {
                                 ^^^^^^^^^^^^^^^^^^^^^^^
-WARNING unused: Variable v is unused (use $_ to ignore this inspection) at testdata/mustache/src/Mustache/Template.php:122
+WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/mustache/src/Mustache/Template.php:122
                 foreach ($value as $k => $v) {
                                          ^^

--- a/src/tests/golden/testdata/parsedown/golden.txt
+++ b/src/tests/golden/testdata/parsedown/golden.txt
@@ -25,7 +25,7 @@ MAYBE   trailingComma: last element in a multi-line array must have a trailing c
 MAYBE   typeHint: specify the type for the parameter $Block in phpdoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:643
     protected function blockListContinue($Line, array $Block)
                        ^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$matches[1] ?? ''` at testdata/parsedown/parsedown.php:674
+MAYBE   ternarySimplify: Could rewrite as `$matches[1] ?? ''` at testdata/parsedown/parsedown.php:674
             $text = isset($matches[1]) ? $matches[1] : '';
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   trailingComma: last element in a multi-line array must have a trailing comma at testdata/parsedown/parsedown.php:683
@@ -61,7 +61,7 @@ MAYBE   typeHint: specify the type for the parameter $Block in phpdoc, 'array' t
 MAYBE   regexpSimplify: May re-write '/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/' as '/^\[(.+?)\]: *+<?(\S+?)>?(?: +["'(](.+)["')])? *+$/' at testdata/parsedown/parsedown.php:875
             and preg_match('/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/', $Line['text'], $matches)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$matches[3] ?? null` at testdata/parsedown/parsedown.php:881
+MAYBE   ternarySimplify: Could rewrite as `$matches[3] ?? null` at testdata/parsedown/parsedown.php:881
                 'title' => isset($matches[3]) ? $matches[3] : null,
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   typeHint: specify the type for the parameter $Block in phpdoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:897
@@ -124,16 +124,16 @@ MAYBE   typeHint: specify the type for the parameter $Elements in phpdoc, 'array
 MAYBE   typeHint: specify the type for the parameter $Element in phpdoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1689
     protected function element(array $Element)
                        ^^^^^^^
-WARNING undefined: Variable might have not been defined: text at testdata/parsedown/parsedown.php:1755
+WARNING undefined: Variable $text might have not been defined at testdata/parsedown/parsedown.php:1755
                     $markup .= self::escape($text, true);
                                             ^^^^^
-WARNING undefined: Variable might have not been defined: text at testdata/parsedown/parsedown.php:1759
+WARNING undefined: Variable $text might have not been defined at testdata/parsedown/parsedown.php:1759
                     $markup .= $text;
                                ^^^^^
 MAYBE   typeHint: specify the type for the parameter $Elements in phpdoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1773
     protected function elements(array $Elements)
                        ^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$Element['autobreak'] ?? isset($Element['name'])` at testdata/parsedown/parsedown.php:1786
+MAYBE   ternarySimplify: Could rewrite as `$Element['autobreak'] ?? isset($Element['name'])` at testdata/parsedown/parsedown.php:1786
             $autoBreakNext = (isset($Element['autobreak'])
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/parsedown/parsedown.php:1807
@@ -142,7 +142,7 @@ WARNING strictCmp: 3rd argument of in_array must be true when comparing strings 
 MAYBE   typeHint: specify the type for the parameter $Element in phpdoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1861
     protected function sanitiseElement(array $Element)
                        ^^^^^^^^^^^^^^^
-WARNING unused: Variable val is unused (use $_ to ignore this inspection) at testdata/parsedown/parsedown.php:1882
+WARNING unused: Variable $val is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/parsedown/parsedown.php:1882
             foreach ($Element['attributes'] as $att => $val)
                                                        ^^^^
 MAYBE   typeHint: specify the type for the parameter $Element in phpdoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1900

--- a/src/tests/golden/testdata/phprocksyd/golden.txt
+++ b/src/tests/golden/testdata/phprocksyd/golden.txt
@@ -16,7 +16,7 @@ WARNING phpdocLint: malformed @param $stream_id tag (maybe type is missing?) on 
 WARNING phpdocLint: malformed @param $req tag (maybe type is missing?) on line 3 at testdata/phprocksyd/Phprocksyd.php:392
     private function requestCheck($stream_id, $req)
                      ^^^^^^^^^^^^
-WARNING unused: Variable status is unused (use $_ to ignore this inspection) at testdata/phprocksyd/Phprocksyd.php:394
+WARNING unused: Variable $status is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/phprocksyd/Phprocksyd.php:394
         $status = null;
         ^^^^^^^
 WARNING phpdocLint: malformed @param $stream_id tag (maybe type is missing?) on line 2 at testdata/phprocksyd/Phprocksyd.php:424

--- a/src/tests/golden/testdata/qrcode/golden.txt
+++ b/src/tests/golden/testdata/qrcode/golden.txt
@@ -4,10 +4,10 @@ MAYBE   phpdoc: Missing PHPDoc for "output_image" public method at testdata/qrco
 MAYBE   phpdoc: Missing PHPDoc for "render_image" public method at testdata/qrcode/qrcode.php:53
   public function render_image() {
                   ^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$this->options['bc'] ?? 'FFFFFF'` at testdata/qrcode/qrcode.php:59
+MAYBE   ternarySimplify: Could rewrite as `$this->options['bc'] ?? 'FFFFFF'` at testdata/qrcode/qrcode.php:59
     $bgcolor = (isset($this->options['bc']) ? $this->options['bc'] : 'FFFFFF');
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$this->options['fc'] ?? '000000'` at testdata/qrcode/qrcode.php:63
+MAYBE   ternarySimplify: Could rewrite as `$this->options['fc'] ?? '000000'` at testdata/qrcode/qrcode.php:63
     $fgcolor = (isset($this->options['fc']) ? $this->options['fc'] : '000000');
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 WARNING deadCode: Unreachable code at testdata/qrcode/qrcode.php:155
@@ -16,10 +16,10 @@ WARNING deadCode: Unreachable code at testdata/qrcode/qrcode.php:155
 MAYBE   trailingComma: last element in a multi-line array must have a trailing comma at testdata/qrcode/qrcode.php:185
       'b' => $mtx
       ^^^^^^^^^^^
-WARNING unused: Variable mode is unused (use $_ to ignore this inspection) at testdata/qrcode/qrcode.php:177
+WARNING unused: Variable $mode is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/qrcode/qrcode.php:177
     list($mode, $vers, $ec, $data) = $this->qr_encode_data($data, $ecl);
          ^^^^^
-WARNING undefined: Variable might have not been defined: code at testdata/qrcode/qrcode.php:221
+WARNING undefined: Variable $code might have not been defined at testdata/qrcode/qrcode.php:221
     while (count($code) % 8) {
                  ^^^^^
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:297

--- a/src/tests/golden/testdata/twitter-api-php/golden.txt
+++ b/src/tests/golden/testdata/twitter-api-php/golden.txt
@@ -1,7 +1,7 @@
 MAYBE   callSimplify: Could simplify to $array['status'][0] at testdata/twitter-api-php/TwitterAPIExchange.php:117
         if (isset($array['status']) && substr($array['status'], 0, 1) === '@')
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING unused: Variable key is unused (use $_ to ignore this inspection) at testdata/twitter-api-php/TwitterAPIExchange.php:122
+WARNING unused: Variable $key is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/twitter-api-php/TwitterAPIExchange.php:122
         foreach ($array as $key => &$value)
                            ^^^^
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/twitter-api-php/TwitterAPIExchange.php:207

--- a/src/tests/golden/testdata/underscore/golden.txt
+++ b/src/tests/golden/testdata/underscore/golden.txt
@@ -31,7 +31,7 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:363
     $calculated = array();
                   ^^^^^^^
-WARNING unused: Variable is_sorted is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:356
+WARNING unused: Variable $is_sorted is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:356
     list($collection, $is_sorted, $iterator) = self::_wrapArgs(func_get_args(), 3);
                       ^^^^^^^^^^
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:448
@@ -76,7 +76,7 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:480
       if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
                                         ^^^^^^^^^^^^^^
-MAYBE   ternarySimplify: could rewrite as `$array[$k] ?? null` at testdata/underscore/underscore.php:483
+MAYBE   ternarySimplify: Could rewrite as `$array[$k] ?? null` at testdata/underscore/underscore.php:483
         $return_arrays[$k][$a] = array_key_exists($k, $array) ? $array[$k] : null;
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   arrayAccess: Array access to non-array type \__|empty_array[]|mixed at testdata/underscore/underscore.php:483
@@ -85,7 +85,7 @@ MAYBE   arrayAccess: Array access to non-array type \__|empty_array[]|mixed at t
 ERROR   varShadow: Variable $array shadow existing variable $array from current function params at testdata/underscore/underscore.php:482
       foreach($arrays as $a=>$array) {
                              ^^^^^^
-WARNING unused: Variable v is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:479
+WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:479
     foreach($return_arrays as $k=>$v) {
                                   ^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:497
@@ -97,7 +97,7 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:529
     $results = array();
                ^^^^^^^
-WARNING unused: Variable v is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:534
+WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:534
     foreach($results as $k=>$v) {
                             ^^
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:545
@@ -106,10 +106,10 @@ MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdat
 MAYBE   arraySyntax: Use of old array syntax (use short form instead) at testdata/underscore/underscore.php:549
       if(!array_key_exists($key, $result)) $result[$key] = array();
                                                            ^^^^^^^
-WARNING unused: Variable __ is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:561
+WARNING unused: Variable $__ is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:561
     $__ = new self;
     ^^^
-WARNING unused: Variable args is unused (use $_ to ignore this inspection) at testdata/underscore/underscore.php:615
+WARNING unused: Variable $args is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:615
     $args = self::_wrapArgs(func_get_args(), 1);
     ^^^^^
 ERROR   undefined: Property {\__|mixed|null}->isEqual does not exist at testdata/underscore/underscore.php:723

--- a/src/tests/inline/testdata/embeddedrules/emptyStringCheck.php
+++ b/src/tests/inline/testdata/embeddedrules/emptyStringCheck.php
@@ -3,23 +3,23 @@
 function emptyStringCheck() {
     $x = "hello";
 
-    if (strlen($x)) { // want `use '$x !== ""' instead`
+    if (strlen($x)) { // want `Use '$x !== ""' instead`
         echo 1;
     }
 
-    if (mb_strlen($x)) { // want `use '$x !== ""' instead`
+    if (mb_strlen($x)) { // want `Use '$x !== ""' instead`
         echo 1;
     }
 
-    if ($x || strlen($x)) { // want `use '$x !== ""' instead`
+    if ($x || strlen($x)) { // want `Use '$x !== ""' instead`
         echo 1;
     }
 
-    if (!strlen($x)) { // want `use '$x === ""' instead`
+    if (!strlen($x)) { // want `Use '$x === ""' instead`
         echo 1;
     }
 
-    if (!mb_strlen($x)) { // want `use '$x === ""' instead`
+    if (!mb_strlen($x)) { // want `Use '$x === ""' instead`
         echo 1;
     }
 }

--- a/src/tests/inline/testdata/embeddedrules/returnAssign.php
+++ b/src/tests/inline/testdata/embeddedrules/returnAssign.php
@@ -4,14 +4,14 @@ function returnAssign(): int {
     $a = 100;
     echo $a;
 
-    return $a = 1; // want `don't use assignment in the return statement`
+    return $a = 1; // want `Don't use assignment in the return statement`
 }
 
 function returnAssign2(): int {
     $a = 100;
     echo $a;
 
-    return $a += 1; // want `don't use assignment in the return statement`
+    return $a += 1; // want `Don't use assignment in the return statement`
 }
 
 function returnAssignOk(): int {

--- a/src/tests/inline/testdata/embeddedrules/strangeCast.php
+++ b/src/tests/inline/testdata/embeddedrules/strangeCast.php
@@ -3,19 +3,19 @@
 function strangeCast() {
     $x = 100;
 
-    $_ = $x . ""; // want `concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string`
-    $_ = "" . $x; // want `concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string`
-    $_ = $x . ''; // want `concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string`
-    $_ = '' . $x; // want `concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string`
+    $_ = $x . ""; // want `Concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string`
+    $_ = "" . $x; // want `Concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string`
+    $_ = $x . ''; // want `Concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string`
+    $_ = '' . $x; // want `Concatenation with empty string, possible type cast, use explicit cast to string instead of concatenate with empty string`
 
     $y = "10";
 
-    $_ = 0 + $y; // want `addition with zero, possible type cast, use an explicit cast to int or float instead of zero addition`
+    $_ = 0 + $y; // want `Addition with zero, possible type cast, use an explicit cast to int or float instead of zero addition`
     $_ = $y + 10; // ok
-    $_ = 0.0 + $y; // want `addition with zero, possible type cast, use an explicit cast to int or float instead of zero addition`
+    $_ = 0.0 + $y; // want `Addition with zero, possible type cast, use an explicit cast to int or float instead of zero addition`
 
     $string = "10";
 
-    $_ = +$string; // want `unary plus, possible type cast, use an explicit cast to int or float instead of using the unary plus`
+    $_ = +$string; // want `Unary plus, possible type cast, use an explicit cast to int or float instead of using the unary plus`
     $_ = -$string; // ok, unary minus
 }

--- a/src/tests/regression/issue128_test.go
+++ b/src/tests/regression/issue128_test.go
@@ -38,13 +38,13 @@ function bad1($v) {
 $_ = $bad1;
 `)
 	test.Expect = []string{
-		`Undefined variable: bad0`,
-		`Undefined variable: bad1`, // At local scope
-		`Undefined variable: bad1`, // At global scope
-		`Undefined variable: bad2`,
-		`Undefined variable: bad3`,
+		`Undefined variable $bad0`,
+		`Undefined variable $bad1`, // At local scope
+		`Undefined variable $bad1`, // At global scope
+		`Undefined variable $bad2`,
+		`Undefined variable $bad3`,
 		`Property {mixed}->x does not exist`,
-		`Variable might have not been defined: y1`,
+		`Variable $y1 might have not been defined`,
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/regression/issue252_test.go
+++ b/src/tests/regression/issue252_test.go
@@ -45,7 +45,7 @@ function alt_switch($v) {
   endswitch;
 }`)
 	test.Expect = []string{
-		`Variable might have not been defined: x1`,
+		`Variable $x1 might have not been defined`,
 		`Add break or '// fallthrough' to the end of the case`,
 	}
 	test.RunAndMatch()

--- a/src/tests/regression/issue26_test.go
+++ b/src/tests/regression/issue26_test.go
@@ -20,7 +20,7 @@ func TestIssue26_1(t *testing.T) {
 		// After the block all vars are undefined again.
 		$_ = $x;
 	}`)
-	test.Expect = []string{"Undefined variable: y"}
+	test.Expect = []string{"Undefined variable $y"}
 	test.RunAndMatch()
 }
 
@@ -49,7 +49,7 @@ func TestIssue26_3(t *testing.T) {
 		}
 	}`)
 	test.Expect = []string{
-		"Undefined variable: x",
+		"Undefined variable $x",
 		"Unknown variable variable $$y used",
 	}
 	test.RunAndMatch()

--- a/src/tests/regression/issue288_test.go
+++ b/src/tests/regression/issue288_test.go
@@ -35,10 +35,10 @@ $_ = isset($x) && isset($y) ? $x : 0;
 $_ = $x instanceof Box ? 0 : 1;
 `)
 	test.Expect = []string{
-		`Undefined variable: badvar`,
-		`Undefined variable: b1`,
-		`Undefined variable: b2`,
-		`Undefined variable: b3`,
+		`Undefined variable $badvar`,
+		`Undefined variable $b1`,
+		`Undefined variable $b2`,
+		`Undefined variable $b3`,
 		`undefined: Property {mixed}->item2 does not exist`,
 	}
 	test.RunAndMatch()


### PR DESCRIPTION
- For embedded dynamic rules, all messages are capitalized;
- For messages with variables, added `$` before the variable name;
- For messages related to an unused variable added mention of the `--unused-var-regex` flag.