### PR TITLE
phpdoctypes: added support for mixing in `array{}`

### DIFF
--- a/src/phpdoc/type_parser_test.go
+++ b/src/phpdoc/type_parser_test.go
@@ -116,6 +116,9 @@ func TestParser(t *testing.T) {
 		{`array{0: int}`, `GenericBrace="array{0: int}"{Name="array" KeyVal="0: int"{Int="0" Name="int"}}`},
 		{`shape{s?: string}`, `GenericBrace="shape{s?: string}"{Name="shape" KeyVal="s?: string"{Optional="s?"{Name="s"} Name="string"}}`},
 		{`foo(A):B`, `KeyVal="foo(A):B"{GenericParen="foo(A)"{Name="foo" Name="A"} Name="B"}`},
+		{`array{int}`, `GenericBrace="array{int}"{Name="array" Name="int"}`},
+		{`array{int, string}`, `GenericBrace="array{int, string}"{Name="array" Name="int" Name="string"}`},
+		{`array{int, foo: string}`, `GenericBrace="array{int, foo: string}"{Name="array" Name="int" KeyVal="foo: string"{Name="foo" Name="string"}}`},
 
 		// MemberType.
 		{`\Foo::CONST`, `MemberType="\Foo::CONST"{Name="\Foo" Name="CONST"}`},

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -3055,6 +3055,57 @@ function f($arr, $arr1, $arr2, $arr3, $arr4, $arr5) {
 	runExprTypeTest(t, &exprTypeTestParams{code: code})
 }
 
+func TestArrayLikeShapeSyntax(t *testing.T) {
+	code := `<?php
+class Foo {}
+
+/**
+ * @param array{int, Foo} $a
+ */
+function f($a) {
+  exprtype($a[0], "int");
+  exprtype($a[1], "\Foo");
+}
+
+/**
+ * @param array{id: int, Foo} $a
+ */
+function f($a) {
+  exprtype($a["id"], "int");
+  exprtype($a[1], "\Foo");
+}
+
+/**
+ * @param array{Foo, id: int} $a
+ */
+function f($a) {
+  exprtype($a[0], "\Foo");
+  exprtype($a["id"], "int");
+}
+
+/**
+ * @param array{foo: Foo, int, id: int} $a
+ */
+function f($a) {
+  exprtype($a["foo"], "\Foo");
+  exprtype($a[1], "int");
+  exprtype($a["id"], "int");
+}
+
+/**
+ * @param array{foo: Foo, int, string, id: int, Foo} $a
+ */
+function f($a) {
+  exprtype($a["foo"], "\Foo");
+  exprtype($a[1], "int");
+  exprtype($a[2], "string");
+  exprtype($a["id"], "int");
+  exprtype($a[4], "\Foo");
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
 func TestArrayTypeCast(t *testing.T) {
 	code := `<?php
 class Foo {}


### PR DESCRIPTION
For example:

```php
/**
 * @param array{int, name: string} is shape<0: int, name: string>
 * @param array{name: string, int} is shape<1: int, name: string>
 */
```

> This syntax is correct for Psalm.