### PR TITLE
linter: fixed quickfix

### DIFF
--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -674,7 +674,7 @@ func (b *blockLinter) addFixForArray(arr *ir.ArrayExpr) {
 	have = bytes.TrimPrefix(have, []byte("("))
 	have = bytes.TrimSuffix(have, []byte(")"))
 
-	b.walker.r.ctx.fixes = append(b.walker.r.ctx.fixes, quickfix.TextEdit{
+	b.walker.r.addQuickFix("arraySyntax", quickfix.TextEdit{
 		StartPos:    arr.Position.StartPos,
 		EndPos:      arr.Position.EndPos,
 		Replacement: fmt.Sprintf("[%s]", string(have)),
@@ -787,7 +787,7 @@ func (b *blockLinter) addFixForMultilineArrayTrailingComma(item *ir.ArrayItemExp
 	to := item.Position.EndPos
 	have := b.walker.r.file.Contents()[from:to]
 
-	b.walker.r.ctx.fixes = append(b.walker.r.ctx.fixes, quickfix.TextEdit{
+	b.walker.r.addQuickFix("trailingComma", quickfix.TextEdit{
 		StartPos:    item.Position.StartPos,
 		EndPos:      item.Position.EndPos,
 		Replacement: string(have) + ",",

--- a/src/linter/custom.go
+++ b/src/linter/custom.go
@@ -244,8 +244,8 @@ func (ctx *BlockContext) File() *workspace.File {
 }
 
 // AddQuickfix adds a new quick fix.
-func (ctx *BlockContext) AddQuickfix(fix quickfix.TextEdit) {
-	ctx.w.r.ctx.fixes = append(ctx.w.r.ctx.fixes, fix)
+func (ctx *BlockContext) AddQuickfix(checkName string, fix quickfix.TextEdit) {
+	ctx.w.r.addQuickFix(checkName, fix)
 }
 
 // BlockCheckerCreateFunc is a factory function for BlockChecker

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1834,6 +1834,14 @@ func (d *rootWalker) LeaveNode(n ir.Node) {
 	}
 }
 
+func (d *rootWalker) addQuickFix(checkName string, fix quickfix.TextEdit) {
+	if !d.checkersFilter.IsEnabledReport(checkName, d.ctx.st.CurrentFile) {
+		return
+	}
+
+	d.ctx.fixes = append(d.ctx.fixes, fix)
+}
+
 func (d *rootWalker) runRules(n ir.Node, sc *meta.Scope, rlist []rules.Rule) {
 	for i := range rlist {
 		rule := &rlist[i]
@@ -1931,7 +1939,7 @@ func (d *rootWalker) runRule(n ir.Node, sc *meta.Scope, rule *rules.Rule) bool {
 		// As rule sets contain only enabled rules,
 		// we should be OK without any filtering here.
 		pos := ir.GetPosition(n)
-		d.ctx.fixes = append(d.ctx.fixes, quickfix.TextEdit{
+		d.addQuickFix(rule.Name, quickfix.TextEdit{
 			StartPos:    pos.StartPos,
 			EndPos:      pos.EndPos,
 			Replacement: d.renderRuleMessage(rule.Fix, n, m, false),


### PR DESCRIPTION
Now if the check is not enabled, quick fixes will not be applied for it.

Fixes #999 