### PR TITLE
cmd: improved `strangeCast` checker

### DIFF
--- a/src/cmd/embeddedrules/rules.php
+++ b/src/cmd/embeddedrules/rules.php
@@ -438,9 +438,7 @@ function langDeprecated() {
 }
 
 /**
- * @comment Report a strange way of type cast.
- * @before  $x.""
- * @after   (string)$x
+ * @extends
  */
 function strangeCast() {
     /**
@@ -460,11 +458,6 @@ function strangeCast() {
         0 + $x;
         0.0 + $x;
     }
-
-    /**
-     * @warning Unary plus, possible type cast, use an explicit cast to int or float instead of using the unary plus
-     */
-    +$x;
 }
 
 /**

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -71,11 +71,7 @@ func (b *blockLinter) enterNode(n ir.Node) {
 		b.checkGlobalStmt(n)
 
 	case *ir.UnaryPlusExpr:
-		val := constfold.Eval(b.classParseState(), n.Expr)
-		if val.IsValid() {
-			return
-		}
-		b.report(n, LevelWarning, "strangeCast", "Unary plus with non-constant expression, possible type cast, use an explicit cast to int or float instead of using the unary plus")
+		b.checkUnaryPlus(n)
 
 	case *ir.BitwiseAndExpr:
 		b.checkBitwiseOp(n, n.Left, n.Right)
@@ -194,6 +190,15 @@ func (b *blockLinter) enterNode(n ir.Node) {
 	case *ir.BadString:
 		b.report(n, LevelError, "syntax", "%s", n.Error)
 	}
+}
+
+func (b *blockLinter) checkUnaryPlus(n *ir.UnaryPlusExpr) {
+	val := constfold.Eval(b.classParseState(), n.Expr)
+	if val.IsValid() {
+		return
+	}
+
+	b.report(n, LevelWarning, "strangeCast", "Unary plus with non-constant expression, possible type cast, use an explicit cast to int or float instead of using the unary plus")
 }
 
 func (b *blockLinter) checkClass(class *ir.ClassStmt) {

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -70,6 +70,13 @@ func (b *blockLinter) enterNode(n ir.Node) {
 	case *ir.GlobalStmt:
 		b.checkGlobalStmt(n)
 
+	case *ir.UnaryPlusExpr:
+		val := constfold.Eval(b.classParseState(), n.Expr)
+		if val.IsValid() {
+			return
+		}
+		b.report(n, LevelWarning, "strangeCast", "Unary plus with non-constant expression, possible type cast, use an explicit cast to int or float instead of using the unary plus")
+
 	case *ir.BitwiseAndExpr:
 		b.checkBitwiseOp(n, n.Left, n.Right)
 	case *ir.BitwiseOrExpr:

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -882,6 +882,15 @@ function main(): void {
   makeHello($name, $age);
 }`,
 		},
+
+		{
+			Name:     "strangeCast",
+			Default:  true,
+			Quickfix: false,
+			Comment:  `Report a strange way of type cast.`,
+			Before:   `$x.""`,
+			After:    `(string)$x`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/tests/inline/testdata/embeddedrules/strangeCast.php
+++ b/src/tests/inline/testdata/embeddedrules/strangeCast.php
@@ -1,5 +1,7 @@
 <?php
 
+const A = 10;
+
 function strangeCast() {
     $x = 100;
 
@@ -10,12 +12,14 @@ function strangeCast() {
 
     $y = "10";
 
-    $_ = 0 + $y; // want `Addition with zero, possible type cast, use an explicit cast to int or float instead of zero addition`
-    $_ = $y + 10; // ok
+    $_ = 0 + $y;   // want `Addition with zero, possible type cast, use an explicit cast to int or float instead of zero addition`
+    $_ = $y + 10;  // ok
     $_ = 0.0 + $y; // want `Addition with zero, possible type cast, use an explicit cast to int or float instead of zero addition`
 
     $string = "10";
 
-    $_ = +$string; // want `Unary plus, possible type cast, use an explicit cast to int or float instead of using the unary plus`
+    $_ = +$string; // want `Unary plus with non-constant expression, possible type cast, use an explicit cast to int or float instead of using the unary plus`
+    $_ = +100;     // ok, constant expression
+    $_ = +A;       // ok, constant expression
     $_ = -$string; // ok, unary minus
 }


### PR DESCRIPTION
Now no warning will be issued for unary plus with
constant expression.

For example:
```php
$a = +100;
$a = +CONST_A;
```