### PR TITLE
linter: added `argsReverse` checker

### DIFF
--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -914,7 +914,7 @@ func (b *blockLinter) checkArgsOrder(fun ir.Node, args []ir.Node, fn meta.FuncIn
 	}
 
 	if firstVar.Name == fn.Params[1].Name && secondVar.Name == fn.Params[0].Name {
-		b.report(fun, LevelWarning, "argsMessedUp", "Perhaps the order of the arguments is messed up, $%[1]s is passed to the $%[2]s parameter, and $%[2]s is passed to the $%[1]s parameter", firstVar.Name, secondVar.Name)
+		b.report(fun, LevelWarning, "argsReverse", "Perhaps the order of the arguments is messed up, $%[1]s is passed to the $%[2]s parameter, and $%[2]s is passed to the $%[1]s parameter", firstVar.Name, secondVar.Name)
 	}
 }
 

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -892,6 +892,30 @@ func (b *blockLinter) checkFunctionAvailability(e *ir.FunctionCallExpr, call *fu
 
 func (b *blockLinter) checkCallArgs(fun ir.Node, args []ir.Node, fn meta.FuncInfo, callerClass string) {
 	b.checkCallArgsCount(fun, args, fn, callerClass)
+	b.checkArgsOrder(fun, args, fn)
+}
+
+func (b *blockLinter) checkArgsOrder(fun ir.Node, args []ir.Node, fn meta.FuncInfo) {
+	if len(args) != 2 || len(fn.Params) < 2 {
+		return
+	}
+
+	firstArg := args[0].(*ir.Argument)
+	secondArg := args[1].(*ir.Argument)
+
+	firstVar, ok := firstArg.Expr.(*ir.SimpleVar)
+	if !ok {
+		return
+	}
+
+	secondVar, ok := secondArg.Expr.(*ir.SimpleVar)
+	if !ok {
+		return
+	}
+
+	if firstVar.Name == fn.Params[1].Name && secondVar.Name == fn.Params[0].Name {
+		b.report(fun, LevelWarning, "argsMessedUp", "Perhaps the order of the arguments is messed up, $%[1]s is passed to the $%[2]s parameter, and $%[2]s is passed to the $%[1]s parameter", firstVar.Name, secondVar.Name)
+	}
 }
 
 func (b *blockLinter) checkCallArgsCount(fun ir.Node, args []ir.Node, fn meta.FuncInfo, callerClass string) {

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -842,7 +842,7 @@ class Boo extends Foo {
 			// Checker can give many false positives, however it is
 			// useful for periodic checking when you can choose what
 			// appears to be a real error.
-			Name:     "argsMessedUp",
+			Name:     "argsReverse",
 			Default:  false,
 			Quickfix: false,
 			Comment:  `Report using variables as arguments in reverse order.`,

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -837,6 +837,34 @@ class Boo extends Foo {
   public function f() {}
 }`,
 		},
+
+		{
+			// Checker can give many false positives, however it is
+			// useful for periodic checking when you can choose what
+			// appears to be a real error.
+			Name:     "argsMessedUp",
+			Default:  false,
+			Quickfix: false,
+			Comment:  `Report using variables as arguments in reverse order.`,
+			Before: `function makeHello(string $name, int $age) {
+  echo "Hello ${$name}-${$age}";
+}
+
+function main(): void {
+  $name = "John";
+  $age = 18;
+  makeHello($age, $name); // The name should come first, and then the age.
+}`,
+			After: `function makeHello(string $name, int $age) {
+  echo "Hello ${$name}-${$age}";
+}
+
+function main(): void {
+  $name = "John";
+  $age = 18;
+  makeHello($name, $age);
+}`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/tests/checkers/functions_test.go
+++ b/src/tests/checkers/functions_test.go
@@ -110,5 +110,5 @@ function main(): void {
 	test.Expect = []string{
 		`Perhaps the order of the arguments is messed up, $age is passed to the $name parameter, and $name is passed to the $age parameter`,
 	}
-	linttest.RunFilterMatch(test, "argsMessedUp")
+	linttest.RunFilterMatch(test, "argsReverse")
 }


### PR DESCRIPTION
It checks if parameters are passed in reverse order.
For functions with two parameters only.