### PR TITLE
linter: improved `undefinedVariable` and `maybeUndefined` checkers

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1393,7 +1393,7 @@ func (b *blockWalker) handleVariable(v ir.Node) bool {
 	have := b.ctx.sc.HaveVar(v)
 
 	if !have && !b.inArrowFunction {
-		b.r.reportUndefinedVariable(v, b.ctx.sc.MaybeHaveVar(v))
+		b.r.reportUndefinedVariable(v, b.ctx.sc.MaybeHaveVar(v), b.path)
 		b.ctx.sc.AddVar(v, types.NewMap("undefined"), "undefined", meta.VarAlwaysDefined)
 	}
 
@@ -1430,7 +1430,7 @@ func (b *blockWalker) handleVariable(v ir.Node) bool {
 		}
 
 		if varNotFound {
-			b.r.reportUndefinedVariable(v, varMaybeNotDefined)
+			b.r.reportUndefinedVariable(v, varMaybeNotDefined, b.path)
 			b.ctx.sc.AddVar(v, types.NewMap("undefined"), "undefined", meta.VarAlwaysDefined)
 		}
 	}

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -304,7 +304,16 @@ func (b *blockLinter) checkCoalesceExpr(n *ir.CoalesceExpr) {
 		return
 	}
 
-	if !lhsType.Contains("null") {
+	rhsVariableUndefined := false
+	variable, ok := n.Left.(*ir.SimpleVar)
+	if ok {
+		have := b.walker.ctx.sc.HaveVar(variable)
+		rhsVariableUndefined = !have
+	}
+
+	// If the variable is not defined, then ?? can be a test
+	// for this, so we do not need to give this warning
+	if !lhsType.Contains("null") && !rhsVariableUndefined {
 		b.report(n.Right, LevelWarning, "deadCode", "%s is not nullable, right side of the expression is unreachable", irutil.FmtNode(n.Left))
 	}
 }

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -2423,3 +2423,27 @@ function f2($v) {
 	}
 	test.RunAndMatch()
 }
+
+func TestUndefinedVariableInCoalesceOrIsset(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+function f() {
+  if (1) {
+    $a = 100;
+  }
+
+  echo $a ?? 100;
+  echo isset($a) ? $a : 100;
+
+  if (isset($a)) {
+    echo $a;
+  }
+
+  echo $e; // variable undefined
+}
+`)
+	test.Expect = []string{
+		`Undefined variable $e`,
+	}
+	test.RunAndMatch()
+}

--- a/src/tests/checkers/deadcode_test.go
+++ b/src/tests/checkers/deadcode_test.go
@@ -37,6 +37,16 @@ function f() {
   $_ = $x ?? 10; // ok
 }
 
+function f1() {
+  if (1) {
+    $a = 100;
+  }
+
+  $b = $a ?? 100; // ok, $a maybe undefined
+  $b = $c ?? 100; // ok, $c undefined
+  echo $bl
+}
+
 `)
 	test.Expect = []string{
 		`$a is not nullable, right side of the expression is unreachable`,

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"github.com/VKCOM/noverify/src/ir/irutil"
 	"path/filepath"
 	"strings"
+
+	"github.com/VKCOM/noverify/src/ir/irutil"
 
 	"github.com/VKCOM/noverify/src/ir"
 )

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/VKCOM/noverify/src/ir/irutil"
 	"path/filepath"
 	"strings"
 
@@ -44,4 +45,18 @@ func IsSpecialClassName(n ir.Node) bool {
 
 func InVendor(path string) bool {
 	return strings.Contains(filepath.ToSlash(path), "/vendor/")
+}
+
+func InCoalesceOrIsset(path irutil.NodePath) bool {
+	inIsset := false
+	_, inCoalesce := path.NthParent(1).(*ir.CoalesceExpr)
+	call, inFuncCall := path.NthParent(1).(*ir.FunctionCallExpr)
+	if inFuncCall {
+		name, ok := call.Function.(*ir.Name)
+		if ok {
+			inIsset = name.Value == "isset"
+		}
+	}
+
+	return inCoalesce || inIsset
 }


### PR DESCRIPTION
In the following cases:

```php
$undefinedVar ?? 100
isset($undefinedVar)
```

no need to throw a warning about an undefined variable,
since these constructs are used to check that the
variable is defined.

Fixes #1007 