### PR TITLE
linter: now, if the function returns array, then inferred type is taken into account

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1680,6 +1680,11 @@ func (b *blockWalker) handleAndCheckDimFetchLValue(e *ir.ArrayDimFetchExpr, reas
 		// necessary to replace this type with a new, more precise one.
 		if ok && varType.Len() == 1 && varType.Contains("empty_array") {
 			b.replaceVar(v, arrayOfType, reason, meta.VarAlwaysDefined)
+			sv, ok := v.(*ir.SimpleVar)
+			if !ok {
+				return
+			}
+			b.untrackVarName(sv.Name)
 		} else {
 			b.addVar(v, arrayOfType, reason, meta.VarAlwaysDefined)
 			b.handleVariable(v)

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1674,8 +1674,16 @@ func (b *blockWalker) handleAndCheckDimFetchLValue(e *ir.ArrayDimFetchExpr, reas
 	switch v := e.Variable.(type) {
 	case *ir.Var, *ir.SimpleVar:
 		arrayOfType := typ.Map(types.WrapArrayOf)
-		b.addVar(v, arrayOfType, reason, meta.VarAlwaysDefined)
-		b.handleVariable(v)
+
+		varType, ok := b.ctx.sc.GetVarType(v)
+		// If the variable contains the type of an empty array, then it is
+		// necessary to replace this type with a new, more precise one.
+		if ok && varType.Len() == 1 && varType.Contains("empty_array") {
+			b.replaceVar(v, arrayOfType, reason, meta.VarAlwaysDefined)
+		} else {
+			b.addVar(v, arrayOfType, reason, meta.VarAlwaysDefined)
+			b.handleVariable(v)
+		}
 	case *ir.ArrayDimFetchExpr:
 		arrayOfType := typ.Map(types.WrapArrayOf)
 		b.handleAndCheckDimFetchLValue(v, reason, arrayOfType)

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -140,7 +140,11 @@ func mergeTypeMaps(left types.Map, right types.Map) types.Map {
 // 2. If there is a type hint, then it is added to the types from the @return.
 //    If the @return is empty, then the type matches the type hint itself;
 //
-// 3. If there is no @return annotation and type hint, then the return type is equal to
+// 3. If the resulting type is mixed[], then if the actual type is a specific
+//    array type, then we use it, otherwise we combine this type with the
+//    resulting mixed[] type.
+//
+// 4. If there is no @return annotation and type hint, then the return type is equal to
 //    the union of the types that are returned from the function by return.
 func functionReturnType(phpdocReturnType types.Map, hintReturnType types.Map, actualReturnTypes types.Map) types.Map {
 	var returnTypes types.Map
@@ -148,6 +152,14 @@ func functionReturnType(phpdocReturnType types.Map, hintReturnType types.Map, ac
 		returnTypes = mergeTypeMaps(phpdocReturnType, hintReturnType)
 	} else {
 		returnTypes = actualReturnTypes
+	}
+
+	if returnTypes.IsLazyArrayOf("mixed") {
+		if actualReturnTypes.IsLazyArray() && !actualReturnTypes.IsLazyArrayOf("mixed") {
+			returnTypes = actualReturnTypes
+		} else if !actualReturnTypes.Contains(types.WrapArrayOf("mixed")) {
+			returnTypes.Append(actualReturnTypes)
+		}
 	}
 
 	if returnTypes.Empty() {

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -157,7 +157,8 @@ func functionReturnType(phpdocReturnType types.Map, hintReturnType types.Map, ac
 	if returnTypes.IsLazyArrayOf("mixed") {
 		if actualReturnTypes.IsLazyArray() && !actualReturnTypes.IsLazyArrayOf("mixed") {
 			returnTypes = actualReturnTypes
-		} else if !actualReturnTypes.Contains(types.WrapArrayOf("mixed")) {
+		} else if !actualReturnTypes.Contains(types.WrapArrayOf("mixed")) &&
+			!actualReturnTypes.Contains("null") {
 			returnTypes.Append(actualReturnTypes)
 		}
 	}

--- a/src/meta/scope.go
+++ b/src/meta/scope.go
@@ -262,6 +262,15 @@ func (s *Scope) HaveVarName(name string) bool {
 	return v.flags.IsAlwaysDefined()
 }
 
+// GetVarType returns type map for variable if it exists
+func (s *Scope) GetVarType(v ir.Node) (m types.Map, ok bool) {
+	name, ok := scopeVarName(v)
+	if !ok {
+		return types.Map{}, false
+	}
+	return s.GetVarNameType(name)
+}
+
 // GetVarNameType returns type map for variable if it exists
 func (s *Scope) GetVarNameType(name string) (m types.Map, ok bool) {
 	res, ok := s.vars[name]

--- a/src/types/map.go
+++ b/src/types/map.go
@@ -394,6 +394,17 @@ func (m Map) LazyArrayElemType() Map {
 
 	mm := make(map[string]struct{}, m.Len())
 	for typ := range m.m {
+		if typ == "empty_array" {
+			// If the type contains only empty_array,
+			// then we resolve its element as mixed.
+			if len(m.m) == 0 {
+				mm["mixed"] = struct{}{}
+			}
+			// If not, then we remove it, since there
+			// is a more precise type.
+			continue
+		}
+
 		mm[UnwrapArrayOf(typ)] = struct{}{}
 	}
 	return Map{m: mm, flags: m.flags}


### PR DESCRIPTION
If the resulting type is `mixed[]`, then if the actual type is a specific
array type, then we use it, otherwise, we combine this type with the
resulting `mixed[`] type.

If a new element is added to an empty array, then the `empty_array` type
is removed.

#849 