### PR TITLE
linter: added a check for using `void` type in the type union or `@param` annotation

### DIFF
--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1327,6 +1327,12 @@ func (d *rootWalker) checkPHPDoc(n ir.Node, doc phpdoc.Comment, actualParams []i
 			for _, warning := range converted.Warnings {
 				errors.pushType("%s on line %d", warning, part.Line())
 			}
+
+			returnType := types.NewMapWithNormalization(d.ctx.typeNormalizer, converted.Types)
+
+			if returnType.Contains("void") && returnType.Len() > 1 {
+				errors.pushType("Void type can only be used as a standalone type for the return type")
+			}
 			continue
 		}
 
@@ -1372,11 +1378,11 @@ func (d *rootWalker) checkPHPDoc(n ir.Node, doc phpdoc.Comment, actualParams []i
 
 		var param phpdoctypes.Param
 		param.Typ = types.NewMapWithNormalization(d.ctx.typeNormalizer, converted.Types)
-		param.Typ.Iterate(func(t string) {
-			if t == "void" {
-				errors.pushType("void is not a valid type for input parameter")
-			}
-		})
+
+		if param.Typ.Contains("void") {
+			errors.pushType("Void type can only be used as a standalone type for the return type")
+		}
+
 		param.Optional = optional
 	}
 

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -535,18 +535,26 @@ func TestVoidResultUsedInBinary(t *testing.T) {
 	test.RunAndMatch()
 }
 
-func TestVoidParam(t *testing.T) {
+func TestVoidForParamAndReturn(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
-	/**
-	* @param void $x
-	* @param int $y
-	* @return void
-	*/
-	function f($x, $y) {}
+/**
+* @param void $x
+* @param int $y
+* @param int|void $z
+* @return void
+*/
+function f($x, $y, $z) {}
+
+/**
+* @return int|void
+*/
+function f1() {}
 `)
 	test.Expect = []string{
-		`void is not a valid type for input parameter`,
+		`Void type can only be used as a standalone type for the return type`,
+		`Void type can only be used as a standalone type for the return type`,
+		`Void type can only be used as a standalone type for the return type`,
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/golden/testdata/flysystem/golden.txt
+++ b/src/tests/golden/testdata/flysystem/golden.txt
@@ -13,6 +13,9 @@ MAYBE   ternarySimplify: Could rewrite as `$mkdirError['message'] ?? ''` at test
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/flysystem/src/Adapter/Local.php:324
         if (in_array($mimetype, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+MAYBE   phpdocType: Void type can only be used as a standalone type for the return type at testdata/flysystem/src/Adapter/Local.php:448
+    protected function normalizeFileInfo(SplFileInfo $file)
+                       ^^^^^^^^^^^^^^^^^
 WARNING phpdocRef: Line 8: @see tag refers to unknown symbol League\Flysystem\ReadInterface::readStream at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:19
     public function readStream($path)
                     ^^^^^^^^^^


### PR DESCRIPTION
Fixes #953