### PR TITLE
solver: now typecast to an array does not overwrite existing types

### DIFF
--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -124,7 +124,7 @@ func exprTypeLocalCustom(sc *meta.Scope, cs *meta.ClassParseState, n ir.Node, cu
 	case *ir.PreDecExpr:
 		return unaryMathOpType(sc, cs, n.Variable, custom)
 	case *ir.TypeCastExpr:
-		return typeCastType(n)
+		return typeCastType(sc, cs, n, custom)
 	case *ir.ShiftLeftExpr, *ir.ShiftRightExpr:
 		return types.PreciseIntType
 	case *ir.ClassConstFetchExpr:
@@ -378,10 +378,11 @@ func classConstFetchType(n *ir.ClassConstFetchExpr, cs *meta.ClassParseState) ty
 	return types.NewMap(types.WrapClassConstFetch(className, n.ConstantName.Value))
 }
 
-func typeCastType(n *ir.TypeCastExpr) types.Map {
+func typeCastType(sc *meta.Scope, cs *meta.ClassParseState, n *ir.TypeCastExpr, custom []CustomType) types.Map {
 	switch n.Type {
 	case "array":
-		return types.NewMap("mixed[]")
+		typ := exprTypeLocalCustom(sc, cs, n.Expr, custom)
+		return typ.Append(types.NewMap("mixed[]"))
 	case "int":
 		return types.PreciseIntType
 	case "string":

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -3046,6 +3046,32 @@ function f($arr, $arr1, $arr2, $arr3, $arr4, $arr5) {
 	runExprTypeTest(t, &exprTypeTestParams{code: code})
 }
 
+func TestArrayTypeCast(t *testing.T) {
+	code := `<?php
+class Foo {}
+
+/**
+ * @return Foo[]
+ */
+function f() {
+  return [];
+}
+
+function f1() {
+  $a = (array) f();
+  exprtype($a, "\Foo[]|mixed[]");
+  exprtype($a[0], "\Foo|mixed");
+
+  $b = (array) 10;
+  exprtype($b, "int|mixed[]");
+
+  $c = (array) [1, "s"];
+  exprtype($c, "mixed[]");
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func runExprTypeTest(t *testing.T, params *exprTypeTestParams) {
 	exprTypeTestImpl(t, params, false)
 }


### PR DESCRIPTION
For example:

```php
/**
 * @return Foo[]
 */
function f() {
  return [];
}

function f1() {
  $a = (array) f();
  echo $a[0]->f();
}
```

### Before:
```
<critical> ERROR   undefined: Call to undefined method {mixed}->f() at ...:16
  echo $a[0]->f();
              ^
```

### After:

No error.