### PR TITLE
linter: added `NewLinterWithInfo` function

### DIFF
--- a/src/linter/linter.go
+++ b/src/linter/linter.go
@@ -25,6 +25,14 @@ func NewLinter(config *Config) *Linter {
 	}
 }
 
+func NewLinterWithInfo(config *Config, info *meta.Info) *Linter {
+	return &Linter{
+		config: config,
+		info:   info,
+		checks: NewCheckersFilterWithEnabledAll(),
+	}
+}
+
 func (l *Linter) Config() *Config {
 	return l.config
 }


### PR DESCRIPTION
See #1067

After we clone `Info`, we need to create a linter with this 
particular instance of `Info` structure, so we need this constructor.