### PR TITLE
solver: fixed type inference for the functions starts with a backslash

### DIFF
--- a/src/solver/exprtype.go
+++ b/src/solver/exprtype.go
@@ -499,7 +499,7 @@ func functionCallType(n *ir.FunctionCallExpr, sc *meta.Scope, cs *meta.ClassPars
 	case *ir.Name:
 		if nm.IsFullyQualified() {
 			if nm.NumParts() == 1 {
-				typ, ok := internalFuncType(strings.TrimPrefix(nm.Value, `\`), sc, cs, n, custom)
+				typ, ok := internalFuncType(nm.Value, sc, cs, n, custom)
 				if ok {
 					return typ
 				}

--- a/src/tests/regression/issue1071_test.go
+++ b/src/tests/regression/issue1071_test.go
@@ -1,0 +1,32 @@
+package regression_test
+
+import (
+	"testing"
+
+	"github.com/VKCOM/noverify/src/linttest"
+)
+
+func TestIssue1071FunctionWithBackSlash(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.LoadStubs = []string{
+		"stubs/phpstorm-stubs/standard/standard_8.php",
+		"stubs/phpstorm-stubs/meta/.phpstorm.meta.php",
+	}
+	test.AddFile(`<?php
+class Foo {
+  /**
+   * @return int
+   */
+  public function f(): int { return 0; }
+}
+
+function f() {
+  $a = [new Foo];
+  $b = reset($a);
+  $b1 = \reset($a);
+  echo $b->f();
+  echo $b1->f();
+}
+`)
+	test.RunAndMatch()
+}


### PR DESCRIPTION
Fixes #1071 