### PR TITLE
linter: added `reverseAssign` checker

### DIFF
--- a/docs/checkers_doc.md
+++ b/docs/checkers_doc.md
@@ -4,7 +4,7 @@
 
 | Total checks | Checks enabled by default | Disabled checks by default | Autofixable checks |
 | ------------ | ------------------------- | -------------------------- | ------------------ |
-| 87           | 77                        | 10                         | 12                 |
+| 88           | 78                        | 10                         | 12                 |
 ## Table of contents
  - Enabled by default
    - [`accessLevel` checker](#accesslevel-checker)
@@ -68,6 +68,7 @@
    - [`regexpSyntax` checker](#regexpsyntax-checker)
    - [`regexpVet` checker](#regexpvet-checker)
    - [`returnAssign` checker](#returnassign-checker)
+   - [`reverseAssign` checker](#reverseassign-checker)
    - [`selfAssign` checker](#selfassign-checker)
    - [`stdInterface` checker](#stdinterface-checker)
    - [`strangeCast` checker](#strangecast-checker)
@@ -1336,6 +1337,24 @@ return $a = 100;
 #### Compliant code:
 ```php
 return $a;
+```
+<p><br></p>
+
+
+### `reverseAssign` checker
+
+#### Description
+
+Report a reverse assign with unary plus or minus.
+
+#### Non-compliant code:
+```php
+$a =+ 100;
+```
+
+#### Compliant code:
+```php
+$a += 100;
 ```
 <p><br></p>
 

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -905,9 +905,9 @@ function main(): void {
 			Name:     "reverseAssign",
 			Default:  true,
 			Quickfix: false,
-			Comment:  `Report a strange way of type cast.`,
-			Before:   `$x.""`,
-			After:    `(string)$x`,
+			Comment:  `Report a reverse assign with unary plus or minus.`,
+			Before:   `$a =+ 100;`,
+			After:    `$a += 100;`,
 		},
 	}
 

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -900,6 +900,15 @@ function main(): void {
 			Before:   `$x.""`,
 			After:    `(string)$x`,
 		},
+
+		{
+			Name:     "reverseAssign",
+			Default:  true,
+			Quickfix: false,
+			Comment:  `Report a strange way of type cast.`,
+			Before:   `$x.""`,
+			After:    `(string)$x`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/tests/inline/testdata/checkers/reverseAssign.php
+++ b/src/tests/inline/testdata/checkers/reverseAssign.php
@@ -1,0 +1,21 @@
+<?php
+
+function reverseAssign($b) {
+    $a = 100;
+
+    $a += $b; // ok
+    $a =+ $b; // want `Possible there should be '+='`
+    $a =+$b;  // want `Possible there should be '+='`
+    $a=+$b;   // ok
+    $a= +$b;  // ok
+    $a = +$b; // ok
+
+    $a -= $b; // ok
+    $a =- $b; // want `Possible there should be '-='`
+    $a =-$b;  // want `Possible there should be '-='`
+    $a=-$b;   // ok
+    $a= -$b;  // ok
+    $a = -$b; // ok
+
+    echo $a;
+}


### PR DESCRIPTION
For example:

```php
$a =- 100;
// or
$a =+ 100;
```