### PR TITLE
linter: added checks from SonarLint

### DIFF
--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -516,3 +516,38 @@ function returnAssign() {
         return $_ ??= $_;
     }
 }
+
+/**
+ * @comment Report comparisons count(...) which are always false or true.
+ * @before  if (count($arr) >= 0) { ... }
+ * @after   if (count($arr) != 0) { ... }
+ */
+function countUse() {
+  /**
+   * @warning Count of elements is always greater than or equal to zero, this expression is always true
+   */
+  any_greater_or_equal: {
+    count($arr) >= 0;
+    0 <= count($arr);
+  }
+
+  /**
+   * @warning Count of elements is always greater than or equal to zero, this expression is always false
+   */
+  any_less: {
+    count($arr) < 0;
+    0 > count($arr);
+  }
+
+  /**
+   * @warning Count of elements is always greater than or equal to zero, use count($arr) == 0 instead.
+   * @fix count($arr) == 0
+   */
+  count($arr) <= 0;
+
+  /**
+   * @warning Count of elements is always greater than or equal to zero, use 0 == count($arr) instead.
+   * @fix 0 == count($arr)
+   */
+  0 >= count($arr);
+}

--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -551,3 +551,37 @@ function countUse() {
    */
   0 >= count($arr);
 }
+
+/**
+ * @comment Report the repetition of unary (! and ~) operators in a row.
+ * @before  echo !!$a;
+ * @after   echo (bool) $a;
+ */
+function unaryRepeat() {
+  /**
+   * @warning Several negations in a row does not make sense, if you want to cast a value to a boolean type, use an explicit cast
+   */
+  any_repeat_negation: {
+    !!$a;
+    !!!$a;
+    !!!!$a;
+  }
+
+  /**
+   * @warning Several bitwise not (~) in a row does not make sense
+   * @fix     $a
+   */
+  ~~~~$a;
+
+  /**
+   * @warning Several bitwise not (~) in a row does not make sense
+   * @fix     ~$a
+   */
+  ~~~$a;
+
+  /**
+   * @warning Several bitwise not (~) in a row does not make sense
+   * @fix $a
+   */
+  ~~$a;
+}

--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -612,3 +612,28 @@ function forLoop() {
     for ($i = $start; $i >= $length; $i += $addition) { ${"*"};}
   }
 }
+
+/**
+ * @comment Report when use to always null object.
+ * @before  if ($obj == null && $obj->method()) { ... }
+ * @after   if ($obj != null && $obj->method()) { ... }
+ */
+function alwaysNull() {
+  /**
+   * @warning '$obj' is always 'null', maybe you meant '$obj != null && ...' or '$obj == null || ...'
+   * @location $obj
+   */
+  any_equal: {
+    if ($obj == null && $obj->$method(${"*"})) { ${"*"}; }
+    if ($obj == null && $obj->$prop) { ${"*"}; }
+  }
+
+  /**
+   * @warning '$obj' is always 'null', maybe you meant '$obj == null || ...' or '$obj != null && ...'
+   * @location $obj
+   */
+  any_not_equal: {
+    if ($obj != null || $obj->$method(${"*"})) { ${"*"}; }
+    if ($obj != null || $obj->$prop) { ${"*"}; }
+  }
+}

--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -637,3 +637,15 @@ function alwaysNull() {
     if ($obj != null || $obj->$prop) { ${"*"}; }
   }
 }
+
+/**
+ * @comment Report self-assignment of variables.
+ * @before  $x = $x;
+ * @after   $x = $y;
+ */
+function selfAssign() {
+  /**
+   * @warning Assignment to $x itself does not make sense
+   */
+  ${'x:var'} = ${'x:var'};
+}

--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -649,3 +649,15 @@ function selfAssign() {
    */
   ${'x:var'} = ${'x:var'};
 }
+
+/**
+ * @comment Report using @.
+ * @before  $f();
+ * @after   f();
+ */
+function errorSilence() {
+  /**
+   * @warning Don't use @, silencing errors is bad practice
+   */
+  @$_;
+}

--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -540,13 +540,13 @@ function countUse() {
   }
 
   /**
-   * @warning Count of elements is always greater than or equal to zero, use count($arr) == 0 instead.
+   * @warning Count of elements is always greater than or equal to zero, use count($arr) == 0 instead
    * @fix count($arr) == 0
    */
   count($arr) <= 0;
 
   /**
-   * @warning Count of elements is always greater than or equal to zero, use 0 == count($arr) instead.
+   * @warning Count of elements is always greater than or equal to zero, use 0 == count($arr) instead
    * @fix 0 == count($arr)
    */
   0 >= count($arr);

--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -585,3 +585,30 @@ function unaryRepeat() {
    */
   ~~$a;
 }
+
+/**
+ * @comment Report potentially erroneous 'for' loops.
+ * @before  for ($i = 0; $i < 100; $i--) { ... }
+ * @after   for ($i = 0; $i < 100; $i++) { ... }
+ */
+function forLoop() {
+  /**
+   * @warning Potentially infinite 'for' loop, because $i decreases and is always less than initial value $start and, accordingly, $length
+   */
+  any_for_loop_decrease: {
+    for ($i = $start; $i < $length; $i--) { ${"*"};}
+    for ($i = $start; $i <= $length; $i--) { ${"*"};}
+    for ($i = $start; $i < $length; $i -= $subtraction) { ${"*"};}
+    for ($i = $start; $i <= $length; $i -= $subtraction) { ${"*"};}
+  }
+
+  /**
+   * @warning Potentially infinite 'for' loop, because $i increases and is always greater than initial value $start and, accordingly, $length
+   */
+  any_for_loop_increase: {
+    for ($i = $start; $i > $length; $i++) { ${"*"};}
+    for ($i = $start; $i >= $length; $i++) { ${"*"};}
+    for ($i = $start; $i > $length; $i += $addition) { ${"*"};}
+    for ($i = $start; $i >= $length; $i += $addition) { ${"*"};}
+  }
+}

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -744,6 +744,54 @@ function f(array $a) {}`,
   public $item;
 }`,
 		},
+
+		{
+			Name:     "switchDefault",
+			Default:  true,
+			Quickfix: false,
+			Comment:  `Report the lack or wrong position of default.`,
+			Before: `switch ($a) {
+  case 1:
+    echo 1;
+    break;
+}`,
+			After: `switch ($a) {
+  case 1:
+    echo 1;
+    break;
+  default:
+    echo 2;
+    break;
+}`,
+		},
+
+		{
+			Name:     "switchSimplify",
+			Default:  true,
+			Quickfix: false,
+			Comment:  `Report possibility to rewrite 'switch' with the 'if'.`,
+			Before: `switch ($a) {
+  case 1:
+    echo 1;
+    break;
+}`,
+			After: `if ($a == 1) {
+  echo 1;
+}`,
+		},
+
+		{
+			Name:     "switchEmpty",
+			Default:  true,
+			Quickfix: false,
+			Comment:  `Report switch with empty body.`,
+			Before:   `switch ($a) {}`,
+			After: `switch ($a) {
+  case 1:
+    // do something
+    break;
+}`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -443,7 +443,7 @@ function good() {
 		`Use public instead of PubliC`,
 	}
 
-	test.RunAndMatch()
+	linttest.RunFilterMatch(test, "keywordCase")
 }
 
 func TestCallStaticParent(t *testing.T) {
@@ -1137,7 +1137,7 @@ func TestSwitchContinue1(t *testing.T) {
 		`Use 'break' instead of 'continue' or 'continue 2' to continue the loop around switch`,
 		`Use 'break' instead of 'continue' or 'continue 2' to continue the loop around switch`,
 	}
-	test.RunAndMatch()
+	linttest.RunFilterMatch(test, "caseContinue")
 }
 
 func TestSwitchContinue2(t *testing.T) {
@@ -1151,6 +1151,11 @@ func TestSwitchContinue2(t *testing.T) {
 				continue; // OK, bound to 'for'
 			}
 		}
+		break;
+	case 2:
+		break;
+	default:
+		break;
 	}
 
 	// OK, "continue 2" does the right thing.
@@ -1160,6 +1165,10 @@ func TestSwitchContinue2(t *testing.T) {
 		switch ($x) {
 		case 10:
 			continue 2;
+		case 1:
+			break;
+		default:
+			break;
 		}
 	}`)
 	test.RunAndMatch()
@@ -1762,7 +1771,8 @@ func TestFunctionThrowsExceptionsAndReturns(t *testing.T) {
 		switch ($b) {
 			case "a":
 				throw new \Exception("a");
-
+			case "b":
+				break;
 			default:
 				throw new \Exception("default");
 		}
@@ -1833,6 +1843,7 @@ func TestSwitchBreak(t *testing.T) {
 	test.AddFile(`<?php
 	function bad($a) {
 		switch ($a) {
+		case 2:
 		case 1:
 			echo "One\n"; // Bad, no break.
 		default:
@@ -1842,6 +1853,8 @@ func TestSwitchBreak(t *testing.T) {
 
 	function good($a) {
 		switch ($a) {
+		default:
+			break;
 		case 1:
 			echo "One\n";
 			break;

--- a/src/tests/checkers/codedup_test.go
+++ b/src/tests/checkers/codedup_test.go
@@ -329,12 +329,12 @@ function f($cond) {
 }
 `)
 	test.Expect = []string{
-		`duplicated switch case #2`,
-		`duplicated switch case #4`,
-		`duplicated switch case #5 (value 2)`,
-		`duplicated switch case #2`,
-		`duplicated switch case #3 (value 1)`,
-		`duplicated switch case #4 (value 3)`,
+		`Duplicated switch case for expression 'abc'`,
+		`Duplicated switch case for expression 1`,
+		`Duplicated switch case for expression C2 (value: 2)`,
+		`Duplicated switch case for expression purefunc(1)`,
+		`Duplicated switch case for expression C1 (value: 1)`,
+		`Duplicated switch case for expression C3 (value: 3)`,
 	}
-	test.RunAndMatch()
+	linttest.RunFilterMatch(test, "dupCond")
 }

--- a/src/tests/golden/testdata/flysystem/golden.txt
+++ b/src/tests/golden/testdata/flysystem/golden.txt
@@ -4,15 +4,45 @@ MAYBE   regexpSimplify: May re-write '/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/' as '/^\d{
 MAYBE   callSimplify: Could simplify to $permissions[0] at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:548
         return substr($permissions, 0, 1) === 'd' ? 'dir' : 'file';
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:134
+            $this->connection = @ftp_ssl_connect($this->getHost(), $this->getPort(), $this->getTimeout());
+                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:136
+            $this->connection = @ftp_connect($this->getHost(), $this->getPort(), $this->getTimeout());
+                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:233
+            @ftp_close($this->connection);
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:391
+        if (@ftp_chdir($this->getConnection(), $path) === true) {
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^total [0-9]*$/' as '/^total \d*$/' at testdata/flysystem/src/Adapter/Ftp.php:407
         if (preg_match('/^total [0-9]*$/', $listing[0])) {
                        ^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:570
+        $response = @ftp_raw($this->connection, trim($command));
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftpd.php:15
+        if (@ftp_chdir($this->getConnection(), $path) === true) {
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:103
+            if ( ! @mkdir($root, $this->permissionMap['dir']['public'], true)) {
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   ternarySimplify: Could rewrite as `$mkdirError['message'] ?? ''` at testdata/flysystem/src/Adapter/Local.php:111
                 $errorMessage = isset($mkdirError['message']) ? $mkdirError['message'] : '';
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:222
+        $contents = @file_get_contents($location);
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:263
+        return @unlink($location);
+               ^^^^^^^^^^^^^^^^^^
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/flysystem/src/Adapter/Local.php:324
         if (in_array($mimetype, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:387
+            if (false === @mkdir($location, $this->permissionMap['dir'][$visibility], true)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   phpdocType: Void type can only be used as a standalone type for the return type at testdata/flysystem/src/Adapter/Local.php:448
     protected function normalizeFileInfo(SplFileInfo $file)
                        ^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/flysystem/golden.txt
+++ b/src/tests/golden/testdata/flysystem/golden.txt
@@ -40,6 +40,9 @@ WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/flysystem/src/Adapter/Local.php:324
         if (in_array($mimetype, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:387
+            if (false === @mkdir($location, $this->permissionMap['dir'][$visibility], true)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   phpdocType: Void type can only be used as a standalone type for the return type at testdata/flysystem/src/Adapter/Local.php:444
      * @return array|void
                ^^^^^^^^^^

--- a/src/tests/golden/testdata/idn/golden.txt
+++ b/src/tests/golden/testdata/idn/golden.txt
@@ -4,6 +4,9 @@ MAYBE   phpdoc: Missing PHPDoc for \Symfony\Polyfill\Intl\Idn\Idn::idn_to_ascii 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:64
     public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
                                                                                    ^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/idn/idn.php:67
+            @trigger_error('idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:87
         $idna_info = array(
                      
@@ -13,6 +16,9 @@ MAYBE   phpdoc: Missing PHPDoc for \Symfony\Polyfill\Intl\Idn\Idn::idn_to_utf8 p
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:96
     public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
                                                                                   ^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/idn/idn.php:99
+            @trigger_error('idn_to_utf8(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:119
         $idna_info = array(
                      

--- a/src/tests/golden/testdata/inflector/golden.txt
+++ b/src/tests/golden/testdata/inflector/golden.txt
@@ -13,12 +13,12 @@ WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:123
         @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+MAYBE   phpdocType: Use bool type instead of boolean at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:142
+     * @param boolean $reset        If true, will unset default inflections for all
+              ^^^^^^^
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:165
         @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:181
         @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   phpdocType: Use bool type instead of boolean at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:142
-     * @param boolean $reset        If true, will unset default inflections for all
-              ^^^^^^^

--- a/src/tests/golden/testdata/inflector/golden.txt
+++ b/src/tests/golden/testdata/inflector/golden.txt
@@ -1,3 +1,24 @@
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:54
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:64
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:76
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:110
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please use the "ucwords" function instead.', __METHOD__), E_USER_DEPRECATED);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:123
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   phpdocType: use bool type instead of boolean on line 17 at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:149
     public static function rules(string $type, iterable $rules, bool $reset = false) : void
                            ^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:165
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:181
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -112,6 +112,9 @@ MAYBE   callSimplify: Could simplify to $this->stack[] = $value at testdata/must
 MAYBE   callSimplify: Could simplify to $this->blockStack[] = $value at testdata/mustache/src/Mustache/Context.php:49
         array_push($this->blockStack, $value);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/mustache/src/Mustache/Context.php:213
+            switch (gettype($frame)) {
+            ^
 MAYBE   ternarySimplify: Could rewrite as `$options['cache_file_mode'] ?? null` at testdata/mustache/src/Mustache/Engine.php:156
                 $mode  = isset($options['cache_file_mode']) ? $options['cache_file_mode'] : null;
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -145,6 +148,9 @@ MAYBE   phpdoc: Missing PHPDoc for \Mustache_Exception_UnknownTemplateException:
 WARNING regexpVet: '\w' intersects with '\d' in [\w\d\.] at testdata/mustache/src/Mustache/Loader/InlineLoader.php:115
             foreach (preg_split("/^@@(?= [\w\d\.]+$)/m", $data, -1) as $chunk) {
                                 ^^^^^^^^^^^^^^^^^^^^^^^
+WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/mustache/src/Mustache/Parser.php:307
+        switch ($name) {
+        ^
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Source/FilesystemSource.php:53
                 $this->stat = @stat($this->fileName);
                               ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -1,9 +1,21 @@
 MAYBE   ternarySimplify: Could rewrite as `$baseDir ?: 0` at testdata/mustache/src/Mustache/Autoloader.php:56
         $key = $baseDir ? $baseDir : 0;
                ^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:110
+            @mkdir($dirName, 0777, true);
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:140
+        if (false !== @file_put_contents($tempFile, $value)) {
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:141
+            if (@rename($tempFile, $fileName)) {
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   ternarySimplify: Could rewrite as `$this->fileMode ?? (0666 & ~umask())` at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:142
                 $mode = isset($this->fileMode) ? $this->fileMode : (0666 & ~umask());
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:143
+                @chmod($fileName, $mode);
+                ^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:99
                         isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -133,6 +145,9 @@ MAYBE   phpdoc: Missing PHPDoc for \Mustache_Exception_UnknownTemplateException:
 WARNING regexpVet: '\w' intersects with '\d' in [\w\d\.] at testdata/mustache/src/Mustache/Loader/InlineLoader.php:115
             foreach (preg_split("/^@@(?= [\w\d\.]+$)/m", $data, -1) as $chunk) {
                                 ^^^^^^^^^^^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Source/FilesystemSource.php:53
+                $this->stat = @stat($this->fileName);
+                              ^^^^^^^^^^^^^^^^^^^^^^
 WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/mustache/src/Mustache/Template.php:122
                 foreach ($value as $k => $v) {
                                          ^^

--- a/src/tests/golden/testdata/options-resolver/golden.txt
+++ b/src/tests/golden/testdata/options-resolver/golden.txt
@@ -34,3 +34,6 @@ MAYBE   typeHint: Specify the type for the parameter $values in PHPDoc, 'array' 
 MAYBE   typeHint: Specify the type for the parameter $options in PHPDoc, 'array' type hint too generic at testdata/options-resolver/OptionsResolver.php:1268
     private function formatOptions(array $options): string
                      ^^^^^^^^^^^^^
+WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/options-resolver/function.php:25
+        @trigger_error(($package || $version ? "Since $package $version: " : '').($args ? vsprintf($message, $args) : $message), E_USER_DEPRECATED);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/qrcode/golden.txt
+++ b/src/tests/golden/testdata/qrcode/golden.txt
@@ -19,6 +19,9 @@ MAYBE   trailingComma: Last element in a multi-line array should have a trailing
 WARNING unused: Variable $mode is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/qrcode/qrcode.php:177
     list($mode, $vers, $ec, $data) = $this->qr_encode_data($data, $ecl);
          ^^^^^
+WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:203
+    switch ($mode) {
+    ^
 WARNING undefined: Variable $code might have not been defined at testdata/qrcode/qrcode.php:221
     while (count($code) % 8) {
                  ^^^^^
@@ -28,18 +31,27 @@ WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testd
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:300
       case 1:  /* 10 - 26 */
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:296
+    switch ($version_group) {
+    ^
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:318
         case 3:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:322
         case 2:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:317
+      switch (strlen($group)) {
+      ^
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:341
       case 2:  /* 27 - 40 */
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:344
       case 1:  /* 10 - 26 */
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:340
+    switch ($version_group) {
+    ^
 MAYBE   callSimplify: Could simplify to $group[0] at testdata/qrcode/qrcode.php:361
         $c1     = strpos($alphabet, substr($group, 0, 1));
                                     ^^^^^^^^^^^^^^^^^^^^
@@ -49,6 +61,9 @@ MAYBE   callSimplify: Could simplify to $group[1] at testdata/qrcode/qrcode.php:
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:393
       case 1:  /* 10 - 26 */
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:391
+    switch ($version_group) {
+    ^
 MAYBE   callSimplify: Could simplify to $data[$i] at testdata/qrcode/qrcode.php:413
       $ch     = ord(substr($data, $i, 1));
                     ^^^^^^^^^^^^^^^^^^^^
@@ -58,12 +73,18 @@ WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testd
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:433
       case 1:  /* 10 - 26 */
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:429
+    switch ($version_group) {
+    ^
 MAYBE   callSimplify: Could simplify to $group[0] at testdata/qrcode/qrcode.php:448
       $c1    = ord(substr($group, 0, 1));
                    ^^^^^^^^^^^^^^^^^^^^
 MAYBE   callSimplify: Could simplify to $group[1] at testdata/qrcode/qrcode.php:449
       $c2    = ord(substr($group, 1, 1));
                    ^^^^^^^^^^^^^^^^^^^^
+WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:697
+    switch ($mask) {
+    ^
 ERROR   classMembersOrder: Property $qr_capacity must go before methods in the class QRCode at testdata/qrcode/qrcode.php:890
   private $qr_capacity = [
   ^^

--- a/src/tests/golden/testdata/quickfix/unaryRepeat.php
+++ b/src/tests/golden/testdata/quickfix/unaryRepeat.php
@@ -1,0 +1,15 @@
+<?php
+
+function unaryRepeat() {
+  $a = 100;
+
+  echo !$a;    // ok
+  echo !!$a;   // want `Several negations in a row does not make sense`
+  echo !!!$a;  // want `Several negations in a row does not make sense`
+  echo !!!!$a; // want `Several negations in a row does not make sense`
+
+  echo ~$a;     // ok
+  echo ~~$a;    // want `Several bitwise not (~) in a row does not make sense`
+  echo ~~~$a;   // want `Several bitwise not (~) in a row does not make sense`
+  echo ~~~~$a;  // want `Several bitwise not (~) in a row does not make sense`
+}

--- a/src/tests/golden/testdata/quickfix/unaryRepeat.php.fix.expected
+++ b/src/tests/golden/testdata/quickfix/unaryRepeat.php.fix.expected
@@ -1,0 +1,15 @@
+<?php
+
+function unaryRepeat() {
+  $a = 100;
+
+  echo !$a;    // ok
+  echo !!$a;   // want `Several negations in a row does not make sense`
+  echo !!!$a;  // want `Several negations in a row does not make sense`
+  echo !!!!$a; // want `Several negations in a row does not make sense`
+
+  echo ~$a;     // ok
+  echo $a;    // want `Several bitwise not (~) in a row does not make sense`
+  echo ~$a;   // want `Several bitwise not (~) in a row does not make sense`
+  echo $a;  // want `Several bitwise not (~) in a row does not make sense`
+}

--- a/src/tests/inline/testdata/checkers/dupBranchBody.php
+++ b/src/tests/inline/testdata/checkers/dupBranchBody.php
@@ -1,0 +1,83 @@
+<?php
+
+function dupBranchBody($a) {
+  switch ($a) {
+    case 1:
+      echo 1;
+      break;
+    case 2: // want `Branch 'case 2' in 'switch' is a duplicate`
+      echo 1;
+      break;
+  }
+
+  switch ($a) {
+    case 1:
+      echo 1;
+      break;
+    case 2: // want `Branch 'case 2' in 'switch' is a duplicate`
+      echo 1;
+      break;
+    case 3: // want `Branch 'case 3' in 'switch' is a duplicate`
+      echo 1;
+      break;
+  }
+
+  switch ($a) {
+    case 1:
+      echo 1;
+      break;
+    case 2: // ok
+      echo 2;
+      break;
+  }
+
+  switch ($a) {
+    case 1:
+    case 2: // ok
+      echo 2;
+      break;
+  }
+
+  switch ($a) {
+    case 1:
+    case 2: // ok
+      echo 2;
+      break;
+    case 3: // want `Branch 'case 3' in 'switch' is a duplicate`
+      echo 2;
+      break;
+  }
+
+  switch ($a) {
+    case 1: case 2: // ok
+      echo 2;
+      break;
+  }
+
+  switch ($a) {
+    case 1: case 2: // ok
+      echo 2;
+      break;
+    default:
+      echo 2;
+      break;
+  }
+
+  switch ($a) {
+    case 1: case 2: // ok
+      echo 2;
+      // fallthrough
+    default:
+      echo 2;
+      break;
+  }
+
+  switch ($a) {
+    case 1: case 2: // ok
+      echo 2;
+      // fallthrough
+    case 3:
+      echo 2;
+      break;
+  }
+}

--- a/src/tests/inline/testdata/checkers/switchDefault.php
+++ b/src/tests/inline/testdata/checkers/switchDefault.php
@@ -1,0 +1,150 @@
+<?php
+
+function switchDefaultShouldBeFirstOrLastRule($a) {
+  switch ($a) {
+    case 100:
+      echo 2;
+      break;
+    default: // want `'default' should be first or last to improve readability`
+      echo 100;
+      break;
+    case 101:
+      echo 3;
+      break;
+  }
+
+  switch ($a) {
+    case 100:
+      echo 2;
+      break;
+    case 102:
+      echo 4;
+      break;
+    default: // want `'default' should be first or last to improve readability`
+      echo 100;
+      break;
+    case 101:
+      echo 3;
+      break;
+  }
+
+  switch ($a) {
+    case 100:
+      echo 2;
+      break;
+    case 102:
+      echo 4;
+      break;
+    default: // want `'default' should be first or last to improve readability`
+      echo 100;
+      break;
+    case 103:
+      echo 5;
+      break;
+    case 101:
+      echo 3;
+      break;
+  }
+
+  switch ($a) {
+    case 100:
+      echo 2;
+      break;
+    default: // want `'default' should be first or last to improve readability`
+    case 101:
+      echo 3;
+      break;
+  }
+
+  switch ($a) {
+    case 100:
+      echo 2;
+      break;
+    case 101:
+    default: // ok
+      echo 3;
+      break;
+  }
+
+  switch ($a) {
+    case 102:
+    case 101:
+      echo 3;
+      break;
+    default: // ok
+      echo 100;
+      break;
+  }
+
+  switch ($a) {
+    case 100:
+      echo 2;
+      break;
+    case 101:
+      echo 3;
+      break;
+    default: // ok
+      echo 100;
+      break;
+  }
+
+  switch ($a) {
+    default: // ok
+      echo 100;
+      break;
+    case 100:
+      echo 2;
+      break;
+    case 101:
+      echo 3;
+      break;
+  }
+
+  switch ($a) {
+    default: // ok
+      echo 100;
+      break;
+    case 102:
+    case 100:
+      echo 2;
+      break;
+  }
+}
+
+function switchShouldContainDefault($a) {
+  switch ($a) { // want `Add 'default' branch to avoid unexpected unhandled condition values`
+    case 102:
+    case 103:
+    case 101:
+      echo 3;
+      break;
+  }
+
+  switch ($a) { // want `Add 'default' branch to avoid unexpected unhandled condition values`
+    case 102:
+    case 100:
+      echo 2;
+      break;
+    case 101:
+      echo 3;
+      break;
+  }
+
+  switch ($a) { // ok
+    case 102:
+    case 101:
+      echo 3;
+      break;
+    default:
+      echo 4;
+      break;
+  }
+
+  switch ($a) { // ok
+    case 101:
+    case 102:
+    default:
+      echo 4;
+      break;
+  }
+}

--- a/src/tests/inline/testdata/checkers/switchEmpty.php
+++ b/src/tests/inline/testdata/checkers/switchEmpty.php
@@ -1,0 +1,9 @@
+<?php
+
+function switchEmpty($a) {
+  switch ($a) { // want `Switch has empty body`
+
+  }
+
+  switch ($a) {} // want `Switch has empty body`
+}

--- a/src/tests/inline/testdata/checkers/switchSimplify.php
+++ b/src/tests/inline/testdata/checkers/switchSimplify.php
@@ -1,0 +1,51 @@
+<?php
+
+function switchSimplify($a) {
+  switch ($a) { // want `Switch can be rewritten into an 'if' statement to increase readability`
+    case 10:
+      echo 2;
+      break;
+  }
+
+  switch ($a) { // ok
+    case 10:
+      echo 2;
+      break;
+    case 11:
+      echo 3;
+      break;
+  }
+
+  switch ($a) { // ok
+    case 10:
+      echo 2;
+      break;
+    case 11:
+      echo 3;
+      break;
+    case 12:
+      echo 4;
+      break;
+  }
+
+  switch ($a) { // want `Switch can be rewritten into an 'if' statement to increase readability`
+    case 10:
+      echo 2;
+      break;
+    default:
+      echo 3;
+      break;
+  }
+
+  switch ($a) { // ok
+    case 10:
+      echo 2;
+      break;
+    case 11:
+      echo 4;
+      break;
+    default:
+      echo 3;
+      break;
+  }
+}

--- a/src/tests/inline/testdata/embeddedrules/alwaysNull.php
+++ b/src/tests/inline/testdata/embeddedrules/alwaysNull.php
@@ -1,0 +1,27 @@
+<?php
+
+class Foo {
+  public int $prop = 100;
+  public function method(): bool {return true; }
+  public function method2($a, $b): bool { return true; }
+}
+
+function alwaysNull() {
+  $obj = new Foo;
+
+  if ($obj == null && $obj->method()) { echo 1;} // want `'$obj' is always 'null', maybe you meant '$obj != null && ...' or '$obj == null || ...'`
+  if ($obj == null && $obj->method2(100, 200)) { echo 1;} // want `'$obj' is always 'null', maybe you meant '$obj != null && ...' or '$obj == null || ...'`
+  if ($obj == null && $obj->prop) { echo 1; } // want `'$obj' is always 'null', maybe you meant '$obj != null && ...' or '$obj == null || ...'`
+
+  if ($obj != null || $obj->method()) { echo 1;} // want `'$obj' is always 'null', maybe you meant '$obj == null || ...' or '$obj != null && ...'`
+  if ($obj != null || $obj->method2(100, 200)) { echo 1;} // want `'$obj' is always 'null', maybe you meant '$obj == null || ...' or '$obj != null && ...'`
+  if ($obj != null || $obj->prop) { echo 1; } // want `'$obj' is always 'null', maybe you meant '$obj == null || ...' or '$obj != null && ...'`
+
+  if ($obj == null || $obj->method()) { echo 1;}
+  if ($obj == null || $obj->method2(100, 200)) { echo 1;}
+  if ($obj == null || $obj->prop) { echo 1; }
+
+  if ($obj != null && $obj->method()) { echo 1;}
+  if ($obj != null && $obj->method2(100, 200)) { echo 1;}
+  if ($obj != null && $obj->prop) { echo 1; }
+}

--- a/src/tests/inline/testdata/embeddedrules/countUse.php
+++ b/src/tests/inline/testdata/embeddedrules/countUse.php
@@ -1,0 +1,81 @@
+<?php
+
+function countUse() {
+  $arr = [1, 2, 3];
+
+  // always true cases
+
+  if (count($arr) >= 0) { // want `this expression is always true`
+    echo 1;
+  }
+
+  if (0 <= count($arr)) { // want `this expression is always true`
+    echo 1;
+  }
+
+  if (count($arr) > 0) { // ok
+    echo 1;
+  }
+
+  if (0 < count($arr)) { // ok
+    echo 1;
+  }
+
+  if (count($arr) != 0) { // ok
+    echo 1;
+  }
+
+  if (0 != count($arr)) { // ok
+    echo 1;
+  }
+
+  if (count($arr) !== 0) { // ok
+    echo 1;
+  }
+
+  if (0 !== count($arr)) { // ok
+    echo 1;
+  }
+
+  if (count($arr)) { // ok
+    echo 1;
+  }
+
+  // always false cases
+
+  if (count($arr) < 0) { // want `this expression is always false`
+    echo 1;
+  }
+
+  if (0 > count($arr)) { // want `this expression is always false`
+    echo 1;
+  }
+
+  if (count($arr) <= 0) { // want `use count($arr) == 0 instead`
+    echo 1;
+  }
+
+  if (0 >= count($arr)) { // want `use 0 == count($arr) instead`
+    echo 1;
+  }
+
+  if (count($arr) == 0) { // ok
+    echo 1;
+  }
+
+  if (0 == count($arr)) { // ok
+    echo 1;
+  }
+
+  if (count($arr) === 0) { // ok
+    echo 1;
+  }
+
+  if (0 === count($arr)) { // ok
+    echo 1;
+  }
+
+  if (!count($arr)) { // ok
+    echo 1;
+  }
+}

--- a/src/tests/inline/testdata/embeddedrules/errorSilence.php
+++ b/src/tests/inline/testdata/embeddedrules/errorSilence.php
@@ -1,0 +1,13 @@
+<?php
+
+@include_once "file.php"; // want `Don't use @, silencing errors is bad practice`
+
+function g(): int { return 1; }
+function g1(): array { return [1]; }
+
+function errorSilence() {
+  @include_once "file.php"; // want `Don't use @, silencing errors is bad practice`
+
+  echo @g(); // want `Don't use @, silencing errors is bad practice`
+  echo @g1()[123]; // want `Don't use @, silencing errors is bad practice`
+}

--- a/src/tests/inline/testdata/embeddedrules/forLoop.php
+++ b/src/tests/inline/testdata/embeddedrules/forLoop.php
@@ -1,0 +1,99 @@
+<?php
+
+function forLoop(array $a) {
+  for ($i = 0; $i < count($a); $i--) { // want `Potentially infinite 'for' loop, because $i decreases and is always less than initial value 0 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 0; $i < count($a); $i -= 1) { // want `Potentially infinite 'for' loop, because $i decreases and is always less than initial value 0 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 0; $i < count($a); $i -= 100) { // want `Potentially infinite 'for' loop, because $i decreases and is always less than initial value 0 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 0; $i <= count($a); $i--) { // want `Potentially infinite 'for' loop, because $i decreases and is always less than initial value 0 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 0; $i <= count($a); $i -= 1) { // want `Potentially infinite 'for' loop, because $i decreases and is always less than initial value 0 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 0; $i <= count($a); $i -= 100) { // want `Potentially infinite 'for' loop, because $i decreases and is always less than initial value 0 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 100; $i > count($a); $i++) { // want `Potentially infinite 'for' loop, because $i increases and is always greater than initial value 100 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 100; $i > count($a); $i += 1) { // want `Potentially infinite 'for' loop, because $i increases and is always greater than initial value 100 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 100; $i > count($a); $i += 100) { // want `Potentially infinite 'for' loop, because $i increases and is always greater than initial value 100 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 100; $i >= count($a); $i++) { // want `Potentially infinite 'for' loop, because $i increases and is always greater than initial value 100 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 100; $i >= count($a); $i += 1) { // want `Potentially infinite 'for' loop, because $i increases and is always greater than initial value 100 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 100; $i >= count($a); $i += 100) { // want `Potentially infinite 'for' loop, because $i increases and is always greater than initial value 100 and, accordingly, count($a)`
+    echo $i;
+  }
+
+  for ($i = 0; $i < count($a); $i++) { // ok
+    echo $i;
+  }
+
+  for ($i = 0; $i < count($a); $i += 1) { // ok
+    echo $i;
+  }
+
+  for ($i = 0; $i < count($a); $i += 100) { // ok
+    echo $i;
+  }
+
+  for ($i = 0; $i <= count($a); $i++) { // ok
+    echo $i;
+  }
+
+  for ($i = 0; $i <= count($a); $i += 1) { // ok
+    echo $i;
+  }
+
+  for ($i = 0; $i <= count($a); $i += 100) { // ok
+    echo $i;
+  }
+
+  for ($i = 100; $i > count($a); $i--) { // ok
+    echo $i;
+  }
+
+  for ($i = 100; $i > count($a); $i -= 1) { // ok
+    echo $i;
+  }
+
+  for ($i = 100; $i > count($a); $i -= 100) { // ok
+    echo $i;
+  }
+
+  for ($i = 100; $i >= count($a); $i--) { // ok
+    echo $i;
+  }
+
+  for ($i = 100; $i >= count($a); $i -= 1) { // ok
+    echo $i;
+  }
+
+  for ($i = 100; $i >= count($a); $i -= 100) { // ok
+    echo $i;
+  }
+}

--- a/src/tests/inline/testdata/embeddedrules/selfAssign.php
+++ b/src/tests/inline/testdata/embeddedrules/selfAssign.php
@@ -1,0 +1,19 @@
+<?php
+
+class Foo {
+  private int $prop = 100;
+
+  public function f(int $prop) {
+    $prop = $prop; // want `Assignment to $prop itself does not make sense`
+    $this->prop = $prop;
+    $propNew = $prop;
+    echo $propNew;
+  }
+}
+
+function selfAssign() {
+  $c = 100;
+  $d = 100;
+  $c = $c; // want `Assignment to $c itself does not make sense`
+  $c = $d; // ok
+}

--- a/src/tests/inline/testdata/embeddedrules/unaryRepeat.php
+++ b/src/tests/inline/testdata/embeddedrules/unaryRepeat.php
@@ -1,0 +1,15 @@
+<?php
+
+function unaryRepeat() {
+  $a = 100;
+
+  echo !$a;    // ok
+  echo !!$a;   // want `Several negations in a row does not make sense`
+  echo !!!$a;  // want `Several negations in a row does not make sense`
+  echo !!!!$a; // want `Several negations in a row does not make sense`
+
+  echo ~$a;     // ok
+  echo ~~$a;    // want `Several bitwise not (~) in a row does not make sense`
+  echo ~~~$a;   // want `Several bitwise not (~) in a row does not make sense`
+  echo ~~~~$a;  // want `Several bitwise not (~) in a row does not make sense`
+}

--- a/src/tests/regression/issue170_test.go
+++ b/src/tests/regression/issue170_test.go
@@ -17,6 +17,8 @@ case 1:
 case 2:
   $_ = $v;
   break;
+default:
+  break;
 }
 
 function error() {}

--- a/src/tests/regression/issue252_test.go
+++ b/src/tests/regression/issue252_test.go
@@ -42,6 +42,8 @@ function alt_switch($v) {
     $v = 3;
   case 2:
     return $v;
+  default:
+    break;
   endswitch;
 }`)
 	test.Expect = []string{

--- a/src/tests/regression/issue78_test.go
+++ b/src/tests/regression/issue78_test.go
@@ -60,6 +60,8 @@ case 11:
   trailing_exit_switch($xs);
   echo "unreachable";
   break;
+default:
+  break;
 }
 
 class Exception {}
@@ -68,6 +70,10 @@ function trailing_exit_switch($xs) {
   switch($xs[0]) {
   case 1:
     die("ok");
+  case 2:
+    break;
+  default:
+    break;
   }
   exit;
 }
@@ -247,12 +253,18 @@ case 11:
   trailing_exit_switch($xs);
   echo "unreachable";
   break;
+default:
+  break;
 }
 
 class Exception {}
 
 function trailing_exit_switch($xs) {
   switch($xs[0]) {
+  default:
+    break;
+  case 2:
+    break;
   case 1:
     $_ = $xs[0];
   }
@@ -391,6 +403,10 @@ function trailing_exit_switch($xs) {
   switch($xs[0]) {
   case 1:
     return "ok";
+  case 2:
+    break;
+  default:
+    break;
   }
   exit;
 }


### PR DESCRIPTION
- countUse (https://rules.sonarsource.com/php/type/Bug/RSPEC-3981)
- improved `dupBranchBody` checker, added handling switch cases, and improved message for `dupCond` checkers for switch cases (https://rules.sonarsource.com/php/type/Bug/RSPEC-3923)
- unaryRepeat (https://rules.sonarsource.com/php/type/Bug/RSPEC-2761)
- forLoop (https://rules.sonarsource.com/php/type/Bug/RSPEC-2251)
- alwaysNull (https://rules.sonarsource.com/php/type/Bug/RSPEC-1697)
- selfAssign (https://rules.sonarsource.com/php/type/Bug/RSPEC-1656)
- errorSilence (https://rules.sonarsource.com/php/type/Bug/RSPEC-2002)
- switchDefault (https://rules.sonarsource.com/php/type/Code%20Smell/RSPEC-131 https://rules.sonarsource.com/php/type/Code%20Smell/RSPEC-4524)
- switchSimplify (https://rules.sonarsource.com/php/type/Code%20Smell/RSPEC-1301)
- switchEmpty