### PR TITLE
added lost `EmptyTkn` in irconv for `ExprEmpty`

### DIFF
--- a/src/ir/irconv/irconv.go
+++ b/src/ir/irconv/irconv.go
@@ -800,6 +800,7 @@ func (c *Converter) convNode(n ast.Vertex) ir.Node {
 		}
 		out := &ir.EmptyExpr{}
 		out.Position = n.Position
+		out.EmptyTkn = n.EmptyTkn
 		out.OpenParenthesisTkn = n.OpenParenthesisTkn
 		out.CloseParenthesisTkn = n.CloseParenthesisTkn
 		out.Expr = c.convNode(n.Expr)


### PR DESCRIPTION
This affected checks that depended on tokens.