### PR TITLE
linter: renamed `phpdoc*` checkers as in Psalm

### DIFF
--- a/docs/checkers_doc.md
+++ b/docs/checkers_doc.md
@@ -41,6 +41,9 @@
    - [`indexingSyntax` checker (autofixable)](#indexingsyntax-checker)
    - [`intNeedle` checker](#intneedle-checker)
    - [`intOverflow` checker](#intoverflow-checker)
+   - [`invalidDocblock` checker](#invaliddocblock-checker)
+   - [`invalidDocblockRef` checker](#invaliddocblockref-checker)
+   - [`invalidDocblockType` checker](#invaliddocblocktype-checker)
    - [`invalidExtendClass` checker](#invalidextendclass-checker)
    - [`invalidNew` checker](#invalidnew-checker)
    - [`keywordCase` checker](#keywordcase-checker)
@@ -59,9 +62,6 @@
    - [`oldStyleConstructor` checker](#oldstyleconstructor-checker)
    - [`paramClobber` checker](#paramclobber-checker)
    - [`parentConstructor` checker](#parentconstructor-checker)
-   - [`phpdocLint` checker](#phpdoclint-checker)
-   - [`phpdocRef` checker](#phpdocref-checker)
-   - [`phpdocType` checker](#phpdoctype-checker)
    - [`precedence` checker](#precedence-checker)
    - [`printf` checker](#printf-checker)
    - [`redundantGlobal` checker](#redundantglobal-checker)
@@ -799,6 +799,60 @@ return PHP_INT_MIN;
 <p><br></p>
 
 
+### `invalidDocblock` checker
+
+#### Description
+
+Report malformed PHPDoc comments.
+
+#### Non-compliant code:
+```php
+@property $foo // Property type is missing.
+```
+
+#### Compliant code:
+```php
+@property Foo $foo
+```
+<p><br></p>
+
+
+### `invalidDocblockRef` checker
+
+#### Description
+
+Report invalid symbol references inside PHPDoc.
+
+#### Non-compliant code:
+```php
+@see MyClass
+```
+
+#### Compliant code:
+```php
+@see \Foo\MyClass
+```
+<p><br></p>
+
+
+### `invalidDocblockType` checker
+
+#### Description
+
+Report potential issues in PHPDoc types.
+
+#### Non-compliant code:
+```php
+@var []int $xs
+```
+
+#### Compliant code:
+```php
+@var int[] $xs
+```
+<p><br></p>
+
+
 ### `invalidExtendClass` checker
 
 #### Description
@@ -1179,60 +1233,6 @@ class Foo extends Bar {
     $this->y = $y;
   }
 }
-```
-<p><br></p>
-
-
-### `phpdocLint` checker
-
-#### Description
-
-Report malformed PHPDoc comments.
-
-#### Non-compliant code:
-```php
-@property $foo // Property type is missing.
-```
-
-#### Compliant code:
-```php
-@property Foo $foo
-```
-<p><br></p>
-
-
-### `phpdocRef` checker
-
-#### Description
-
-Report invalid symbol references inside PHPDoc.
-
-#### Non-compliant code:
-```php
-@see MyClass
-```
-
-#### Compliant code:
-```php
-@see \Foo\MyClass
-```
-<p><br></p>
-
-
-### `phpdocType` checker
-
-#### Description
-
-Report potential issues in PHPDoc types.
-
-#### Non-compliant code:
-```php
-@var []int $xs
-```
-
-#### Compliant code:
-```php
-@var int[] $xs
 ```
 <p><br></p>
 

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -236,7 +236,7 @@ func (b *blockWalker) handleCommentToken(n ir.Node, t *token.Token) {
 
 	if phpdoc.IsSuspicious(t.Value) {
 		b.r.ReportPHPDoc(PHPDocLine(n, 1),
-			LevelWarning, "phpdocLint",
+			LevelWarning, "invalidDocblock",
 			"Multiline PHPDoc comment should start with /**, not /*",
 		)
 	}
@@ -254,7 +254,7 @@ func (b *blockWalker) handleCommentToken(n ir.Node, t *token.Token) {
 		if converted.Warning != "" {
 			b.r.ReportPHPDoc(
 				PHPDocLineField(n, part.Line(), 1),
-				LevelNotice, "phpdocType", converted.Warning,
+				LevelNotice, "invalidDocblockType", converted.Warning,
 			)
 		}
 

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -265,7 +265,7 @@ thisFunctionAlwaysExits();`,
 		},
 
 		{
-			Name:     "phpdocLint",
+			Name:     "invalidDocblock",
 			Default:  true,
 			Quickfix: false,
 			Comment:  `Report malformed PHPDoc comments.`,
@@ -274,7 +274,7 @@ thisFunctionAlwaysExits();`,
 		},
 
 		{
-			Name:     "phpdocType",
+			Name:     "invalidDocblockType",
 			Default:  true,
 			Quickfix: false,
 			Comment:  `Report potential issues in PHPDoc types.`,
@@ -283,7 +283,7 @@ thisFunctionAlwaysExits();`,
 		},
 
 		{
-			Name:     "phpdocRef",
+			Name:     "invalidDocblockRef",
 			Default:  true,
 			Quickfix: false,
 			Comment:  `Report invalid symbol references inside PHPDoc.`,

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1196,10 +1196,10 @@ func (d *rootWalker) parseTypeHintNode(n ir.Node) (typ types.Map, ok bool) {
 
 func (d *rootWalker) reportPHPDocErrors(errs PHPDocErrors) {
 	for _, err := range errs.types {
-		d.ReportPHPDoc(err.Location, LevelNotice, "phpdocType", err.Message)
+		d.ReportPHPDoc(err.Location, LevelNotice, "invalidDocblockType", err.Message)
 	}
 	for _, err := range errs.lint {
-		d.ReportPHPDoc(err.Location, LevelWarning, "phpdocLint", err.Message)
+		d.ReportPHPDoc(err.Location, LevelWarning, "invalidDocblock", err.Message)
 	}
 }
 

--- a/src/linter/root_checker.go
+++ b/src/linter/root_checker.go
@@ -92,10 +92,10 @@ func (r *rootChecker) CheckFunction(fun *ir.FunctionStmt) bool {
 
 func (r *rootChecker) reportPHPDocErrors(errs PHPDocErrors) {
 	for _, err := range errs.types {
-		r.walker.ReportPHPDoc(err.Location, LevelNotice, "phpdocType", err.Message)
+		r.walker.ReportPHPDoc(err.Location, LevelNotice, "invalidDocblockType", err.Message)
 	}
 	for _, err := range errs.lint {
-		r.walker.ReportPHPDoc(err.Location, LevelWarning, "phpdocLint", err.Message)
+		r.walker.ReportPHPDoc(err.Location, LevelWarning, "invalidDocblock", err.Message)
 	}
 }
 
@@ -253,7 +253,7 @@ func (r *rootChecker) checkPHPDocSeeRef(n ir.Node, part phpdoc.CommentPart) {
 		if !r.isValidPHPDocRef(ref) {
 			r.walker.ReportPHPDoc(
 				PHPDocLineField(n, part.Line(), 1),
-				LevelWarning, "phpdocRef", "@see tag refers to unknown symbol %s", ref,
+				LevelWarning, "invalidDocblockRef", "@see tag refers to unknown symbol %s", ref,
 			)
 		}
 	}
@@ -281,7 +281,7 @@ func (r *rootChecker) checkPHPDocMixinRef(n ir.Node, part phpdoc.CommentPart) {
 	if _, ok := r.info.GetClass(name); !ok {
 		r.walker.ReportPHPDoc(
 			PHPDocLineField(n, part.Line(), 1),
-			LevelWarning, "phpdocRef", "@mixin tag refers to unknown class %s", name,
+			LevelWarning, "invalidDocblockRef", "@mixin tag refers to unknown class %s", name,
 		)
 	}
 }
@@ -676,7 +676,7 @@ func (r *rootChecker) CheckOldStyleConstructor(meth *ir.ClassMethodStmt) {
 func (r *rootChecker) CheckPHPDocVar(n ir.Node, doc phpdoc.Comment, typ types.Map) {
 	if phpdoc.IsSuspicious([]byte(doc.Raw)) {
 		r.walker.ReportPHPDoc(PHPDocLine(n, 1),
-			LevelWarning, "phpdocLint",
+			LevelWarning, "invalidDocblock",
 			"Multiline PHPDoc comment should start with /**, not /*",
 		)
 	}
@@ -693,7 +693,7 @@ func (r *rootChecker) CheckPHPDocVar(n ir.Node, doc phpdoc.Comment, typ types.Ma
 					field = 2
 				}
 				r.walker.ReportPHPDoc(PHPDocLineField(n, part.Line(), field),
-					LevelNotice, "phpdocType",
+					LevelNotice, "invalidDocblockType",
 					converted.Warning,
 				)
 			}

--- a/src/tests/checkers/phpdoc_test.go
+++ b/src/tests/checkers/phpdoc_test.go
@@ -138,7 +138,7 @@ class BadClass {
 		`@see tag refers to unknown symbol invalid1`,
 		`@see tag refers to unknown symbol invalid2`,
 	}
-	linttest.RunFilterMatch(test, "phpdocRef")
+	linttest.RunFilterMatch(test, "invalidDocblockRef")
 }
 
 func TestPHPDocRefForConstantInClass(t *testing.T) {
@@ -181,7 +181,7 @@ function f() {}
 		`@see tag refers to unknown symbol TYPE_TEXT_UNDEFINED`,
 		`@see tag refers to unknown symbol TYPE_TEXT`,
 	}
-	linttest.RunFilterMatch(test, "phpdocRef")
+	linttest.RunFilterMatch(test, "invalidDocblockRef")
 }
 
 func TestBadParamName(t *testing.T) {

--- a/src/tests/golden/testdata/flysystem/golden.txt
+++ b/src/tests/golden/testdata/flysystem/golden.txt
@@ -46,13 +46,13 @@ WARNING strictCmp: 3rd argument of in_array must be true when comparing strings 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:387
             if (false === @mkdir($location, $this->permissionMap['dir'][$visibility], true)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   phpdocType: Void type can only be used as a standalone type for the return type at testdata/flysystem/src/Adapter/Local.php:444
+MAYBE   invalidDocblockType: Void type can only be used as a standalone type for the return type at testdata/flysystem/src/Adapter/Local.php:444
      * @return array|void
                ^^^^^^^^^^
-WARNING phpdocRef: @see tag refers to unknown symbol League\Flysystem\ReadInterface::readStream at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:17
+WARNING invalidDocblockRef: @see tag refers to unknown symbol League\Flysystem\ReadInterface::readStream at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:17
      * @see League\Flysystem\ReadInterface::readStream()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-WARNING phpdocRef: @see tag refers to unknown symbol League\Flysystem\ReadInterface::read at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:41
+WARNING invalidDocblockRef: @see tag refers to unknown symbol League\Flysystem\ReadInterface::read at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:41
      * @see League\Flysystem\ReadInterface::read()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\Adapter\Polyfill\StreamedWritingTrait::write public method at testdata/flysystem/src/Adapter/Polyfill/StreamedWritingTrait.php:58

--- a/src/tests/golden/testdata/inflector/golden.txt
+++ b/src/tests/golden/testdata/inflector/golden.txt
@@ -13,7 +13,7 @@ WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:123
         @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   phpdocType: Use bool type instead of boolean at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:142
+MAYBE   invalidDocblockType: Use bool type instead of boolean at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:142
      * @param boolean $reset        If true, will unset default inflections for all
               ^^^^^^^
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:165

--- a/src/tests/golden/testdata/options-resolver/golden.txt
+++ b/src/tests/golden/testdata/options-resolver/golden.txt
@@ -22,13 +22,13 @@ MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass()
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (7.4) at testdata/options-resolver/OptionsResolver.php:209
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
                                                                                                                                                                           ^^^^^^^^
-WARNING phpdocLint: @param for non-existing argument $package at testdata/options-resolver/OptionsResolver.php:424
+WARNING invalidDocblock: @param for non-existing argument $package at testdata/options-resolver/OptionsResolver.php:424
      * @param string          $package The name of the composer package that is triggering the deprecation
                               ^^^^^^^^
-WARNING phpdocLint: @param for non-existing argument $version at testdata/options-resolver/OptionsResolver.php:425
+WARNING invalidDocblock: @param for non-existing argument $version at testdata/options-resolver/OptionsResolver.php:425
      * @param string          $version The version of the package that introduced the deprecation
                               ^^^^^^^^
-WARNING phpdocLint: @param for non-existing argument $message at testdata/options-resolver/OptionsResolver.php:426
+WARNING invalidDocblock: @param for non-existing argument $message at testdata/options-resolver/OptionsResolver.php:426
      * @param string|\Closure $message The deprecation message to use
                               ^^^^^^^^
 MAYBE   complexity: Too big method: more than 150 lines at testdata/options-resolver/OptionsResolver.php:917

--- a/src/tests/golden/testdata/phpdoc/golden.txt
+++ b/src/tests/golden/testdata/phpdoc/golden.txt
@@ -1,90 +1,90 @@
-WARNING phpdocLint: @method requires return type and method name fields at testdata/phpdoc/phpdoc.php:4
+WARNING invalidDocblock: @method requires return type and method name fields at testdata/phpdoc/phpdoc.php:4
  * @method
    ^^^^^^^
-WARNING phpdocLint: @method requires return type and method name fields at testdata/phpdoc/phpdoc.php:5
+WARNING invalidDocblock: @method requires return type and method name fields at testdata/phpdoc/phpdoc.php:5
  * @method int
    ^^^^^^^^^^^
-WARNING phpdocLint: @method missing parentheses after method name at testdata/phpdoc/phpdoc.php:6
+WARNING invalidDocblock: @method missing parentheses after method name at testdata/phpdoc/phpdoc.php:6
  * @method int    method1
                   ^^^^^^^
-WARNING phpdocLint: @method missing parentheses after method name at testdata/phpdoc/phpdoc.php:7
+WARNING invalidDocblock: @method missing parentheses after method name at testdata/phpdoc/phpdoc.php:7
  * @method ?string  method2
                     ^^^^^^^
-WARNING phpdocLint: @property requires type and property name fields at testdata/phpdoc/phpdoc.php:11
+WARNING invalidDocblock: @property requires type and property name fields at testdata/phpdoc/phpdoc.php:11
  * @property
    ^^^^^^^^^
-WARNING phpdocLint: @property requires type and property name fields at testdata/phpdoc/phpdoc.php:12
+WARNING invalidDocblock: @property requires type and property name fields at testdata/phpdoc/phpdoc.php:12
  * @property   int
    ^^^^^^^^^^^^^^^
-WARNING phpdocLint: Non-canonical order of name and type at testdata/phpdoc/phpdoc.php:14
+WARNING invalidDocblock: Non-canonical order of name and type at testdata/phpdoc/phpdoc.php:14
  * @property       $b  int
    ^^^^^^^^^^^^^^^^^^^^^^^
-WARNING phpdocLint: @property c field name must start with '$' at testdata/phpdoc/phpdoc.php:15
+WARNING invalidDocblock: @property c field name must start with '$' at testdata/phpdoc/phpdoc.php:15
  * @property int c
                  ^
-WARNING phpdocLint: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:18
+WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:18
   /*
 ^^^^
-MAYBE   phpdocType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:24
+MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:24
    * @var ?int|null
           ^^^^^^^^^
-MAYBE   phpdocType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:25
+MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:25
    * @var $b ?int|null
              ^^^^^^^^^
-MAYBE   phpdocType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:26
+MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:26
    * @var ?int|null $b
           ^^^^^^^^^
-WARNING phpdocLint: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
+WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
 /*
 ^^
-WARNING phpdocRef: @see tag refers to unknown symbol FooUnExisting at testdata/phpdoc/phpdoc.php:54
+WARNING invalidDocblockRef: @see tag refers to unknown symbol FooUnExisting at testdata/phpdoc/phpdoc.php:54
  * @see  FooUnExisting
          ^^^^^^^^^^^^^
-WARNING phpdocRef: @see tag refers to unknown symbol FooUnExisting at testdata/phpdoc/phpdoc.php:55
+WARNING invalidDocblockRef: @see tag refers to unknown symbol FooUnExisting at testdata/phpdoc/phpdoc.php:55
  * @see       FooUnExisting
               ^^^^^^^^^^^^^
-MAYBE   phpdocType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:44
+MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:44
  * @param    ?int|null $d
              ^^^^^^^^^
-MAYBE   phpdocType: Expected a type, found '-'; if you want to express 'any' type, use 'mixed' at testdata/phpdoc/phpdoc.php:46
+MAYBE   invalidDocblockType: Expected a type, found '-'; if you want to express 'any' type, use 'mixed' at testdata/phpdoc/phpdoc.php:46
  * @param - $e the y param
           ^
-MAYBE   phpdocType: Expected a type, found '-'; if you want to express 'any' type, use 'mixed' at testdata/phpdoc/phpdoc.php:47
+MAYBE   invalidDocblockType: Expected a type, found '-'; if you want to express 'any' type, use 'mixed' at testdata/phpdoc/phpdoc.php:47
  * @param    $f - the z param
              ^^
-MAYBE   phpdocType: Use int type instead of integer at testdata/phpdoc/phpdoc.php:49
+MAYBE   invalidDocblockType: Use int type instead of integer at testdata/phpdoc/phpdoc.php:49
  * @param integer   $g
           ^^^^^^^
-MAYBE   phpdocType: Array syntax is T[], not []T at testdata/phpdoc/phpdoc.php:50
+MAYBE   invalidDocblockType: Array syntax is T[], not []T at testdata/phpdoc/phpdoc.php:50
  * @param  []int   $h
            ^^^^^
-MAYBE   phpdocType: Nullable syntax is ?T, not T? at testdata/phpdoc/phpdoc.php:51
+MAYBE   invalidDocblockType: Nullable syntax is ?T, not T? at testdata/phpdoc/phpdoc.php:51
  * @param   int? $a1
             ^^^^
-WARNING phpdocLint: @param for non-existing argument $unexisting at testdata/phpdoc/phpdoc.php:40
+WARNING invalidDocblock: @param for non-existing argument $unexisting at testdata/phpdoc/phpdoc.php:40
  * @param    int    $unexisting
                     ^^^^^^^^^^^
-WARNING phpdocLint: Malformed @param tag (maybe var is missing?) at testdata/phpdoc/phpdoc.php:41
+WARNING invalidDocblock: Malformed @param tag (maybe var is missing?) at testdata/phpdoc/phpdoc.php:41
  * @param int
           ^^^
-WARNING phpdocLint: Non-canonical order of variable and type at testdata/phpdoc/phpdoc.php:42
+WARNING invalidDocblock: Non-canonical order of variable and type at testdata/phpdoc/phpdoc.php:42
  * @param $b       int
    ^^^^^^^^^^^^^^^^^^^
-WARNING phpdocLint: Malformed @param $c tag (maybe type is missing?) at testdata/phpdoc/phpdoc.php:43
+WARNING invalidDocblock: Malformed @param $c tag (maybe type is missing?) at testdata/phpdoc/phpdoc.php:43
  * @param $c
           ^^
-WARNING phpdocLint: Non-canonical order of variable and type at testdata/phpdoc/phpdoc.php:47
+WARNING invalidDocblock: Non-canonical order of variable and type at testdata/phpdoc/phpdoc.php:47
  * @param    $f - the z param
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   phpdocType: Invalid shape key: x[] at testdata/phpdoc/phpdoc.php:62
+MAYBE   invalidDocblockType: Invalid shape key: x[] at testdata/phpdoc/phpdoc.php:62
   /** @var    shape(x[]:a) */
               ^^^^^^^^^^^^
-MAYBE   phpdocType: Shape param #1: want key:type, found x at testdata/phpdoc/phpdoc.php:66
+MAYBE   invalidDocblockType: Shape param #1: want key:type, found x at testdata/phpdoc/phpdoc.php:66
   /** @var shape(x)    $a */
            ^^^^^^^^
-WARNING phpdocLint: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:70
+WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:70
   /*
 ^^^^
-WARNING phpdocLint: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
+WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
 /*
 ^^

--- a/src/tests/golden/testdata/phprocksyd/golden.txt
+++ b/src/tests/golden/testdata/phprocksyd/golden.txt
@@ -4,31 +4,31 @@ MAYBE   deprecated: Call to deprecated function dl (5.3) at testdata/phprocksyd/
 ERROR   constCase: Constant 'NULL' should be used in lower case as 'null' at testdata/phprocksyd/Phprocksyd.php:321
             $n = stream_select($read, $write, $except, NULL);
                                                        ^^^^
-WARNING phpdocLint: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:364
+WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:364
      * @param $stream_id
               ^^^^^^^^^^
-WARNING phpdocLint: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:365
+WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:365
      * @param $req
               ^^^^
-WARNING phpdocLint: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:389
+WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:389
      * @param $stream_id
               ^^^^^^^^^^
-WARNING phpdocLint: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:390
+WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:390
      * @param $req
               ^^^^
 WARNING unused: Variable $status is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/phprocksyd/Phprocksyd.php:394
         $status = null;
         ^^^^^^^
-WARNING phpdocLint: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:421
+WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:421
      * @param $stream_id
               ^^^^^^^^^^
-WARNING phpdocLint: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:422
+WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:422
      * @param $req
               ^^^^
-WARNING phpdocLint: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:443
+WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:443
      * @param $stream_id
               ^^^^^^^^^^
-WARNING phpdocLint: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:444
+WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:444
      * @param $req
               ^^^^
 ERROR   undefinedMethod: Call to undefined method {mixed}->run() at testdata/phprocksyd/Phprocksyd.php:479

--- a/src/tests/golden/testdata/twitter-api-php/golden.txt
+++ b/src/tests/golden/testdata/twitter-api-php/golden.txt
@@ -10,7 +10,7 @@ WARNING strictCmp: 3rd argument of in_array must be true when comparing strings 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/TwitterAPIExchange.php:223
             'oauth_version' => '1.0'
             ^^^^^^^^^^^^^^^^^^^^^^^^
-MAYBE   phpdocType: Use bool type instead of boolean at testdata/twitter-api-php/TwitterAPIExchange.php:267
+MAYBE   invalidDocblockType: Use bool type instead of boolean at testdata/twitter-api-php/TwitterAPIExchange.php:267
      * @param boolean $return      If true, returns data. This is left in for backward compatibility reasons
               ^^^^^^^
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/twitter-api-php/TwitterAPIExchange.php:286
@@ -19,7 +19,7 @@ WARNING strictCmp: 3rd argument of in_array must be true when comparing strings 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/TwitterAPIExchange.php:366
                 'oauth_signature_method', 'oauth_timestamp', 'oauth_token', 'oauth_version'))) {
                                                                             ^^^^^^^^^^^^^^^
-MAYBE   phpdocType: Use int type instead of integer at testdata/twitter-api-php/TwitterAPIExchange.php:404
+MAYBE   invalidDocblockType: Use int type instead of integer at testdata/twitter-api-php/TwitterAPIExchange.php:404
      * @return integer
                ^^^^^^^
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/index.php:10


### PR DESCRIPTION
`phpdocLint` => `invalidDocblock`
`phpdocType` => `invalidDocblockType`
`phpdocRef` => `invalidDocblockRef`