### PR TITLE
cmd: exported `ParseExternalRules` and `ParseExternalRules` functions

### DIFF
--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -11,7 +11,7 @@ func Check(ctx *AppContext) (int, error) {
 
 	bindConfigValuesWithFlags(ctx, config)
 
-	ruleSets, err := parseExternalRules(ctx.ParsedFlags.RulesList)
+	ruleSets, err := ParseExternalRules(ctx.ParsedFlags.RulesList)
 	if err != nil {
 		return 1, fmt.Errorf("preload external rules: %v", err)
 	}

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -94,7 +94,7 @@ func Run(cfg *MainConfig) (int, error) {
 
 	cfg.linter = linter.NewLinter(config)
 
-	ruleSets, err := parseEmbeddedRules()
+	ruleSets, err := ParseEmbeddedRules()
 	if err != nil {
 		return 1, fmt.Errorf("preload embedded rules: %v", err)
 	}


### PR DESCRIPTION
This is necessary to load the rules into the playground.