### PR TITLE
cmd: export `LinterRunner` struct

### DIFF
--- a/src/cmd/git_main.go
+++ b/src/cmd/git_main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/VKCOM/noverify/src/workspace"
 )
 
-func gitParseUntracked(l *linterRunner) []*linter.Report {
+func gitParseUntracked(l *LinterRunner) []*linter.Report {
 	if !l.flags.GitIncludeUntracked {
 		return nil
 	}
@@ -24,7 +24,7 @@ func gitParseUntracked(l *linterRunner) []*linter.Report {
 	return l.linter.AnalyzeFiles(workspace.ReadFilenames(filenames, nil, l.config.PhpExtensions))
 }
 
-func parseIndexOnlyFiles(l *linterRunner) {
+func parseIndexOnlyFiles(l *LinterRunner) {
 	if l.flags.IndexOnlyFiles == "" {
 		return
 	}
@@ -34,7 +34,7 @@ func parseIndexOnlyFiles(l *linterRunner) {
 
 // Not the best name, and not the best function signature.
 // Refactor this function whenever you get the idea how to separate logic better.
-func gitRepoComputeReportsFromCommits(l *linterRunner, logArgs, diffArgs []string) (oldReports, reports []*linter.Report, changes []git.Change, changeLog []git.Commit, ok bool) {
+func gitRepoComputeReportsFromCommits(l *LinterRunner, logArgs, diffArgs []string) (oldReports, reports []*linter.Report, changes []git.Change, changeLog []git.Commit, ok bool) {
 	// TODO(quasilyte): hard to replace fatalf with error return here. Use panicf for now.
 
 	changeLog, err := git.Log(l.flags.GitRepo, logArgs)
@@ -110,7 +110,7 @@ func gitRepoComputeReportsFromCommits(l *linterRunner, logArgs, diffArgs []strin
 	return oldReports, reports, changes, changeLog, true
 }
 
-func gitRepoComputeReportsFromLocalChanges(l *linterRunner) (oldReports, reports []*linter.Report, changes []git.Change, ok bool) {
+func gitRepoComputeReportsFromLocalChanges(l *LinterRunner) (oldReports, reports []*linter.Report, changes []git.Change, ok bool) {
 	// TODO(quasilyte): hard to replace fatalf with error return here. Use panicf for now.
 
 	if l.flags.GitWorkTree == "" {
@@ -156,7 +156,7 @@ func gitRepoComputeReportsFromLocalChanges(l *linterRunner) (oldReports, reports
 	return oldReports, reports, changes, true
 }
 
-func gitMain(l *linterRunner, cfg *MainConfig) (int, error) {
+func gitMain(l *LinterRunner, cfg *MainConfig) (int, error) {
 	var (
 		oldReports, reports []*linter.Report
 		diffArgs            []string
@@ -207,7 +207,7 @@ func gitMain(l *linterRunner, cfg *MainConfig) (int, error) {
 	return 0, nil
 }
 
-func analyzeGitAuthorsWhiteList(l *linterRunner, changeLog []git.Commit) (shouldRun bool) {
+func analyzeGitAuthorsWhiteList(l *LinterRunner, changeLog []git.Commit) (shouldRun bool) {
 	if l.flags.GitAuthorsWhitelist != "" {
 		whiteList := make(map[string]bool)
 		for _, name := range strings.Split(l.flags.GitAuthorsWhitelist, ",") {
@@ -225,7 +225,7 @@ func analyzeGitAuthorsWhiteList(l *linterRunner, changeLog []git.Commit) (should
 	return true
 }
 
-func prepareGitArgs(l *linterRunner) (logArgs, diffArgs []string, err error) {
+func prepareGitArgs(l *LinterRunner) (logArgs, diffArgs []string, err error) {
 	if l.flags.GitPushArg != "" {
 		args := strings.Fields(l.flags.GitPushArg)
 		if len(args) != 3 {
@@ -271,6 +271,6 @@ func prepareGitArgs(l *linterRunner) (logArgs, diffArgs []string, err error) {
 }
 
 // This function is a kludge to make old git-related code work without many modifications.
-func resetMetaInfo(l *linterRunner) {
+func resetMetaInfo(l *LinterRunner) {
 	l.linter = linter.NewLinter(l.config)
 }

--- a/src/cmd/linter_runner.go
+++ b/src/cmd/linter_runner.go
@@ -17,7 +17,7 @@ import (
 	"github.com/VKCOM/noverify/src/workspace"
 )
 
-type linterRunner struct {
+type LinterRunner struct {
 	flags *ParsedFlags
 
 	linter         *linter.Linter
@@ -29,7 +29,7 @@ type linterRunner struct {
 	filenameFilter *workspace.FilenameFilter
 }
 
-func (l *linterRunner) collectGitIgnoreFiles() error {
+func (l *LinterRunner) collectGitIgnoreFiles() error {
 	l.filenameFilter = workspace.NewFilenameFilter(l.config.ExcludeRegex)
 
 	if !l.flags.Gitignore {
@@ -68,7 +68,7 @@ func (l *linterRunner) collectGitIgnoreFiles() error {
 	return nil
 }
 
-func (l *linterRunner) Init(ruleSets []*rules.Set, flags *ParsedFlags) error {
+func (l *LinterRunner) Init(ruleSets []*rules.Set, flags *ParsedFlags) error {
 	l.flags = flags
 
 	if err := l.collectGitIgnoreFiles(); err != nil {
@@ -115,7 +115,7 @@ func (l *linterRunner) Init(ruleSets []*rules.Set, flags *ParsedFlags) error {
 	return nil
 }
 
-func (l *linterRunner) addVendorFolderToIndex(flags *ParsedFlags) {
+func (l *LinterRunner) addVendorFolderToIndex(flags *ParsedFlags) {
 	if flags.IgnoreVendor {
 		return
 	}
@@ -152,7 +152,7 @@ func (l *linterRunner) addVendorFolderToIndex(flags *ParsedFlags) {
 	}
 }
 
-func (l *linterRunner) initBaseline() error {
+func (l *LinterRunner) initBaseline() error {
 	if l.flags.Baseline == "" {
 		return nil
 	}
@@ -170,7 +170,7 @@ func (l *linterRunner) initBaseline() error {
 	return nil
 }
 
-func (l *linterRunner) compileRegexes() error {
+func (l *LinterRunner) compileRegexes() error {
 	if l.flags.ReportsExclude != "" {
 		var err error
 		l.config.ExcludeRegex, err = regexp.Compile(l.flags.ReportsExclude)
@@ -208,7 +208,7 @@ func (l *linterRunner) compileRegexes() error {
 	return nil
 }
 
-func (l *linterRunner) initCheckMappings(ruleSets []*rules.Set) *linter.CheckersFilter {
+func (l *LinterRunner) initCheckMappings(ruleSets []*rules.Set) *linter.CheckersFilter {
 	stringToSet := func(s string) map[string]bool {
 		set := make(map[string]bool)
 		for _, name := range strings.Split(s, ",") {
@@ -250,7 +250,7 @@ func (l *linterRunner) initCheckMappings(ruleSets []*rules.Set) *linter.Checkers
 	return l.checkersFilter
 }
 
-func (l *linterRunner) initRules(ruleSets []*rules.Set) error {
+func (l *LinterRunner) initRules(ruleSets []*rules.Set) error {
 	ruleFilter := func(r rules.Rule) bool {
 		return l.checkersFilter.IsEnabledCheck(r.Name)
 	}

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -173,7 +173,7 @@ func mainNoExit(ctx *AppContext) (int, error) {
 	lint := ctx.MainConfig.linter
 	ruleSets := ctx.MainConfig.rulesSets
 
-	runner := linterRunner{
+	runner := LinterRunner{
 		config:         lint.Config(),
 		linter:         lint,
 		checkersFilter: linter.NewCheckersFilter(),
@@ -238,7 +238,7 @@ func mainNoExit(ctx *AppContext) (int, error) {
 	return 0, nil
 }
 
-func createBaseline(l *linterRunner, cfg *MainConfig, reports []*linter.Report) error {
+func createBaseline(l *LinterRunner, cfg *MainConfig, reports []*linter.Report) error {
 	var stats baseline.Stats
 	stats.CountPerCheck = make(map[string]int)
 
@@ -330,7 +330,7 @@ func haveAutofixableReports(config *linter.Config, reports []*linter.Report) boo
 	return false
 }
 
-func analyzeReports(l *linterRunner, cfg *MainConfig, diff []*linter.Report) (criticalReports, minorReports int, containsAutofixableReports bool) {
+func analyzeReports(l *LinterRunner, cfg *MainConfig, diff []*linter.Report) (criticalReports, minorReports int, containsAutofixableReports bool) {
 	filtered := make([]*linter.Report, 0, len(diff))
 
 	for _, r := range diff {


### PR DESCRIPTION
We need to use `LinterRunner` to properly initialize the linter for Playground.