### PR TITLE
linter: added type inference for `callable` from PHPDoc

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -245,6 +245,8 @@ func (b *blockWalker) handleCommentToken(n ir.Node, t *token.Token) {
 
 		converted := phpdoctypes.ToRealType(b.r.ctx.typeNormalizer.ClassFQNProvider(), part.Type)
 		moveShapesToContext(&b.r.ctx, converted.Shapes)
+		b.r.handleClosuresFromDoc(converted.Closures)
+
 		for _, warning := range converted.Warnings {
 			b.r.Report(n, LevelNotice, "phpdocType", "%s on line %d", warning, part.Line())
 		}
@@ -1159,6 +1161,7 @@ func (b *blockWalker) enterArrowFunction(fun *ir.ArrowFunctionExpr) bool {
 	// Indexing stage.
 	doc := phpdoctypes.Parse(fun.Doc, fun.Params, b.r.ctx.typeNormalizer)
 	moveShapesToContext(&b.r.ctx, doc.Shapes)
+	b.r.handleClosuresFromDoc(doc.Closures)
 
 	// Check stage.
 	errors := b.r.checkPHPDoc(fun, fun.Doc, fun.Params)
@@ -1183,6 +1186,7 @@ func (b *blockWalker) enterClosure(fun *ir.ClosureExpr, haveThis bool, thisType 
 	// Indexing stage.
 	doc := phpdoctypes.Parse(fun.Doc, fun.Params, b.r.ctx.typeNormalizer)
 	moveShapesToContext(&b.r.ctx, doc.Shapes)
+	b.r.handleClosuresFromDoc(doc.Closures)
 
 	// Check stage.
 	errors := b.r.checkPHPDoc(fun, fun.Doc, fun.Params)

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1646,6 +1646,10 @@ func (d *rootWalker) enterFunction(fun *ir.FunctionStmt) bool {
 }
 
 func (d *rootWalker) handleClosuresFromDoc(closures types.ClosureMap) {
+	if d.meta.Functions.H == nil {
+		d.meta.Functions = meta.NewFunctionsMap()
+	}
+
 	for name, closureInfo := range closures {
 		var params []meta.FuncParam
 		for i, paramType := range closureInfo.ParamTypes {

--- a/src/phpdoc/type_parser.go
+++ b/src/phpdoc/type_parser.go
@@ -49,7 +49,7 @@ const (
 	// Examples: `int` `\Foo\Bar` `$this`
 	ExprName
 
-	// ExprKeyword is a special name-like type node.
+	// ExprSpecialName is a special name-like type node.
 	// Examples: `*` `...`
 	ExprSpecialName
 

--- a/src/phpdoctypes/parser.go
+++ b/src/phpdoctypes/parser.go
@@ -22,7 +22,8 @@ type ParseResult struct {
 	AdditionalInfo meta.PhpDocInfo
 	Inherit        bool
 
-	Shapes types.ShapesMap
+	Shapes   types.ShapesMap
+	Closures types.ClosureMap
 }
 
 func Parse(doc phpdoc.Comment, actualParams []ir.Node, normalizer types.Normalizer) (result ParseResult) {
@@ -31,6 +32,7 @@ func Parse(doc phpdoc.Comment, actualParams []ir.Node, normalizer types.Normaliz
 	}
 
 	result.Shapes = make(types.ShapesMap)
+	result.Closures = make(types.ClosureMap)
 	result.ParamTypes = make(ParamsMap)
 
 	var curParam int
@@ -50,6 +52,9 @@ func Parse(doc phpdoc.Comment, actualParams []ir.Node, normalizer types.Normaliz
 			converted := ToRealType(normalizer.ClassFQNProvider(), part.Type)
 			for name, shape := range converted.Shapes {
 				result.Shapes[name] = shape
+			}
+			for name, closure := range converted.Closures {
+				result.Closures[name] = closure
 			}
 
 			result.ReturnType = types.NewMapWithNormalization(normalizer, converted.Types)
@@ -77,6 +82,9 @@ func Parse(doc phpdoc.Comment, actualParams []ir.Node, normalizer types.Normaliz
 		converted := ToRealType(normalizer.ClassFQNProvider(), part.Type)
 		for name, shape := range converted.Shapes {
 			result.Shapes[name] = shape
+		}
+		for name, closure := range converted.Closures {
+			result.Closures[name] = closure
 		}
 
 		var param Param

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -2254,3 +2254,26 @@ echo ONE;
 echo TWO;
 `)
 }
+
+func TestClosureDoc(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+class Foo {
+  /**
+   * @return int
+   */
+  public function method(): int { return 0; }
+}
+
+/**
+ * @param callable(int, string): Boo|Foo $s
+ */
+function f(callable $s) {
+  $a = $s(10);
+  echo $a->method();
+}
+`,
+	)
+	test.Expect = []string{"Too few arguments for $s"}
+	test.RunAndMatch()
+}

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -2917,6 +2917,113 @@ function f() {
 	runExprTypeTest(t, &exprTypeTestParams{code: code})
 }
 
+func TestCallableDoc(t *testing.T) {
+	code := `<?php
+class Foo {
+  /**
+   * @return int
+   */
+  public function method(): int { return 0; }
+}
+
+class Boo {
+  /**
+   * @return int
+   */
+  public function method(): int { return 0; }
+}
+
+/**
+ * @param callable(): Foo $s
+ */
+function f1(callable $s) {
+  $a = $s();
+  exprtype($a, "\Foo");
+}
+
+/**
+ * @param callable(Foo): Foo $s
+ */
+function f2(callable $s) {
+  $a = $s(new Foo);
+  exprtype($a, "\Foo");
+}
+
+/**
+ * @param callable(int): Foo $s
+ */
+function f3(callable $s) {
+  $a = $s(10);
+  exprtype($a, "\Foo");
+}
+
+/**
+ * @param callable(int, string): Foo|Boo $s
+ */
+function f4(callable $s) {
+  $a = $s(10, "ss");
+  exprtype($a, "\Boo|\Foo");
+}
+
+/**
+ * @param callable(): callable(): Foo $s
+ * @param callable(): callable(): Foo|Boo $s1
+ */
+function f5(callable $s, callable $s1) {
+  $a = $s();
+  $a1 = $s1();
+  exprtype($a, "\Closure$():Foo");
+  exprtype($a1, "\Closure$():Foo/Boo");
+  $b = $a();
+  $b1 = $a1();
+  exprtype($b, "\Foo");
+  exprtype($b1, "\Boo|\Foo");
+}
+
+/**
+ * @return callable(): callable(): Foo
+ */
+function f6(): callable {
+  return function() { return function() { return new Foo; }; };
+}
+
+function f7() {
+  $a = f6();
+  exprtype($a, "\Closure$():callable(): Foo|callable");
+  $b = $a();
+  exprtype($b, "\Closure$():Foo");
+  $c = $b();
+  exprtype($c, "\Foo");
+}
+
+function f8() {
+  /**
+   * @var callable(): Foo $a
+   */
+  $a = null;
+
+  $b = $a();
+  exprtype($b, "\Foo");
+}
+
+/**
+* @var callable(): Foo $a
+*/
+$a = null;
+$b = $a();
+exprtype($b, "\Foo");
+
+/**
+ * @param callable(int, string) $s
+ */
+function f9(callable $s) {
+  $a = $s(10, "ss");
+  exprtype($a, "mixed");
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func runExprTypeTest(t *testing.T, params *exprTypeTestParams) {
 	exprTypeTestImpl(t, params, false)
 }

--- a/src/types/closure.go
+++ b/src/types/closure.go
@@ -1,0 +1,9 @@
+package types
+
+type ClosureMap map[string]ClosureInfo
+
+type ClosureInfo struct {
+	Name       string
+	ReturnType []Type
+	ParamTypes [][]Type
+}


### PR DESCRIPTION
For example:

```php
/**
 * @param callable(): Foo $s
 */
function f1(callable $s) {
  $a = $s();
  exprtype($a, "\Foo");
}
```

Fixes #1006 