### PR TITLE
cmd/stat: added a tool for comparing reports between versions

### DIFF
--- a/src/cmd/stat/Makefile
+++ b/src/cmd/stat/Makefile
@@ -1,10 +1,10 @@
-WORKING_DIR=/Users/petrmakhnev/psalm/
-COMMAND=--index-only-files="./stubs" ./src
+PROJECT_DIR=./
+NOVERIFY_ARGS=./src
 NOVERIFY_MASTER_EXE=$(PWD)/noverify_master/build/noverify
 NOVERIFY_CURRENT_EXE=$(PWD)/../../../build/noverify
 
 clone_master:
-	if [ ! -d noverify_master ]; then mkdir noverify_master && git clone https://github.com/VKCOM/noverify ./noverify_master; fi
+	if [ ! -d noverify_master ]; then mkdir noverify_master && git clone https://github.com/VKCOM/noverify ./noverify_master; else git pull; fi
 
 build_master: clone_master
 	cd ./noverify_master && make build
@@ -12,6 +12,6 @@ build_master: clone_master
 compare: build_master
 	go build
 	cd ../../../ && make build
-	cd $(WORKING_DIR) && $(NOVERIFY_CURRENT_EXE) check --output-json --output='$(PWD)/new.json' $(COMMAND)
-	cd $(WORKING_DIR) && $(NOVERIFY_MASTER_EXE) check --output-json --output='$(PWD)/old.json' $(COMMAND)
+	cd $(PROJECT_DIR) && $(NOVERIFY_CURRENT_EXE) check --output-json --output='$(PWD)/new.json' $(NOVERIFY_ARGS)
+	cd $(PROJECT_DIR) && $(NOVERIFY_MASTER_EXE) check --output-json --output='$(PWD)/old.json' $(NOVERIFY_ARGS)
 	./stat -new new.json --old old.json > reports.md

--- a/src/cmd/stat/Makefile
+++ b/src/cmd/stat/Makefile
@@ -1,0 +1,17 @@
+WORKING_DIR=/Users/petrmakhnev/psalm/
+COMMAND=--index-only-files="./stubs" ./src
+NOVERIFY_MASTER_EXE=$(PWD)/noverify_master/build/noverify
+NOVERIFY_CURRENT_EXE=$(PWD)/../../../build/noverify
+
+clone_master:
+	if [ ! -d noverify_master ]; then mkdir noverify_master && git clone https://github.com/VKCOM/noverify ./noverify_master; fi
+
+build_master: clone_master
+	cd ./noverify_master && make build
+
+compare: build_master
+	go build
+	cd ../../../ && make build
+	cd $(WORKING_DIR) && $(NOVERIFY_CURRENT_EXE) check --output-json --output='$(PWD)/new.json' $(COMMAND)
+	cd $(WORKING_DIR) && $(NOVERIFY_MASTER_EXE) check --output-json --output='$(PWD)/old.json' $(COMMAND)
+	./stat -m --new new.json --old old.json > reports.md

--- a/src/cmd/stat/Makefile
+++ b/src/cmd/stat/Makefile
@@ -14,4 +14,4 @@ compare: build_master
 	cd ../../../ && make build
 	cd $(WORKING_DIR) && $(NOVERIFY_CURRENT_EXE) check --output-json --output='$(PWD)/new.json' $(COMMAND)
 	cd $(WORKING_DIR) && $(NOVERIFY_MASTER_EXE) check --output-json --output='$(PWD)/old.json' $(COMMAND)
-	./stat -m --new new.json --old old.json > reports.md
+	./stat -new new.json --old old.json > reports.md

--- a/src/cmd/stat/README.md
+++ b/src/cmd/stat/README.md
@@ -1,0 +1,12 @@
+# Comparing reports between versions
+
+A tool for comparing reports between versions. At the output, it creates a markdown file with the results.
+
+Run:
+
+```shell
+cd src/cmd/stat
+make compare -i PROJECT_DIR=/Users/petrmakhnev/psalm/ NOVERIFY_ARGS='--index-only-files="./stubs" ./src'
+```
+
+The current master is automatically cloned into the folder, compiles and runs the analysis of the project on it If the master is already cloned, it will be updated.

--- a/src/cmd/stat/go.mod
+++ b/src/cmd/stat/go.mod
@@ -4,7 +4,4 @@ go 1.16
 
 require (
 	github.com/VKCOM/noverify v0.4.0
-	github.com/fatih/color v1.12.0 // indirect
-	github.com/gosuri/uitable v0.0.4
-	github.com/mattn/go-runewidth v0.0.13 // indirect
 )

--- a/src/cmd/stat/go.mod
+++ b/src/cmd/stat/go.mod
@@ -1,0 +1,10 @@
+module stat
+
+go 1.16
+
+require (
+	github.com/VKCOM/noverify v0.4.0
+	github.com/fatih/color v1.12.0 // indirect
+	github.com/gosuri/uitable v0.0.4
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+)

--- a/src/cmd/stat/main.go
+++ b/src/cmd/stat/main.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gosuri/uitable"
-
 	"github.com/VKCOM/noverify/src/cmd"
 	"github.com/VKCOM/noverify/src/linter"
 )
@@ -46,10 +44,8 @@ func loadReportsFile(filename string) *linterOutput {
 }
 
 func main() {
-	var markdown bool
 	var newReportsPath string
 	var oldReportsPath string
-	flag.BoolVar(&markdown, "m", false, "print with markdown table")
 	flag.StringVar(&newReportsPath, "new", "reports.json", "reports from current branch")
 	flag.StringVar(&oldReportsPath, "old", "reports-master.json", "reports from master branch")
 	flag.Parse()
@@ -63,41 +59,21 @@ func main() {
 	masterCountByType := getReportsByType(reportsMaster)
 	diffSorted := getSortedDiffSlice(diffByType)
 
-	if markdown {
-		markdownDiff := getMarkdownReportDiff(diff)
+	markdownDiff := getMarkdownReportDiff(diff)
 
-		fmt.Println("## Changes in reports")
+	fmt.Println("## Changes in reports")
 
-		if len(diffSorted) == 0 {
-			fmt.Println("No changes.")
-		} else {
-			fmt.Println("Name | Count | New | Deleted")
-			fmt.Println("---- | :---: | :-: | :-----:")
-
-			for _, info := range diffSorted {
-				fmt.Printf("[`%s`](#%[1]s) | %d | %d | %d\n", info.CheckName, masterCountByType[info.CheckName], info.Added, info.Deleted)
-			}
-
-			fmt.Println(markdownDiff)
-		}
+	if len(diffSorted) == 0 {
+		fmt.Println("No changes.")
 	} else {
-		strDiff := getReportDiff(diff)
-
-		table := uitable.New()
-
-		table.AddRow("Name", "Count", "Added", "Deleted")
+		fmt.Println("Name | Count | New | Deleted")
+		fmt.Println("---- | :---: | :-: | :-----:")
 
 		for _, info := range diffSorted {
-			table.AddRow(info.CheckName, masterCountByType[info.CheckName], info.Added, info.Deleted)
+			fmt.Printf("[`%s`](#%[1]s) | %d | %d | %d\n", info.CheckName, masterCountByType[info.CheckName], info.Added, info.Deleted)
 		}
 
-		fmt.Println("Changes in reports with the current master.")
-		fmt.Println()
-
-		fmt.Println(table)
-
-		fmt.Println()
-		fmt.Println(strDiff)
+		fmt.Println(markdownDiff)
 	}
 }
 

--- a/src/cmd/stat/main.go
+++ b/src/cmd/stat/main.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/gosuri/uitable"
+
+	"github.com/VKCOM/noverify/src/cmd"
+	"github.com/VKCOM/noverify/src/linter"
+)
+
+type linterOutput struct {
+	Reports []*linter.Report
+	Errors  []string
+}
+
+type ReportCount struct {
+	CheckName string
+	Count     int
+	Added     int
+	Deleted   int
+}
+
+type ReportDiff struct {
+	Report  *linter.Report
+	New     bool
+	Deleted bool
+}
+
+func loadReportsFile(filename string) *linterOutput {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Fatalf("read reports file: %v", err)
+	}
+	var output linterOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		log.Fatalf("unmarshal reports file: %v", err)
+	}
+	return &output
+}
+
+func main() {
+	var markdown bool
+	var newReportsPath string
+	var oldReportsPath string
+	flag.BoolVar(&markdown, "m", false, "print with markdown table")
+	flag.StringVar(&newReportsPath, "new", "reports.json", "reports from current branch")
+	flag.StringVar(&oldReportsPath, "old", "reports-master.json", "reports from master branch")
+	flag.Parse()
+
+	reports := loadReportsFile(newReportsPath).Reports
+	reportsMaster := loadReportsFile(oldReportsPath).Reports
+
+	diff := reportsDiff(reports, reportsMaster)
+
+	diffByType := getReportsDiffByType(diff)
+	masterCountByType := getReportsByType(reportsMaster)
+	diffSorted := getSortedDiffSlice(diffByType)
+
+	if markdown {
+		markdownDiff := getMarkdownReportDiff(diff)
+
+		fmt.Println("## Changes in reports")
+
+		if len(diffSorted) == 0 {
+			fmt.Println("No changes.")
+		} else {
+			fmt.Println("Name | Count | New | Deleted")
+			fmt.Println("---- | :---: | :-: | :-----:")
+
+			for _, info := range diffSorted {
+				fmt.Printf("[`%s`](#%[1]s) | %d | %d | %d\n", info.CheckName, masterCountByType[info.CheckName], info.Added, info.Deleted)
+			}
+
+			fmt.Println(markdownDiff)
+		}
+	} else {
+		strDiff := getReportDiff(diff)
+
+		table := uitable.New()
+
+		table.AddRow("Name", "Count", "Added", "Deleted")
+
+		for _, info := range diffSorted {
+			table.AddRow(info.CheckName, masterCountByType[info.CheckName], info.Added, info.Deleted)
+		}
+
+		fmt.Println("Changes in reports with the current master.")
+		fmt.Println()
+
+		fmt.Println(table)
+
+		fmt.Println()
+		fmt.Println(strDiff)
+	}
+}
+
+func getSortedDiffSlice(diffByType map[string]*ReportCount) []*ReportCount {
+	var diffSorted []*ReportCount
+	for _, reportCount := range diffByType {
+		diffSorted = append(diffSorted, reportCount)
+	}
+	sort.Slice(diffSorted, func(i, j int) bool {
+		if diffSorted[i].Added == diffSorted[j].Added {
+			return diffSorted[i].Deleted > diffSorted[j].Deleted
+		}
+
+		return diffSorted[i].Deleted > diffSorted[j].Deleted
+	})
+	return diffSorted
+}
+
+func getReportDiff(diff []ReportDiff) string {
+	var diffReportsString string
+
+	reportDiffByName := map[string][]ReportDiff{}
+	for _, reportDiff := range diff {
+		reportDiffByName[reportDiff.Report.CheckName] = append(reportDiffByName[reportDiff.Report.CheckName], reportDiff)
+	}
+
+	for name, diffs := range reportDiffByName {
+		diffReportsString += "\n## `" + name + "`\n\n"
+
+		diffReportsString += "```diff\n"
+		for _, reportDiff := range diffs {
+			addOrDeleteSymbol := "-"
+			if reportDiff.New {
+				addOrDeleteSymbol = "+"
+			}
+
+			formattedReport := cmd.FormatReport(reportDiff.Report)
+			formattedReportParts := strings.Split(formattedReport, "\n")
+			formattedReport = strings.Join(formattedReportParts, "\n"+addOrDeleteSymbol)
+			formattedReport = addOrDeleteSymbol + formattedReport + "\n"
+
+			diffReportsString += formattedReport
+		}
+		diffReportsString += "```\n"
+	}
+
+	return diffReportsString
+}
+
+func getMarkdownReportDiff(diff []ReportDiff) string {
+	return fmt.Sprintf(getReportDiff(diff))
+}
+
+func reportsDiff(now, master []*linter.Report) (diff []ReportDiff) {
+	for _, reportFromNow := range now {
+		var found bool
+		for _, reportFromMaster := range master {
+			if reportFromMaster.Context == reportFromNow.Context && reportFromMaster.Message == reportFromNow.Message {
+				found = true
+			}
+		}
+
+		if !found {
+			diff = append(diff, ReportDiff{
+				Report:  reportFromNow,
+				New:     true,
+				Deleted: false,
+			})
+		}
+	}
+	for _, reportFromMaster := range master {
+		var found bool
+		for _, reportFromNow := range now {
+			if reportFromMaster.Context == reportFromNow.Context && reportFromMaster.Message == reportFromNow.Message {
+				found = true
+			}
+		}
+
+		if !found {
+			diff = append(diff, ReportDiff{
+				Report:  reportFromMaster,
+				New:     false,
+				Deleted: true,
+			})
+		}
+	}
+
+	return diff
+}
+
+func getReportsByType(reports []*linter.Report) map[string]int {
+	reportsByType := map[string]int{}
+	for _, report := range reports {
+		reportsByType[report.CheckName]++
+	}
+	return reportsByType
+}
+
+func getReportsDiffByType(reportDiffs []ReportDiff) map[string]*ReportCount {
+	reportsByType := map[string]*ReportCount{}
+	for _, diff := range reportDiffs {
+		rep, ok := reportsByType[diff.Report.CheckName]
+		if !ok {
+			info := &ReportCount{
+				CheckName: diff.Report.CheckName,
+			}
+			if diff.New {
+				info.Added++
+			} else if diff.Deleted {
+				info.Deleted++
+			}
+
+			reportsByType[diff.Report.CheckName] = info
+		} else {
+			if diff.New {
+				rep.Added++
+			} else if diff.Deleted {
+				rep.Deleted++
+			}
+		}
+	}
+	return reportsByType
+}


### PR DESCRIPTION
A tool for comparing reports between versions. At the output, it creates a markdown file with the results.

Run:

```shell
cd src/cmd/stat
make compare -i PROJECT_DIR=/Users/petrmakhnev/psalm/ NOVERIFY_ARGS='--index-only-files="./stubs" ./src'
```

The current master is automatically cloned into the folder, compiles and runs the analysis of the project on it If the master is already cloned, it will be updated.