### PR TITLE
linter: added check for `new` for traits and interfaces

### DIFF
--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -142,7 +142,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 5358
+		wantLen := 5360
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -151,7 +151,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "ac764c2a270fca7341a4650318480a67cb02e1fad8c9f0036c35fade2bf2f22cae76f3de8d200a1d03581565b9e86ea9c6b18108e4f48366359b916769c141f8"
+		wantStrings := "e92736453a08fdd905945a7df844c3fcefb0091a8726ac647d1ccae69bb34cd442641564a93f3eaa269f978edea5e09b17cef705e5c5a50a851812dc951b765e"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -376,6 +376,15 @@ return [$result, $err];`,
 		},
 
 		{
+			Name:     "invalidNew",
+			Default:  true,
+			Quickfix: false,
+			Comment:  `Report trait or interface usages in new expressions.`,
+			Before:   `return new SomeTrait();`,
+			After:    `return new SomeClass();`,
+		},
+
+		{
 			Name:     "regexpSimplify",
 			Default:  true,
 			Quickfix: false,

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -775,9 +775,15 @@ func (d *rootWalker) getClass() meta.ClassInfo {
 
 	cl, ok := m.Get(d.ctx.st.CurrentClass)
 	if !ok {
+		var flags meta.ClassFlags
+		if d.ctx.st.IsInterface {
+			flags = meta.ClassInterface
+		}
+
 		cl = meta.ClassInfo{
 			Pos:              d.getElementPos(d.currentClassNode),
 			Name:             d.ctx.st.CurrentClass,
+			Flags:            flags,
 			Parent:           d.ctx.st.CurrentParentClass,
 			ParentInterfaces: d.ctx.st.CurrentParentInterfaces,
 			Interfaces:       make(map[string]struct{}),

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -133,6 +133,7 @@ const (
 	ClassAbstract ClassFlags = 1 << iota
 	ClassFinal
 	ClassShape
+	ClassInterface
 )
 
 type ClassInfo struct {
@@ -149,14 +150,16 @@ type ClassInfo struct {
 	Mixins           []string
 }
 
-func (info *ClassInfo) IsAbstract() bool { return info.Flags&ClassAbstract != 0 }
-func (info *ClassInfo) IsShape() bool    { return info.Flags&ClassShape != 0 }
+func (info *ClassInfo) IsAbstract() bool  { return info.Flags&ClassAbstract != 0 }
+func (info *ClassInfo) IsShape() bool     { return info.Flags&ClassShape != 0 }
+func (info *ClassInfo) IsInterface() bool { return info.Flags&ClassInterface != 0 }
 
 // TODO: rename it; it's not only class-related.
 type ClassParseState struct {
 	Info *Info
 
 	IsTrait                 bool
+	IsInterface             bool
 	Namespace               string
 	FunctionUses            map[string]string
 	Uses                    map[string]string

--- a/src/state/update.go
+++ b/src/state/update.go
@@ -33,6 +33,7 @@ func EnterNode(st *meta.ClassParseState, n ir.Node) {
 
 	case *ir.InterfaceStmt:
 		st.IsTrait = false
+		st.IsInterface = true
 		st.CurrentClass = st.Namespace + `\` + n.InterfaceName.Value
 		st.CurrentParentClass = ""
 		st.CurrentParentInterfaces = nil
@@ -48,6 +49,7 @@ func EnterNode(st *meta.ClassParseState, n ir.Node) {
 	case *ir.ClassStmt:
 		// TODO: handle anonymous classes (they can be nested as well)
 		st.IsTrait = false
+		st.IsInterface = false
 		id := n.ClassName
 		st.CurrentClass = st.Namespace + `\` + id.Value
 		st.CurrentParentClass = ""
@@ -57,6 +59,7 @@ func EnterNode(st *meta.ClassParseState, n ir.Node) {
 		}
 	case *ir.TraitStmt:
 		st.IsTrait = true
+		st.IsInterface = false
 		st.CurrentClass = st.Namespace + `\` + n.TraitName.Value
 		st.CurrentParentClass = ""
 		st.CurrentParentInterfaces = nil
@@ -126,6 +129,7 @@ func LeaveNode(st *meta.ClassParseState, n ir.Node) {
 
 	case *ir.ClassStmt, *ir.InterfaceStmt, *ir.TraitStmt:
 		st.IsTrait = false
+		st.IsInterface = false
 		st.CurrentClass = ""
 		st.CurrentParentClass = ""
 		st.CurrentParentInterfaces = nil

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -118,8 +118,32 @@ abstract class AC {
 $x = new AC();
 `)
 	test.Expect = []string{
-		`Cannot instantiate abstract class`,
-		`Cannot instantiate abstract class`,
+		`Cannot instantiate abstract class \AC`,
+		`Cannot instantiate abstract class \AC`,
+	}
+	test.RunAndMatch()
+}
+
+func TestNewInterface(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+interface IElement {}
+$x = new IElement;
+`)
+	test.Expect = []string{
+		`Cannot instantiate interface \IElement`,
+	}
+	test.RunAndMatch()
+}
+
+func TestNewTrait(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+trait Element {}
+$x = new Element;
+`)
+	test.Expect = []string{
+		`Cannot instantiate trait \Element`,
 	}
 	test.RunAndMatch()
 }


### PR DESCRIPTION
Fixes #562 