### PR TITLE
linter: fix regexp modifiers analysis

### DIFF
--- a/src/tests/inline/testdata/checkers/regexpVet.php
+++ b/src/tests/inline/testdata/checkers/regexpVet.php
@@ -1,0 +1,13 @@
+<?php
+
+$options = [];
+$s = 'efdfw';
+
+preg_match('/clipFrom/([0-9]+)', $options['foo'], $match); // want `invalid modifier (`
+
+preg_match('/foo/-i', $s); // want `invalid modifier -`
+
+// Good modifiers.
+preg_match('/foo/imsxADSUXJu', $s);
+preg_match('/foo/imsx', $s);
+preg_match('/foo/mi', $s);


### PR DESCRIPTION
Do not analyze modifiers when there is an invalid modifier
char in the top-level modifiers group.