### PR TITLE
Add rule @path-exclude rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ phplinter-output-*.json
 err.log
 src/cmd/stubs/phpstorm-stubs/
 y.output
+.idea
+vendor

--- a/docs/dynamic_rules.md
+++ b/docs/dynamic_rules.md
@@ -401,6 +401,27 @@ function ternarySimplify() {
 
 This rule will now only apply to files with the `common/` folder in the path.
 
+##### `@path-exclude`
+
+The `@path-exclude` restriction allows you to restrict the rule by file path.
+
+Thus, the rule will be applied only if there is a substring from `@path-exclude` in the file path.
+
+For example:
+
+```php
+function ternarySimplify() {
+  /**
+   * @maybe Could rewrite as '$x ?: $y'
+   * @pure $x
+   * @path-exclude common/
+   */
+  $x ? $x : $y;
+}
+```
+
+This rule will now don't apply to files with the `common/` folder in the path.
+
 #### Underline location (`@location`)
 
 For every warning that NoVerify finds, it underlines the location. However, for dynamic rules, the right place is not always underlined.

--- a/src/linter/utils.go
+++ b/src/linter/utils.go
@@ -471,6 +471,20 @@ func classHasProp(st *meta.ClassParseState, className, propName string) bool {
 	return ok
 }
 
+func isFilePathExcluded(filename string, rule rules.Rule) bool {
+	if len(rule.PathExcludes) == 0 {
+		return false
+	}
+
+	for exclude := range rule.PathExcludes {
+		if strings.Contains(filename, exclude) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func cloneRulesForFile(filename string, ruleSet *rules.ScopedSet) *rules.ScopedSet {
 	if ruleSet.CountRules == 0 {
 		return nil
@@ -480,7 +494,7 @@ func cloneRulesForFile(filename string, ruleSet *rules.ScopedSet) *rules.ScopedS
 	for kind, ruleByKind := range &ruleSet.RulesByKind {
 		res := make([]rules.Rule, 0, len(ruleByKind))
 		for _, rule := range ruleByKind {
-			if !strings.Contains(filename, rule.Path) {
+			if !strings.Contains(filename, rule.Path) || isFilePathExcluded(filename, rule) {
 				continue
 			}
 			res = append(res, rule)

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -235,6 +235,14 @@ func (p *parser) parseRuleInfo(st ir.Node, labelStmt ir.Node, proto *Rule) (Rule
 				return rule, p.errorf(st, "duplicate @path constraint")
 			}
 			rule.Path = part.Params[0]
+		case "path-exclude":
+			if len(part.Params) != 1 {
+				return rule, p.errorf(st, "@exclude expects exactly 1 param, got %d", len(part.Params))
+			}
+			if rule.PathExcludes == nil {
+				rule.PathExcludes = make(map[string]bool, 1)
+			}
+			rule.PathExcludes[part.Params[0]] = true
 		case "type":
 			if len(part.Params) != 2 {
 				return rule, p.errorf(st, "@type expects exactly 2 params, got %d", len(part.Params))

--- a/src/rules/parser_test.go
+++ b/src/rules/parser_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestParser(t *testing.T) {
+func TestParser_Parse(t *testing.T) {
 	p := NewParser()
 	rset, err := p.Parse("rules.php", strings.NewReader(`<?php
 /**
- * @comment This is an example of fully-docummented rule.
+ * @comment This is an example of fully-documented rule.
  * @before  array(1, 2)
  * @after   [1, 2]
  */
@@ -38,7 +38,7 @@ function arraySyntax() {
 		{
 			name: "arraySyntax",
 			doc: RuleDoc{
-				Comment: "This is an example of fully-docummented rule.",
+				Comment: "This is an example of fully-documented rule.",
 				Before:  "array(1, 2)",
 				After:   "[1, 2]",
 			},

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -99,6 +99,10 @@ type Rule struct {
 	// A rule is only applied to a file that contains a Path as a substring in its name.
 	Path string
 
+	// PathExcludes is a filter-like rule switcher.
+	// A rule is not applied to a file that contains a PathExcludes as a substring in its name.
+	PathExcludes map[string]bool
+
 	// Filters is a list of OR-connected filter sets.
 	// Every filter set is a mapping of phpgrep variable to a filter.
 	Filters []map[string]Filter

--- a/src/rules/util.go
+++ b/src/rules/util.go
@@ -24,6 +24,12 @@ func formatRule(r *Rule) string {
 		buf.WriteString(" * @path " + r.Path + "\n")
 	}
 
+	if r.PathExcludes != nil {
+		for pathExclude := range r.PathExcludes {
+			buf.WriteString(" * @path-exclude " + pathExclude + "\n")
+		}
+	}
+
 	if r.Location != "" {
 		buf.WriteString(" * @location $" + r.Location + "\n")
 	}


### PR DESCRIPTION
In some cases we need to exclude some files from checks. 
For example, you want to apply new rule for all files but exclude some legacy code.
I think rule @path-exclude can help us in this. 