### PR TITLE
irconv: fixed PHPDoc for class with modifiers

### DIFF
--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -2220,7 +2220,13 @@ func (c *Converter) convClass(n *ast.StmtClass) ir.Node {
 		}
 	}
 
-	class.Doc = c.getPhpDoc(n.ClassTkn)
+	// If there are modifiers, then PHPDoc will be bound to the
+	// first one, otherwise to the class token.
+	if len(n.Modifiers) != 0 {
+		class.Doc = c.getPhpDoc(ir.GetFirstToken(c.convNode(n.Modifiers[0])))
+	} else {
+		class.Doc = c.getPhpDoc(n.ClassTkn)
+	}
 
 	if n.Name == nil {
 		// Anonymous class expression.

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -294,6 +294,64 @@ $_ = WithProps::$int;
 	test.RunAndMatch()
 }
 
+func TestPhpdocPropertyForClassWithModifiers(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+/**
+ * @property int $int
+ * @property string $string - optional description.
+ * @property-read string $name Name of the class
+ */
+abstract class WithPropsBase {
+  /***/
+  public function getInt() {
+    return $this->int;
+  }
+  /***/
+  public function getString() {
+    return $this->string;
+  }
+}
+
+/**
+ * @property int $int1
+ * @property string $string1 - optional description.
+ * @property-read string $name1 Name of the class
+ */
+final class WithProps extends WithPropsBase {}
+
+$_ = (new WithProps())->int;
+$_ = (new WithProps())->string;
+
+function f(WithProps $x) {
+  return $x->int + $x->int1;
+}
+
+/**
+ * @param WithProps|null $y
+ */
+function f2($y = null) {
+  echo $y->name;
+  echo $y->string1;
+}
+
+// Can't access them as static props/constants.
+$_ = WithProps::int;
+$_ = WithProps::int1;
+$_ = WithProps::$int;
+$_ = WithProps::$int1;
+`)
+
+	test.Expect = []string{
+		`Class constant \WithProps::int does not exist`,
+		`Class constant \WithProps::int1 does not exist`,
+		`Property \WithProps::$int does not exist`,
+		`Property \WithProps::$int1 does not exist`,
+	}
+
+	test.RunAndMatch()
+}
+
 func TestInheritDoc(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php


### PR DESCRIPTION
Previously, if a class had modifiers, then PHPDoc was not attached to the class.