### PR TITLE
linter: added `methodSignatureMismatch` checker

### DIFF
--- a/src/ir/irutil/irtutil.go
+++ b/src/ir/irutil/irtutil.go
@@ -146,3 +146,23 @@ func classClone(x ir.Class) ir.Class {
 		Stmts:      NodeSliceClone(x.Stmts),
 	}
 }
+
+func FindClassMethodNode(n ir.Node, name string) *ir.ClassMethodStmt {
+	class, ok := n.(*ir.ClassStmt)
+	if !ok {
+		return nil
+	}
+
+	for _, stmt := range class.Stmts {
+		method, ok := stmt.(*ir.ClassMethodStmt)
+		if !ok {
+			continue
+		}
+
+		if method.MethodName.Value == name {
+			return method
+		}
+	}
+
+	return nil
+}

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -816,6 +816,27 @@ class Boo extends Foo {}`,
 			After: `class Foo {}
 class Boo extends Foo {}`,
 		},
+
+		{
+			Name:     "methodSignatureMismatch",
+			Default:  true,
+			Quickfix: false,
+			Comment:  `Report a method signature mismatch in inheritance.`,
+			Before: `class Foo {
+  final public function f() {}
+}
+
+class Boo extends Foo {
+  public function f() {} // Foo::f is final.
+}`,
+			After: `class Foo {
+  public function f() {}
+}
+
+class Boo extends Foo {
+  public function f() {}
+}`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -78,6 +78,7 @@ func (info *FuncInfo) IsStatic() bool         { return info.Flags&FuncStatic != 
 func (info *FuncInfo) IsAbstract() bool       { return info.Flags&FuncAbstract != 0 }
 func (info *FuncInfo) IsPure() bool           { return info.Flags&FuncPure != 0 }
 func (info *FuncInfo) IsFromAnnotation() bool { return info.Flags&FuncFromAnnotation != 0 }
+func (info *FuncInfo) IsFinal() bool          { return info.Flags&FuncFinal != 0 }
 
 type OverrideType int
 

--- a/src/tests/inline/testdata/checkers/methodSignatureMismatch.php
+++ b/src/tests/inline/testdata/checkers/methodSignatureMismatch.php
@@ -1,0 +1,13 @@
+<?php
+
+class Foo {
+  final public function f() {}
+  final private function f1() {}
+  final protected function f2() {}
+}
+
+class Boo extends Foo {
+  public function f() {} // want `Method \Foo::f is declared final and cannot be overridden`
+  public function f1() {} // ok
+  public function f2() {} // want `Method \Foo::f2 is declared final and cannot be overridden`
+}


### PR DESCRIPTION
It checks that the method does not override the final method from the base class.