### PR TITLE
linter: fixed the error "Failed parsing ..." for `vendor` folder

### DIFF
--- a/src/linter/worker.go
+++ b/src/linter/worker.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/VKCOM/noverify/src/utils"
 	"github.com/VKCOM/php-parser/pkg/ast"
 	"github.com/VKCOM/php-parser/pkg/conf"
 	phperrors "github.com/VKCOM/php-parser/pkg/errors"
@@ -251,7 +252,11 @@ func (w *Worker) doParseFile(f workspace.FileInfo) []*Report {
 	}
 
 	if err != nil {
-		log.Printf("Failed parsing %s: %s", f.Name, err.Error())
+		// Don't give an error that the file cannot be parsed if it is in the
+		// vendor, as it may be test data that is incorrect by definition.
+		if !utils.InVendor(f.Name) {
+			log.Printf("Failed parsing %s: %s", f.Name, err.Error())
+		}
 		lintdebug.Send("Failed parsing %s: %s", f.Name, err.Error())
 	}
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/VKCOM/noverify/src/ir"
 )
 
@@ -37,4 +40,8 @@ func NameNodeEquals(n ir.Node, s string) bool {
 func IsSpecialClassName(n ir.Node) bool {
 	name := NameNodeToString(n)
 	return name == "static" || name == "self" || name == "parent"
+}
+
+func InVendor(path string) bool {
+	return strings.Contains(filepath.ToSlash(path), "/vendor/")
 }


### PR DESCRIPTION
Now the error "Failed parsing ..." is not shown if the error occurred in the `vendor` folder.