### PR TITLE
linter, ir: fixed panic on `catch` without variable and `types.Map.Erase` method

### DIFF
--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -1426,7 +1426,9 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.CloseCurlyBracketTkn = n.CloseCurlyBracketTkn
 
 		out.Types = c.convNodeSlice(n.Types)
-		out.Variable = c.convNode(n.Var).(*ir.SimpleVar)
+		if n.Var != nil {
+			out.Variable = c.convNode(n.Var).(*ir.SimpleVar)
+		}
 		out.Stmts = c.convNodeSlice(n.Stmts)
 		return out
 

--- a/src/ir/node_types.go
+++ b/src/ir/node_types.go
@@ -933,7 +933,7 @@ type CatchStmt struct {
 	OpenParenthesisTkn   *token.Token
 	Types                []Node
 	SeparatorTkns        []*token.Token
-	Variable             *SimpleVar
+	Variable             Node
 	CloseParenthesisTkn  *token.Token
 	OpenCurlyBracketTkn  *token.Token
 	Stmts                []Node

--- a/src/phpgrep/matcher.go
+++ b/src/phpgrep/matcher.go
@@ -357,7 +357,7 @@ func (m *matcher) eqNode(state *matcherState, x, y ir.Node) bool {
 		return ok && m.eqNode(state, x.Expr, y.Expr)
 	case *ir.CatchStmt:
 		y, ok := y.(*ir.CatchStmt)
-		return ok && m.eqSimpleVar(state, x.Variable, y.Variable) &&
+		return ok && m.eqNode(state, x.Variable, y.Variable) &&
 			m.eqNodeSlice(state, x.Types, y.Types) &&
 			m.eqNodeSlice(state, x.Stmts, y.Stmts)
 	case *ir.TryStmt:

--- a/src/tests/checkers/catch_test.go
+++ b/src/tests/checkers/catch_test.go
@@ -226,3 +226,13 @@ function f() {
 	}
 	test.RunAndMatch()
 }
+
+func TestCatchWithoutVariable(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+try {}
+catch (Exception) {}
+`)
+	test.Expect = []string{}
+	test.RunAndMatch()
+}

--- a/src/tests/exprtype/exprtype_test.go
+++ b/src/tests/exprtype/exprtype_test.go
@@ -3271,13 +3271,13 @@ function f2($a) {
   if ((($a = new Foo) || ($a = new Boo)) && $a instanceof Foo) {
     exprtype($a, "\Foo");
   } else {
-    exprtype($a, "precise \Boo");
+    exprtype($a, "\Boo");
   }
 
   if ((($a = new Foo) || ($a = 10)) && $a instanceof Foo) {
     exprtype($a, "\Foo");
   } else {
-    exprtype($a, "precise int");
+    exprtype($a, "int");
   }
 
   exprtype($add_res, "int");

--- a/src/types/map.go
+++ b/src/types/map.go
@@ -348,8 +348,16 @@ func (m Map) Erase(typ string) Map {
 	if m.Len() == 0 {
 		return m
 	}
-	delete(m.m, typ)
-	return m
+
+	mm := make(map[string]struct{}, m.Len())
+	for k, v := range m.m {
+		if k == typ {
+			continue
+		}
+		mm[k] = v
+	}
+
+	return Map{m: mm}
 }
 
 // Find applies a predicate function to every contained type.


### PR DESCRIPTION
Fixes #1141 