### PR TITLE
linter: added `null` and `stdClass` types to `isMixedLikeType`

### DIFF
--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -643,8 +643,14 @@ func cloneRulesForFile(filename string, ruleSet *rules.ScopedSet) *rules.ScopedS
 }
 
 func isMixedLikeType(typ types.Map) bool {
+	if typ.Is("null") {
+		return true
+	}
+
 	return typ.Find(func(typ string) bool {
-		if typ == "mixed" || typ == "object" || typ == "undefined" || typ == "unknown_from_list" {
+		if typ == "mixed" || typ == "object" ||
+			typ == "undefined" || typ == "unknown_from_list" ||
+			typ == "\\stdClass" {
 			return true
 		}
 

--- a/src/tests/checkers/strict_mixed_test.go
+++ b/src/tests/checkers/strict_mixed_test.go
@@ -32,6 +32,15 @@ function f($b) {
 function f(Foo $a) {
   $a->f();
 }
+
+function f() {
+  $a = null;
+  $a->f();
+}
+
+function f(stdClass $a) {
+  $a->f();
+}
 `,
 	)
 	test.Expect = []string{
@@ -41,6 +50,8 @@ function f(Foo $a) {
 		"Call to undefined method {undefined}->f()",
 		"Call to undefined method {unknown_from_list}->f()",
 		"Call to undefined method {\\Foo}->f()",
+		"Call to undefined method {null}->f()",
+		"Call to undefined method {\\stdClass}->f()",
 	}
 	test.RunAndMatch()
 }
@@ -68,6 +79,15 @@ function f($b) {
 }
 
 function f(Foo $a) {
+  $a->f();
+}
+
+function f() {
+  $a = null;
+  $a->f();
+}
+
+function f(stdClass $a) {
   $a->f();
 }
 `,


### PR DESCRIPTION
Our type inference currently leaves a lot of nulls, so we will not issue warning in a non-strict mode for now.