### PR TITLE
linter: added support when no variable is specified for `@var`

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -257,6 +257,11 @@ func (b *blockWalker) handleCommentToken(n ir.Node, t *token.Token) {
 			)
 		}
 
+		simpleVar, isSimpleVar := n.(*ir.SimpleVar)
+		if isSimpleVar && part.Var == "" {
+			part.Var = simpleVar.Name
+		}
+
 		typesMap := types.NewMapWithNormalization(b.r.ctx.typeNormalizer, converted.Types)
 		b.ctx.sc.AddVarFromPHPDoc(strings.TrimPrefix(part.Var, "$"), typesMap, "@var")
 	}

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -3599,7 +3599,7 @@ function f($a) {
     exit(0);
   }
 
-  exprtype($add_res, "int")
+  exprtype($add_res, "precise int");
 }
 
 function f2($a) {
@@ -3628,6 +3628,48 @@ function f2($a) {
 
   exprtype($add_res, "int");
   exprtype($add_res2, "string");
+}
+`
+	runExprTypeTest(t, &exprTypeTestParams{code: code})
+}
+
+func TestVarAnnotationWithoutVariable(t *testing.T) {
+	code := `<?php
+function exprtype(...$a): bool { return false; }
+
+class Foo {
+  public $prop = 0;
+
+  function f() {}
+}
+
+class Boo  {
+  function b() {}
+}
+
+function f($a) {
+  /**
+   * Ok 
+   * @var Foo
+   */
+  $b = $a;
+  exprtype($b, "\Foo|mixed");
+
+  /**
+   * Not working 
+   * @var Boo
+   */
+  $b->prop = $a;
+  exprtype($b->prop, "int");
+
+  /**
+   * Not working  
+   * @var Foo
+   */
+  [$c, $d] = $a;
+
+  exprtype($c, "unknown_from_list");
+  exprtype($d, "unknown_from_list");
 }
 `
 	runExprTypeTest(t, &exprTypeTestParams{code: code})


### PR DESCRIPTION
Now, if there is a variable on the left of the assignment, then
the type from `@var` is set for it, even if the variable name is
not specified.

Before:

```php
function f($a) {
  /**
   * @var Foo
   */
  $b = $a;
  exprtype($b, "mixed");
}
```

After:
```php
function f($a) {
  /**
   * @var Foo
   */
  $b = $a;
  exprtype($b, "\Foo|mixed");
}
```

Used and supported by Psalm.
Reduces the number of `undefined` reports by 64 when parsing Psalm.