### PR TITLE
linter: added support for some attributes and moved to `phpstorm-stubs` upstream

### DIFF
--- a/src/attributes/attributes.go
+++ b/src/attributes/attributes.go
@@ -1,0 +1,67 @@
+package attributes
+
+import (
+	"github.com/VKCOM/noverify/src/ir"
+	"github.com/VKCOM/noverify/src/meta"
+	"github.com/VKCOM/noverify/src/types"
+)
+
+const (
+	LevelTypeAware       = `\JetBrains\PhpStorm\Internal\LanguageLevelTypeAware`
+	ElementAvailable     = `\JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable`
+	DeprecatedAnnotation = `\JetBrains\PhpStorm\Deprecated`
+)
+
+func TypeAware(groups []*ir.AttributeGroup, state *meta.ClassParseState) (typ types.Map) {
+	Each(groups, func(attr *ir.Attribute) bool {
+		if Name(attr, state) == LevelTypeAware && len(attr.Args) > 1 {
+			defaultType := NamedStringArgument(attr, "default")
+			if defaultType != "" {
+				typ = types.NewMap(defaultType)
+				return false
+			}
+		}
+
+		return true
+	})
+
+	return typ
+}
+
+func Available(groups []*ir.AttributeGroup, state *meta.ClassParseState) (res bool) {
+	res = true
+
+	Each(groups, func(attr *ir.Attribute) bool {
+		if Name(attr, state) == ElementAvailable && len(attr.Args) > 0 {
+			fromVersion := NamedStringArgument(attr, "from")
+			if fromVersion != "" {
+				res = fromVersion != "8.0" && fromVersion != "8.1"
+				return false
+			}
+			firstArg, ok := attr.Arg(0).Expr.(*ir.String)
+			if ok {
+				res = firstArg.Value != "8.0" && firstArg.Value != "8.1"
+				return false
+			}
+		}
+
+		return true
+	})
+
+	return res
+}
+
+func Deprecated(groups []*ir.AttributeGroup, state *meta.ClassParseState) (info meta.DeprecationInfo, ok bool) {
+	Each(groups, func(attr *ir.Attribute) bool {
+		if Name(attr, state) == DeprecatedAnnotation {
+			info.Reason = NamedStringArgument(attr, "reason")
+			info.Since = NamedStringArgument(attr, "since")
+			info.Replacement = NamedStringArgument(attr, "replacement")
+
+			info.Deprecated = true
+		}
+		return true
+	})
+
+	return info, info.Deprecated
+}

--- a/src/attributes/utils.go
+++ b/src/attributes/utils.go
@@ -1,0 +1,54 @@
+package attributes
+
+import (
+	"github.com/VKCOM/noverify/src/ir"
+	"github.com/VKCOM/noverify/src/meta"
+	"github.com/VKCOM/noverify/src/solver"
+)
+
+func Name(attr *ir.Attribute, state *meta.ClassParseState) string {
+	fqn, ok := solver.GetClassName(state, attr.Name)
+	if !ok {
+		return ""
+	}
+	return fqn
+}
+
+func NamedArgument(attr *ir.Attribute, name string) (ir.Node, bool) {
+	for i := range attr.Args {
+		arg := attr.Arg(i)
+		if arg.Name != nil && arg.Name.Value == name {
+			return arg.Expr, true
+		}
+	}
+
+	return nil, false
+}
+
+func NamedStringArgument(attr *ir.Attribute, name string) string {
+	expr, ok := NamedArgument(attr, name)
+	if !ok {
+		return ""
+	}
+
+	str, ok := expr.(*ir.String)
+	if !ok {
+		return ""
+	}
+
+	return str.Value
+}
+
+func Each(groups []*ir.AttributeGroup, cb func(attr *ir.Attribute) bool) {
+	for _, group := range groups {
+		if group == nil {
+			continue
+		}
+
+		for _, attr := range group.Attrs {
+			if !cb(attr) {
+				return
+			}
+		}
+	}
+}

--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -658,15 +658,6 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.ReturnsRef = hasValue(n.AmpersandTkn)
 		out.Static = hasValue(n.StaticTkn)
 
-		var tokenWithDoc *token.Token
-		if n.StaticTkn != nil {
-			tokenWithDoc = n.StaticTkn
-		} else {
-			tokenWithDoc = n.FnTkn
-		}
-
-		out.Doc = c.getPHPDoc(tokenWithDoc)
-
 		out.SeparatorTkns = n.SeparatorTkns
 		out.CloseParenthesisTkn = n.CloseParenthesisTkn
 		out.ColonTkn = n.ColonTkn
@@ -677,6 +668,8 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.DoubleArrowTkn = n.DoubleArrowTkn
 
 		out.Expr = c.convNode(n.Expr)
+
+		out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 		return out
 
 	case *ast.ExprBitwiseNot:
@@ -746,15 +739,6 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.OpenCurlyBracketTkn = n.OpenCurlyBracketTkn
 		out.CloseCurlyBracketTkn = n.CloseCurlyBracketTkn
 
-		var tokenWithDoc *token.Token
-		if n.StaticTkn != nil {
-			tokenWithDoc = n.StaticTkn
-		} else {
-			tokenWithDoc = n.FunctionTkn
-		}
-
-		out.Doc = c.getPHPDoc(tokenWithDoc)
-
 		out.Params = c.convNodeSlice(n.Params)
 
 		out.ClosureUse = &ir.ClosureUsesExpr{
@@ -771,6 +755,8 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 
 		out.ReturnsRef = hasValue(n.AmpersandTkn)
 		out.Static = hasValue(n.StaticTkn)
+
+		out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 		return out
 
 	case *ast.ExprClosureUse:
@@ -1465,9 +1451,9 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 			out.Modifiers = slice
 		}
 
-		out.Doc = c.getPHPDoc(n.ConstTkn)
-
 		out.Consts = c.convNodeSlice(n.Consts)
+
+		out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 		return out
 
 	case *ast.StmtClassMethod:
@@ -1490,15 +1476,6 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.CloseParenthesisTkn = n.CloseParenthesisTkn
 		out.ColonTkn = n.ColonTkn
 
-		var tokenWithDoc *token.Token
-		if len(n.Modifiers) != 0 {
-			tokenWithDoc = n.Modifiers[0].(*ast.Identifier).IdentifierTkn
-		} else {
-			tokenWithDoc = n.FunctionTkn
-		}
-
-		out.Doc = c.getPHPDoc(tokenWithDoc)
-
 		out.MethodName = c.convNode(n.Name).(*ir.Identifier)
 
 		if n.Modifiers != nil {
@@ -1513,6 +1490,8 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.ReturnType = c.convNode(n.ReturnType)
 		out.Stmt = c.convNode(n.Stmt)
 		out.ReturnsRef = hasValue(n.AmpersandTkn)
+
+		out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 		return out
 
 	case *ast.StmtConstList:
@@ -1759,14 +1738,14 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.OpenCurlyBracketTkn = n.OpenCurlyBracketTkn
 		out.CloseCurlyBracketTkn = n.CloseCurlyBracketTkn
 
-		out.Doc = c.getPHPDoc(n.FunctionTkn)
-
 		out.FunctionName = c.convNode(n.Name).(*ir.Identifier)
 		out.Params = c.convNodeSlice(n.Params)
 		out.ReturnType = c.convNode(n.ReturnType)
 		out.Stmts = c.convNodeSlice(n.Stmts)
 
 		out.ReturnsRef = hasValue(n.AmpersandTkn)
+
+		out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 		return out
 
 	case *ast.StmtGlobal:
@@ -1905,8 +1884,6 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.OpenCurlyBracketTkn = n.OpenCurlyBracketTkn
 		out.CloseCurlyBracketTkn = n.CloseCurlyBracketTkn
 
-		out.Doc = c.getPHPDoc(n.InterfaceTkn)
-
 		out.InterfaceName = c.convNode(n.Name).(*ir.Identifier)
 
 		out.Extends = &ir.InterfaceExtendsStmt{
@@ -1917,6 +1894,8 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		}
 
 		out.Stmts = c.convNodeSlice(n.Stmts)
+
+		out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 		return out
 
 	case *ast.StmtLabel:
@@ -1992,12 +1971,6 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 			out.Modifiers = slice
 		}
 
-		var tokenWithDoc *token.Token
-		if len(n.Modifiers) != 0 {
-			tokenWithDoc = n.Modifiers[0].(*ast.Identifier).IdentifierTkn
-		}
-		out.Doc = c.getPHPDoc(tokenWithDoc)
-
 		if n.AttrGroups != nil {
 			slice := make([]*ir.AttributeGroup, len(n.AttrGroups))
 			for i := range n.AttrGroups {
@@ -2008,6 +1981,8 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 
 		out.Type = c.convNode(n.Type)
 		out.Properties = c.convNodeSlice(n.Props)
+
+		out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 		return out
 
 	case *ast.StmtReturn:
@@ -2115,10 +2090,10 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		out.OpenCurlyBracketTkn = n.OpenCurlyBracketTkn
 		out.CloseCurlyBracketTkn = n.CloseCurlyBracketTkn
 
-		out.Doc = c.getPHPDoc(out.TraitTkn)
-
 		out.TraitName = c.convNode(n.Name).(*ir.Identifier)
 		out.Stmts = c.convNodeSlice(n.Stmts)
+
+		out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 		return out
 
 	case *ast.StmtTraitUse:
@@ -2455,14 +2430,6 @@ func (c *Converter) convClass(n *ast.StmtClass) ir.Node {
 		}
 	}
 
-	// If there are modifiers, then PHPDoc will be bound to the
-	// first one, otherwise to the class token.
-	if len(n.Modifiers) != 0 {
-		class.Doc = c.getPHPDoc(ir.GetFirstToken(c.convNode(n.Modifiers[0])))
-	} else {
-		class.Doc = c.getPHPDoc(n.ClassTkn)
-	}
-
 	if n.Name == nil {
 		// Anonymous class expression.
 		out := &ir.AnonClassExpr{
@@ -2478,6 +2445,8 @@ func (c *Converter) convClass(n *ast.StmtClass) ir.Node {
 		if n.Args != nil {
 			out.Args = c.convNodeSlice(n.Args)
 		}
+
+		out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 		return out
 	}
 
@@ -2504,6 +2473,8 @@ func (c *Converter) convClass(n *ast.StmtClass) ir.Node {
 		}
 		out.Modifiers = slice
 	}
+
+	out.Doc = c.getPHPDoc(ir.GetFirstToken(out))
 	return out
 }
 

--- a/src/ir/methods.go
+++ b/src/ir/methods.go
@@ -88,3 +88,6 @@ func (n *StaticCallExpr) Arg(i int) *Argument { return n.Args[i].(*Argument) }
 
 // Arg returns the ith argument.
 func (n *AnonClassExpr) Arg(i int) *Argument { return n.Args[i].(*Argument) }
+
+// Arg returns the ith argument.
+func (n *Attribute) Arg(i int) *Argument { return n.Args[i].(*Argument) }

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1276,14 +1276,14 @@ func (b *blockWalker) enterClosure(fun *ir.ClosureExpr, haveThis bool, thisType 
 	}
 
 	b.r.meta.Functions.Set(name, meta.FuncInfo{
-		Params:       params.params,
-		Name:         name,
-		Pos:          b.r.getElementPos(fun),
-		Typ:          returnTypes.Immutable(),
-		MinParamsCnt: params.minParamsCount,
-		Flags:        0,
-		ExitFlags:    exitFlags,
-		Doc:          doc.AdditionalInfo,
+		Params:          params.params,
+		Name:            name,
+		Pos:             b.r.getElementPos(fun),
+		Typ:             returnTypes.Immutable(),
+		MinParamsCnt:    params.minParamsCount,
+		Flags:           0,
+		ExitFlags:       exitFlags,
+		DeprecationInfo: doc.Deprecation,
 	})
 
 	return false

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -924,12 +924,12 @@ func (b *blockLinter) checkMultilineArrayTrailingComma(item *ir.ArrayItemExpr) {
 }
 
 func (b *blockLinter) checkDeprecatedFunctionCall(e *ir.FunctionCallExpr, call *funcCallInfo) {
-	if !call.info.Doc.Deprecated {
+	if !call.info.Deprecated {
 		return
 	}
 
-	if call.info.Doc.DeprecationNote != "" {
-		b.report(e.Function, LevelNotice, "deprecated", "Call to deprecated function %s (%s)", utils.NameNodeToString(e.Function), call.info.Doc.DeprecationNote)
+	if !call.info.WithDeprecationNote() {
+		b.report(e.Function, LevelNotice, "deprecated", "Call to deprecated function %s (%s)", utils.NameNodeToString(e.Function), call.info.DeprecationInfo)
 		return
 	}
 
@@ -1181,10 +1181,12 @@ func (b *blockLinter) checkMethodCall(e *ir.MethodCallExpr) {
 		}
 	}
 
-	if call.info.Doc.Deprecated {
-		if call.info.Doc.DeprecationNote != "" {
+	if call.info.Deprecated {
+		deprecation := call.info.DeprecationInfo
+
+		if !deprecation.WithDeprecationNote() {
 			b.report(e.Method, LevelNotice, "deprecated", "Call to deprecated method {%s}->%s() (%s)",
-				call.methodCallerType, call.methodName, call.info.Doc.DeprecationNote)
+				call.methodCallerType, call.methodName, deprecation)
 		} else {
 			b.report(e.Method, LevelNotice, "deprecatedUntagged", "Call to deprecated method {%s}->%s()",
 				call.methodCallerType, call.methodName)
@@ -1221,10 +1223,12 @@ func (b *blockLinter) checkStaticCall(e *ir.StaticCallExpr) {
 		b.report(e.Call, LevelWarning, "callStatic", "Calling instance method as static method")
 	}
 
-	if call.methodInfo.Info.Doc.Deprecated {
-		if call.methodInfo.Info.Doc.DeprecationNote != "" {
+	if call.methodInfo.Info.Deprecated {
+		deprecation := call.methodInfo.Info.DeprecationInfo
+
+		if !deprecation.WithDeprecationNote() {
 			b.report(e.Call, LevelNotice, "deprecated", "Call to deprecated static method %s::%s() (%s)",
-				call.className, call.methodName, call.methodInfo.Info.Doc.DeprecationNote)
+				call.className, call.methodName, deprecation)
 		} else {
 			b.report(e.Call, LevelNotice, "deprecatedUntagged", "Call to deprecated static method %s::%s()",
 				call.className, call.methodName)

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -928,7 +928,7 @@ func (b *blockLinter) checkDeprecatedFunctionCall(e *ir.FunctionCallExpr, call *
 		return
 	}
 
-	if !call.info.WithDeprecationNote() {
+	if call.info.WithDeprecationNote() {
 		b.report(e.Function, LevelNotice, "deprecated", "Call to deprecated function %s (%s)", utils.NameNodeToString(e.Function), call.info.DeprecationInfo)
 		return
 	}
@@ -1184,7 +1184,7 @@ func (b *blockLinter) checkMethodCall(e *ir.MethodCallExpr) {
 	if call.info.Deprecated {
 		deprecation := call.info.DeprecationInfo
 
-		if !deprecation.WithDeprecationNote() {
+		if deprecation.WithDeprecationNote() {
 			b.report(e.Method, LevelNotice, "deprecated", "Call to deprecated method {%s}->%s() (%s)",
 				call.methodCallerType, call.methodName, deprecation)
 		} else {
@@ -1226,7 +1226,7 @@ func (b *blockLinter) checkStaticCall(e *ir.StaticCallExpr) {
 	if call.methodInfo.Info.Deprecated {
 		deprecation := call.methodInfo.Info.DeprecationInfo
 
-		if !deprecation.WithDeprecationNote() {
+		if deprecation.WithDeprecationNote() {
 			b.report(e.Call, LevelNotice, "deprecated", "Call to deprecated static method %s::%s() (%s)",
 				call.className, call.methodName, deprecation)
 		} else {

--- a/src/linter/cache.go
+++ b/src/linter/cache.go
@@ -48,7 +48,8 @@ import (
 //     50 - added Flags field for meta.PropertyInfo
 //     51 - added anonymous classes
 //     52 - renamed all PhpDoc and Phpdoc with PHPDoc
-const cacheVersion = 52
+//     53 - added DeprecationInfo for functions and methods and support for some attributes
+const cacheVersion = 53
 
 var (
 	errWrongVersion = errors.New("Wrong cache version")

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -149,7 +149,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 5377
+		wantLen := 5442
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -158,7 +158,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "dca6b73961fb13308e2767c772441cc9817bd0bb7264bfbb6aa880dd25f37ec62f971d20d08507c091c95f59e1e92bcd796d4e2592be8ea021da500d4bc25b88"
+		wantStrings := "6f8052f5b69bd2561daa33a92146490af3f90cd8bc1df40ad871e14cfac7c13eceea8ec6032af98c10fe9469b3511a09d007fbd692c983381b9be91da13519ce"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/VKCOM/noverify/src/attributes"
 	"github.com/VKCOM/noverify/src/phpdoctypes"
 	"github.com/VKCOM/noverify/src/utils"
 	"github.com/VKCOM/php-parser/pkg/position"
@@ -475,69 +476,82 @@ type parseFuncParamsResult struct {
 	minParamsCount int
 }
 
-func (d *rootWalker) parseFuncParams(params []ir.Node, phpDocParamsTypes phpdoctypes.ParamsMap, sc *meta.Scope, closureSolver *solver.ClosureCallerInfo) (res parseFuncParamsResult) {
+func (d *rootWalker) parseFuncParams(params []ir.Node, docblockParams phpdoctypes.ParamsMap, sc *meta.Scope, closureSolver *solver.ClosureCallerInfo) (res parseFuncParamsResult) {
 	if len(params) == 0 {
 		return res
 	}
 
 	minArgs := 0
-	args := make([]meta.FuncParam, 0, len(params))
-	typeHints := make(map[string]types.Map, len(params))
+	parsedParams := make([]meta.FuncParam, 0, len(params))
+	paramHints := make(map[string]types.Map, len(params))
 
-	if closureSolver != nil && solver.IsSupportedFunction(closureSolver.Name) {
+	if closureSolver != nil && solver.IsClosureUseFunction(closureSolver.Name) {
 		return d.parseFuncArgsForCallback(params, sc, closureSolver)
 	}
 
-	for _, param := range params {
-		p := param.(*ir.Parameter)
-		v := p.Variable
-		phpDocType := phpDocParamsTypes[v.Name]
+	for _, p := range params {
+		param := p.(*ir.Parameter)
+		paramVar := param.Variable
+		paramType := types.Map{}
 
-		if !phpDocType.Typ.Empty() {
-			sc.AddVarName(v.Name, phpDocType.Typ, "param", meta.VarAlwaysDefined)
+		if !attributes.Available(param.AttrGroups, d.ctx.st) {
+			continue
 		}
 
-		paramTyp := phpDocType.Typ
+		docType := docblockParams[paramVar.Name]
 
-		if p.DefaultValue == nil && !phpDocType.Optional && !p.Variadic {
-			minArgs++
-		}
-
-		if p.VariableType != nil {
-			typeHintType, ok := d.parseTypeHintNode(p.VariableType)
+		// Handle type hint.
+		if param.VariableType != nil {
+			hintType, ok := d.parseTypeHintNode(param.VariableType)
 			if ok {
-				paramTyp = typeHintType
+				paramType = paramType.Append(hintType)
+				paramHints[paramVar.Name] = hintType
 			}
+		}
 
-			typeHints[v.Name] = typeHintType
-		} else if paramTyp.Empty() && p.DefaultValue != nil {
-			paramTyp = solver.ExprTypeLocal(sc, d.ctx.st, p.DefaultValue)
+		// Handle default value.
+		if paramType.Empty() && param.DefaultValue != nil {
+			paramType = solver.ExprTypeLocal(sc, d.ctx.st, param.DefaultValue)
 			// For the type resolver default value can look like a
 			// precise source of information (e.g. "false" is a precise bool),
 			// but it's not assigned unconditionally.
 			// If explicit argument is provided, that parameter can have
 			// almost any type possible.
-			paramTyp.MarkAsImprecise()
+			paramType.MarkAsImprecise()
 		}
 
-		if p.Variadic {
-			paramTyp = paramTyp.Map(types.WrapArrayOf)
+		// Handle variadic.
+		if param.Variadic {
+			paramType = paramType.Map(types.WrapArrayOf)
 		}
 
-		sc.AddVarName(v.Name, paramTyp, "param", meta.VarAlwaysDefined)
-
-		par := meta.FuncParam{
-			Typ:   paramTyp.Immutable(),
-			IsRef: p.ByRef,
+		// Append @param type.
+		if !docType.Typ.Empty() {
+			paramType = paramType.Append(docType.Typ)
 		}
 
-		par.Name = v.Name
-		args = append(args, par)
+		paramTypeAware := attributes.TypeAware(param.AttrGroups, d.ctx.st)
+		if !paramTypeAware.Empty() {
+			paramType = paramType.Append(paramTypeAware)
+		}
+
+		// Count min args count.
+		if param.DefaultValue == nil && !docType.Optional && !param.Variadic {
+			minArgs++
+		}
+
+		sc.AddVarName(paramVar.Name, paramType, "param", meta.VarAlwaysDefined)
+
+		parsedParams = append(parsedParams, meta.FuncParam{
+			Name:  paramVar.Name,
+			Typ:   paramType.Immutable(),
+			IsRef: param.ByRef,
+		})
 	}
 
 	return parseFuncParamsResult{
-		params:         args,
-		paramsTypeHint: typeHints,
+		params:         parsedParams,
+		paramsTypeHint: paramHints,
 		minParamsCount: minArgs,
 	}
 }
@@ -603,44 +617,50 @@ func (d *rootWalker) parseFuncArgsForCallback(params []ir.Node, sc *meta.Scope, 
 }
 
 func (d *rootWalker) enterFunction(fun *ir.FunctionStmt) bool {
-	nm := d.ctx.st.Namespace + `\` + fun.FunctionName.Value
-
 	if d.meta.Functions.H == nil {
 		d.meta.Functions = meta.NewFunctionsMap()
 	}
+
+	nm := d.ctx.st.Namespace + `\` + fun.FunctionName.Value
+	sc := meta.NewScope()
 
 	// Indexing stage.
 	doc := phpdoctypes.Parse(fun.Doc, fun.Params, d.ctx.typeNormalizer)
 	moveShapesToContext(&d.ctx, doc.Shapes)
 	d.handleClosuresFromDoc(doc.Closures)
 
-	phpDocReturnType := doc.ReturnType
-	phpDocParamTypes := doc.ParamTypes
+	// Handle attributes if any.
+	deprecation, ok := attributes.Deprecated(fun.AttrGroups, d.ctx.st)
+	if ok {
+		doc.Deprecation.Append(deprecation)
+	}
 
-	sc := meta.NewScope()
+	returnTypeHint, ok := d.parseTypeHintNode(fun.ReturnType)
+	if !ok {
+		returnTypeHint = attributes.TypeAware(fun.AttrGroups, d.ctx.st)
+	}
 
-	returnTypeHint, _ := d.parseTypeHintNode(fun.ReturnType)
-	funcParams := d.parseFuncParams(fun.Params, phpDocParamTypes, sc, nil)
+	funcParams := d.parseFuncParams(fun.Params, doc.ParamTypes, sc, nil)
 
 	funcInfo := d.handleFuncStmts(funcParams.params, nil, fun.Stmts, sc)
 	actualReturnTypes := funcInfo.returnTypes
 	exitFlags := funcInfo.prematureExitFlags
 
-	returnTypes := functionReturnType(phpDocReturnType, returnTypeHint, actualReturnTypes)
+	returnTypes := functionReturnType(doc.ReturnType, returnTypeHint, actualReturnTypes)
 
 	var funcFlags meta.FuncFlags
 	if solver.SideEffectFreeFunc(d.scope(), d.ctx.st, nil, fun.Stmts) {
 		funcFlags |= meta.FuncPure
 	}
 	d.meta.Functions.Set(nm, meta.FuncInfo{
-		Params:       funcParams.params,
-		Name:         nm,
-		Pos:          d.getElementPos(fun),
-		Typ:          returnTypes.Immutable(),
-		MinParamsCnt: funcParams.minParamsCount,
-		Flags:        funcFlags,
-		ExitFlags:    exitFlags,
-		Doc:          doc.AdditionalInfo,
+		Params:          funcParams.params,
+		Name:            nm,
+		Pos:             d.getElementPos(fun),
+		Typ:             returnTypes.Immutable(),
+		MinParamsCnt:    funcParams.minParamsCount,
+		Flags:           funcFlags,
+		ExitFlags:       exitFlags,
+		DeprecationInfo: doc.Deprecation,
 	})
 
 	return false
@@ -992,22 +1012,28 @@ func (d *rootWalker) enterClassMethod(meth *ir.ClassMethodStmt) bool {
 	moveShapesToContext(&d.ctx, doc.Shapes)
 	d.handleClosuresFromDoc(doc.Closures)
 
+	// Handle attributes if any.
+	deprecation, ok := attributes.Deprecated(meth.AttrGroups, d.ctx.st)
+	if ok {
+		doc.Deprecation.Append(deprecation)
+	}
+
 	// Check stage.
 	errors := d.checker.CheckPHPDoc(meth, meth.Doc, meth.Params)
 	d.reportPHPDocErrors(errors)
 
-	phpDocReturnType := doc.ReturnType
-	phpDocParamTypes := doc.ParamTypes
-
 	returnTypeHint, ok := d.parseTypeHintNode(meth.ReturnType)
-	if ok && !doc.Inherit {
-		d.checker.CheckFuncReturnType(meth.MethodName, meth.MethodName.Value, returnTypeHint, phpDocReturnType)
+	if !ok {
+		returnTypeHint = attributes.TypeAware(meth.AttrGroups, d.ctx.st)
+	} else if !doc.Inherit {
+		d.checker.CheckFuncReturnType(meth.MethodName, meth.MethodName.Value, returnTypeHint, doc.ReturnType)
 	}
+
 	d.checker.CheckTypeHintNode(meth.ReturnType, "return type")
 
-	funcParams := d.parseFuncParams(meth.Params, phpDocParamTypes, sc, nil)
+	funcParams := d.parseFuncParams(meth.Params, doc.ParamTypes, sc, nil)
 
-	d.checker.CheckFuncParams(meth.MethodName, meth.Params, funcParams, phpDocParamTypes)
+	d.checker.CheckFuncParams(meth.MethodName, meth.Params, funcParams, doc.ParamTypes)
 
 	if len(class.Interfaces) != 0 {
 		// If we implement interfaces, methods that take a part in this
@@ -1054,7 +1080,7 @@ func (d *rootWalker) enterClassMethod(meth *ir.ClassMethodStmt) bool {
 		d.checker.CheckParentConstructorCall(meth.MethodName, funcInfo.callsParentConstructor)
 	}
 
-	returnTypes := functionReturnType(phpDocReturnType, returnTypeHint, actualReturnTypes)
+	returnTypes := functionReturnType(doc.ReturnType, returnTypeHint, actualReturnTypes)
 
 	// TODO: handle duplicate method
 	var funcFlags meta.FuncFlags
@@ -1071,15 +1097,15 @@ func (d *rootWalker) enterClassMethod(meth *ir.ClassMethodStmt) bool {
 		funcFlags |= meta.FuncPure
 	}
 	class.Methods.Set(nm, meta.FuncInfo{
-		Params:       funcParams.params,
-		Name:         nm,
-		Pos:          d.getElementPos(meth),
-		Typ:          returnTypes.Immutable(),
-		MinParamsCnt: funcParams.minParamsCount,
-		AccessLevel:  modif.accessLevel,
-		Flags:        funcFlags,
-		ExitFlags:    exitFlags,
-		Doc:          doc.AdditionalInfo,
+		Params:          funcParams.params,
+		Name:            nm,
+		Pos:             d.getElementPos(meth),
+		Typ:             returnTypes.Immutable(),
+		MinParamsCnt:    funcParams.minParamsCount,
+		AccessLevel:     modif.accessLevel,
+		Flags:           funcFlags,
+		ExitFlags:       exitFlags,
+		DeprecationInfo: doc.Deprecation,
 	})
 
 	if nm == "getIterator" && d.metaInfo().IsIndexingComplete() && solver.Implements(d.metaInfo(), d.ctx.st.CurrentClass, `\IteratorAggregate`) {

--- a/src/linttest/inline.go
+++ b/src/linttest/inline.go
@@ -153,11 +153,16 @@ func (s *inlineTestSuite) handleFileContents(file string) (lines []string, repor
 
 	checkerName := filepath.Base(rawCheckerName)
 	checkerName = checkerName[:len(checkerName)-len(filepath.Ext(file))]
-	if !lint.Config().Checkers.Contains(checkerName) {
-		return nil, nil, fmt.Errorf("file name must be the name of the checker that is tested. Checker %s does not exist", checkerName)
+
+	if !strings.HasSuffix(checkerName, "_any") {
+		if !lint.Config().Checkers.Contains(checkerName) {
+			return nil, nil, fmt.Errorf("file name must be the name of the checker that is tested. Checker %s does not exist", checkerName)
+		}
+
+		return lines, filterReports([]string{checkerName}, res.Reports), nil
 	}
 
-	return lines, filterReports([]string{checkerName}, res.Reports), nil
+	return lines, res.Reports, nil
 }
 
 // createReportsByLine creates a map with a set of reports for each of the lines

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -56,7 +56,7 @@ func (i *DeprecationInfo) Append(other DeprecationInfo) {
 }
 
 func (i DeprecationInfo) WithDeprecationNote() bool {
-	return i.Reason == "" && i.Replacement == "" && i.Since == "" && i.RemovedReason == ""
+	return i.Reason != "" || i.Replacement != "" || i.Since != "" || i.RemovedReason != ""
 }
 
 func (i DeprecationInfo) String() (res string) {

--- a/src/meta/metainfo.go
+++ b/src/meta/metainfo.go
@@ -1,6 +1,8 @@
 package meta
 
 import (
+	"strings"
+
 	"github.com/VKCOM/noverify/src/types"
 )
 
@@ -22,9 +24,59 @@ const (
 	PropFromAnnotation PropertyFlags = 1 << iota
 )
 
-type PHPDocInfo struct {
-	Deprecated      bool
-	DeprecationNote string
+type DeprecationInfo struct {
+	Deprecated bool
+	Removed    bool
+
+	Reason        string
+	Replacement   string
+	Since         string
+	RemovedReason string
+}
+
+func (i *DeprecationInfo) Append(other DeprecationInfo) {
+	if !i.Deprecated {
+		i.Deprecated = other.Deprecated
+	}
+	if !i.Removed {
+		i.Removed = other.Removed
+	}
+
+	if i.Replacement == "" {
+		i.Replacement = other.Replacement
+	}
+	if i.Since == "" {
+		i.Since = other.Since
+	}
+	if i.RemovedReason == "" {
+		i.RemovedReason = other.RemovedReason
+	}
+
+	i.Reason = other.Reason
+}
+
+func (i DeprecationInfo) WithDeprecationNote() bool {
+	return i.Reason == "" && i.Replacement == "" && i.Since == "" && i.RemovedReason == ""
+}
+
+func (i DeprecationInfo) String() (res string) {
+	parts := make([]string, 0, 3)
+
+	if i.Since != "" {
+		parts = append(parts, "since: "+i.Since)
+	}
+	if i.Reason != "" {
+		reason := strings.TrimRight(i.Reason, ".!,")
+		parts = append(parts, "reason: "+reason)
+	}
+	if i.Replacement != "" {
+		parts = append(parts, "use "+i.Replacement+" instead")
+	}
+	if i.RemovedReason != "" {
+		parts = append(parts, "removed: "+i.RemovedReason)
+	}
+
+	return strings.Join(parts, ", ")
 }
 
 type AccessLevel int
@@ -71,7 +123,8 @@ type FuncInfo struct {
 	AccessLevel  AccessLevel
 	Flags        FuncFlags
 	ExitFlags    int // if function has exit/die/throw, then ExitFlags will be <> 0
-	Doc          PHPDocInfo
+
+	DeprecationInfo
 }
 
 func (info *FuncInfo) IsStatic() bool         { return info.Flags&FuncStatic != 0 }
@@ -79,6 +132,7 @@ func (info *FuncInfo) IsAbstract() bool       { return info.Flags&FuncAbstract !
 func (info *FuncInfo) IsPure() bool           { return info.Flags&FuncPure != 0 }
 func (info *FuncInfo) IsFromAnnotation() bool { return info.Flags&FuncFromAnnotation != 0 }
 func (info *FuncInfo) IsFinal() bool          { return info.Flags&FuncFinal != 0 }
+func (info *FuncInfo) IsDeprecated() bool     { return info.Deprecated }
 
 type OverrideType int
 

--- a/src/phpdoctypes/parser.go
+++ b/src/phpdoctypes/parser.go
@@ -17,10 +17,10 @@ type Param struct {
 type ParamsMap map[string]Param
 
 type ParseResult struct {
-	ReturnType     types.Map
-	ParamTypes     ParamsMap
-	AdditionalInfo meta.PHPDocInfo
-	Inherit        bool
+	ReturnType  types.Map
+	ParamTypes  ParamsMap
+	Deprecation meta.DeprecationInfo
+	Inherit     bool
 
 	Shapes   types.ShapesMap
 	Closures types.ClosureMap
@@ -41,8 +41,15 @@ func Parse(doc phpdoc.Comment, actualParams []ir.Node, normalizer types.Normaliz
 
 		if rawPart.Name() == "deprecated" {
 			part := rawPart.(*phpdoc.RawCommentPart)
-			result.AdditionalInfo.Deprecated = true
-			result.AdditionalInfo.DeprecationNote = part.ParamsText
+			result.Deprecation.Deprecated = true
+			result.Deprecation.Reason = part.ParamsText
+			continue
+		}
+
+		if rawPart.Name() == "removed" {
+			part := rawPart.(*phpdoc.RawCommentPart)
+			result.Deprecation.Removed = true
+			result.Deprecation.RemovedReason = part.ParamsText
 			continue
 		}
 

--- a/src/phpdoctypes/parser.go
+++ b/src/phpdoctypes/parser.go
@@ -53,6 +53,17 @@ func Parse(doc phpdoc.Comment, actualParams []ir.Node, normalizer types.Normaliz
 			continue
 		}
 
+		if rawPart.Name() == "see" {
+			part := rawPart.(*phpdoc.RawCommentPart)
+			if result.Deprecation.Deprecated {
+				if result.Deprecation.Replacement != "" {
+					result.Deprecation.Replacement += " or " + part.ParamsText
+				} else {
+					result.Deprecation.Replacement = part.ParamsText
+				}
+			}
+		}
+
 		if rawPart.Name() == "return" {
 			part := rawPart.(*phpdoc.TypeCommentPart)
 

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -92,7 +92,7 @@ type Rule struct {
 	Fix string
 
 	// Location is a phpgrep variable name that should be used as a warning location.
-	// Empty string selects the root node.
+	// WithDeprecationNote string selects the root node.
 	Location string
 
 	// Path is a filter-like rule switcher.

--- a/src/solver/closure.go
+++ b/src/solver/closure.go
@@ -18,7 +18,7 @@ var supportedFunctions = map[string]struct{}{
 	`\uasort`:               {},
 }
 
-func IsSupportedFunction(name string) bool {
+func IsClosureUseFunction(name string) bool {
 	_, ok := supportedFunctions[name]
 	return ok
 }

--- a/src/tests/checkers/deprecated_test.go
+++ b/src/tests/checkers/deprecated_test.go
@@ -65,9 +65,9 @@ WithText::staticMethod();
 
 `)
 	test.Expect = []string{
-		"Call to deprecated function funcWithText (use funcWithText2() instead)",
-		"Call to deprecated method {\\WithText}->method() (use method2() instead)",
-		"Call to deprecated static method \\WithText::staticMethod() (use staticMethod2() instead)",
+		"Call to deprecated function funcWithText (reason: use funcWithText2() instead)",
+		"Call to deprecated method {\\WithText}->method() (reason: use method2() instead)",
+		"Call to deprecated static method \\WithText::staticMethod() (reason: use staticMethod2() instead)",
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/checkers/phpdoc_test.go
+++ b/src/tests/checkers/phpdoc_test.go
@@ -230,7 +230,7 @@ function f() {
 }
 `)
 	test.Expect = []string{
-		`Call to deprecated method {\Foo}->legacyMethod1() (use newMethod instead)`,
+		`Call to deprecated method {\Foo}->legacyMethod1() (reason: use newMethod instead)`,
 		`Call to deprecated method {\Foo}->legacyMethod2()`,
 	}
 	test.RunAndMatch()
@@ -257,7 +257,7 @@ function f() {
 }
 `)
 	test.Expect = []string{
-		`Call to deprecated static method \Foo::legacyMethod1() (use newMethod instead)`,
+		`Call to deprecated static method \Foo::legacyMethod1() (reason: use newMethod instead)`,
 		`Call to deprecated static method \Foo::legacyMethod2()`,
 	}
 	test.RunAndMatch()
@@ -282,7 +282,7 @@ function f() {
 }
 `)
 	test.Expect = []string{
-		`Call to deprecated function legacy_function1 (use new_function instead)`,
+		`Call to deprecated function legacy_function1 (reason: use new_function instead)`,
 		`Call to deprecated function legacy_function2`,
 	}
 	test.RunAndMatch()

--- a/src/tests/golden/testdata/options-resolver/golden.txt
+++ b/src/tests/golden/testdata/options-resolver/golden.txt
@@ -4,22 +4,22 @@ MAYBE   typeHint: Specify the return type for the function getNormalizers in PHP
 MAYBE   typeHint: Specify the return type for the function getDeprecation in PHPDoc, 'array' type hint too generic at testdata/options-resolver/Debug/OptionsResolverIntrospector.php:116
     public function getDeprecation(string $option): array
                     ^^^^^^^^^^^^^^
-MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (7.4) at testdata/options-resolver/OptionsResolver.php:188
+MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:188
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
                                                                     ^^^^^^^^
-MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (7.4) at testdata/options-resolver/OptionsResolver.php:188
+MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:188
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
                                                                     ^^^^^^^^
-MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (7.4) at testdata/options-resolver/OptionsResolver.php:209
+MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
                                                                     ^^^^^^^^
-MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (7.4) at testdata/options-resolver/OptionsResolver.php:209
+MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
                                                                                                                                                                           ^^^^^^^^
-MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (7.4) at testdata/options-resolver/OptionsResolver.php:209
+MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
                                                                     ^^^^^^^^
-MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (7.4) at testdata/options-resolver/OptionsResolver.php:209
+MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
                                                                                                                                                                           ^^^^^^^^
 WARNING invalidDocblock: @param for non-existing argument $package at testdata/options-resolver/OptionsResolver.php:424

--- a/src/tests/golden/testdata/phprocksyd/golden.txt
+++ b/src/tests/golden/testdata/phprocksyd/golden.txt
@@ -1,4 +1,4 @@
-MAYBE   deprecated: Call to deprecated function dl (5.3) at testdata/phprocksyd/Phprocksyd.php:73
+MAYBE   deprecated: Call to deprecated function dl (since: 5.3) at testdata/phprocksyd/Phprocksyd.php:73
             if (!extension_loaded($ext) && !dl($ext . '.so')) {
                                             ^^
 ERROR   constCase: Constant 'NULL' should be used in lower case as 'null' at testdata/phprocksyd/Phprocksyd.php:321

--- a/src/tests/golden/testdata/underscore/golden.txt
+++ b/src/tests/golden/testdata/underscore/golden.txt
@@ -154,7 +154,7 @@ MAYBE   trailingComma: Last element in a multi-line array should have a trailing
 ERROR   undefinedProperty: Property {mixed}->_template_settings does not exist at testdata/underscore/underscore.php:909
       $ts = $class_name::getInstance()->_template_settings;
                                         ^^^^^^^^^^^^^^^^^^
-MAYBE   deprecated: Call to deprecated function create_function (7.2 Use anonymous functions instead.) at testdata/underscore/underscore.php:940
+MAYBE   deprecated: Call to deprecated function create_function (since: 7.2, reason: Use anonymous functions instead, removed: 8.0) at testdata/underscore/underscore.php:940
       $func = create_function('$context', $code);
               ^^^^^^^^^^^^^^^
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:970

--- a/src/tests/inline/testdata/php8/deprecated_annotation_any.php
+++ b/src/tests/inline/testdata/php8/deprecated_annotation_any.php
@@ -58,3 +58,24 @@ function f() {
   deprecatedReasonWithEmptyPHPDocRemoved(); // want `Call to deprecated function deprecatedReasonWithEmptyPHPDocRemoved (reason: use X instead, removed: 8.0)`
   deprecatedReasonWithPHPDocEmptyRemoved(); // want `Call to deprecated function deprecatedReasonWithPHPDocEmptyRemoved (reason: use X instead)`
 }
+
+function instead1() {}
+function instead2() {}
+
+/**
+ * @deprecated
+ * @see instead1()
+ */
+function deprecatedWithSee() {}
+
+/**
+ * @deprecated
+ * @see instead1()
+ * @see instead2()
+ */
+function deprecatedWithSeveralSee() {}
+
+function f1() {
+  deprecatedWithSee(); // want `Call to deprecated function deprecatedWithSee (use instead1() instead)`
+  deprecatedWithSeveralSee(); // want `Call to deprecated function deprecatedWithSeveralSee (use instead1() or instead2() instead)`
+}

--- a/src/tests/inline/testdata/php8/deprecated_annotation_any.php
+++ b/src/tests/inline/testdata/php8/deprecated_annotation_any.php
@@ -1,0 +1,60 @@
+<?php
+
+use JetBrains\PhpStorm\Deprecated;
+
+#[Deprecated]
+function deprecated() {}
+
+#[Deprecated(reason: "use X instead")]
+function deprecatedReason() {}
+
+#[Deprecated(since: "8.0")]
+function deprecatedSince() {}
+
+#[Deprecated(replacement: "X()")]
+function deprecatedReplacement() {}
+
+#[Deprecated(reason: "use X instead", since: "8.0")]
+function deprecatedReasonSince() {}
+
+#[Deprecated(reason: "use X instead", replacement: "X()", since: "8.0")]
+function deprecatedReasonReplacementSince() {}
+
+/**
+ * @deprecated use Y instead
+ */
+#[Deprecated(reason: "use X instead")]
+function deprecatedReasonWithPHPDoc() {}
+
+/**
+ * @deprecated
+ */
+#[Deprecated(reason: "use X instead")]
+function deprecatedReasonWithEmptyPHPDoc() {}
+
+/**
+ * @deprecated
+ * @removed 8.0
+ */
+#[Deprecated(reason: "use X instead")]
+function deprecatedReasonWithEmptyPHPDocRemoved() {}
+
+/**
+ * @deprecated use Y instead
+ * @removed
+ */
+#[Deprecated(reason: "use X instead")]
+function deprecatedReasonWithPHPDocEmptyRemoved() {}
+
+function f() {
+  deprecated();       // want `Call to deprecated function deprecated`
+  deprecatedReason(); // want `Call to deprecated function deprecatedReason (reason: use X instead)`
+  deprecatedSince();  // want `Call to deprecated function deprecatedSince (since: 8.0)`
+  deprecatedReplacement(); // want `Call to deprecated function deprecatedReplacement (use X() instead)`
+  deprecatedReasonSince(); // want `Call to deprecated function deprecatedReasonSince (since: 8.0, reason: use X instead)`
+  deprecatedReasonReplacementSince(); // want `Call to deprecated function deprecatedReasonReplacementSince (since: 8.0, reason: use X instead, use X() instead)`
+  deprecatedReasonWithPHPDoc();       // want `Call to deprecated function deprecatedReasonWithPHPDoc (reason: use X instead)`
+  deprecatedReasonWithEmptyPHPDoc();  // want `Call to deprecated function deprecatedReasonWithEmptyPHPDoc (reason: use X instead)`
+  deprecatedReasonWithEmptyPHPDocRemoved(); // want `Call to deprecated function deprecatedReasonWithEmptyPHPDocRemoved (reason: use X instead, removed: 8.0)`
+  deprecatedReasonWithPHPDocEmptyRemoved(); // want `Call to deprecated function deprecatedReasonWithPHPDocEmptyRemoved (reason: use X instead)`
+}

--- a/src/tests/inline/testdata/php8/param_available_any.php
+++ b/src/tests/inline/testdata/php8/param_available_any.php
@@ -1,0 +1,24 @@
+<?php
+
+use JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable;
+
+function f(
+  int $hour,
+  #[PhpStormStubsElementAvailable(from: '8.0')] int $seconds,
+) {}
+
+function f1(
+  int $hour,
+  #[PhpStormStubsElementAvailable(to: '7.4')] int $seconds,
+) {}
+
+function f2(
+  int $hour,
+  #[PhpStormStubsElementAvailable('8.0')] int $seconds,
+) {}
+
+function main() {
+  f(); // want `Too few arguments for f, expecting 1, saw 0`
+  f1(); // want `Too few arguments for f1, expecting 2, saw 0`
+  f2(); // want `Too few arguments for f2, expecting 1, saw 0`
+}

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -6,9 +6,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/VKCOM/noverify/src/ir/irutil"
-
 	"github.com/VKCOM/noverify/src/ir"
+	"github.com/VKCOM/noverify/src/ir/irutil"
 )
 
 // NameNodeToString converts nodes of *name.Name, and *node.Identifier to string.


### PR DESCRIPTION
- Added support for `Deprecated` annotation for functions
- Added support for `LanguageLevelTypeAware` annotation for functions return and param types
- Added support for `PhpStormStubsElementAvailable` for functions params
- Use info from `@removed` tag
- If `@deprecated` is empty for a function, but `@see` is present, then its value will be used as if `@deprecated` says `"use $see_text instead"`. Several `@see` will be concatenated and outputted with ` or ` separator

Fixed #576
Fixed #542 