### PR TITLE
phpdoctypes: add handling of unknown `types-with-dashes` annotations

### DIFF
--- a/src/phpdoctypes/converter.go
+++ b/src/phpdoctypes/converter.go
@@ -85,7 +85,12 @@ func (conv *TypeConverter) mapType(e phpdoc.TypeExpr) []types.Type {
 	case phpdoc.ExprGeneric:
 		typ := e.Args[0]
 		params := e.Args[1:]
-		if typ.Value == "array" {
+
+		isArray := typ.Value == "array" ||
+			typ.Value == "list" ||
+			strings.Contains(typ.Value, "-")
+
+		if isArray {
 			if e.Shape == phpdoc.ShapeGenericBrace {
 				return conv.mapShapeType(params)
 			}

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -3024,6 +3024,26 @@ function f9(callable $s) {
 	runExprTypeTest(t, &exprTypeTestParams{code: code})
 }
 
+func TestDifferentArraySyntax(t *testing.T) {
+	code := `<?php
+/**
+ * @param array<Foo> $arr
+ * @param list<Foo> $arr1
+ * @param non-empty-array<Foo> $arr2
+ * @param non-empty-list<Foo> $arr3
+ * @param unknown-type-list<Foo> $arr4
+ */
+function f($arr, $arr1, $arr2, $arr3, $arr4) {
+  exprtype($arr, "\Foo[]");
+  exprtype($arr1, "\Foo[]");
+  exprtype($arr2, "\Foo[]");
+  exprtype($arr3, "\Foo[]");
+  exprtype($arr4, "\Foo[]");
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func runExprTypeTest(t *testing.T, params *exprTypeTestParams) {
 	exprTypeTestImpl(t, params, false)
 }


### PR DESCRIPTION
For `list<T>`, `non-empty-array<T>`, `non-empty-list<T>` and other unknown 
containers with '-' in the name, type `array<T>` is deduced.

Fixes #341 