### PR TITLE
updated output format for reports

### DIFF
--- a/docs/diff.md
+++ b/docs/diff.md
@@ -105,9 +105,11 @@ sh noverify.sh
 The linter will now find a new error:
 
 ```
-<critical> WARNING unused: Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at /Users/petrmakhnev/swiftmailer/test_file.php:4
-  $a = 100;
-  ^^
+<critical> WARNING unused: Variable $a is unused at /Users/petrmakhnev/swiftmailer/test_file.php:4
+    |
+106 |  $a = 100;
+    |  ^^ use `$_` to ignore (see --unused-var-regex flag)
+
 ```
 
 If we create a commit:

--- a/docs/dynamic_rules.md
+++ b/docs/dynamic_rules.md
@@ -542,6 +542,8 @@ function yodaStyle() {
 }
 ```
 
+> Note that label name must start with `any_` or `seq_` or be equal to `any` or `seq`.
+
 Where all rules must be wrapped in `{}`. Thus, now any expression from the list will give a warning.
 
 > Note that you cannot write the `@fix` attribute in this case.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -148,9 +148,10 @@ noverify check --unused-var-regex='^null$|^e$' --allow-checks='unused' ./lib
 Then only a single place will be found where the declared variable is not really used.
 
 ```
-<critical> WARNING unused: Variable $name is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at swiftmailer/lib/classes/Swift/Mailer.php:73
-            foreach ($message->getTo() as $address => $name) {
-                                                      ^^^^^
+<critical> WARNING unused: Variable $name is unused at swiftmailer/lib/classes/Swift/Mailer.php:73
+    |
+106 |     foreach ($message->getTo() as $address => $name) {}
+    |                                               ^^^^^ use `$_` to ignore (see --unused-var-regex flag)
 ```
 
 In order to fix it, it is enough to rename the variable to `$null`.

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -347,8 +347,8 @@ func formatContext(r *linter.Report, cursor strings.Builder) string {
 
 	context := fmt.Sprintf(`%[1]s |
 %[2]d |%[3]s
-%[1]s |%[4]s
-`, strings.Repeat(" ", width), r.Line, r.Context, cursor.String())
+%[1]s |%[4]s %[5]s
+`, strings.Repeat(" ", width), r.Line, r.Context, cursor.String(), r.Hint)
 	return context
 }
 

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1158,7 +1158,8 @@ func (b *blockWalker) handleForeach(s *ir.ForeachStmt) bool {
 
 		b.untrackVarName(key.Name)
 
-		b.r.Report(s.Key, LevelWarning, "unused", "Foreach key $%s is unused, can simplify $%s => $%s to just $%s", key.Name, key.Name, variable.Name, variable.Name)
+		hint := fmt.Sprintf("can simplify $%s => $%s to just $%s", key.Name, variable.Name, variable.Name)
+		b.r.ReportWithHint(s.Key, LevelWarning, "unused", `Foreach key $%s is unused`, hint, key.Name)
 	}
 
 	return false
@@ -2191,7 +2192,7 @@ func (b *blockWalker) flushUnused() {
 			}
 
 			visitedMap[n] = struct{}{}
-			b.r.Report(n, LevelWarning, "unused", `Variable $%s is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`, name)
+			b.r.ReportWithHint(n, LevelWarning, "unused", `Variable $%s is unused`, "use `$_` to ignore (see --unused-var-regex flag)", name)
 		}
 	}
 }

--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -133,7 +133,7 @@ func (b *blockWalker) report(n ir.Node, level int, checkName, msg string, args .
 	b.r.Report(n, level, checkName, msg, args...)
 }
 
-func (b *blockWalker) reportWithHing(n ir.Node, level int, checkName, msg, hint string, args ...interface{}) {
+func (b *blockWalker) reportWithHint(n ir.Node, level int, checkName, msg, hint string, args ...interface{}) {
 	if b.isSuppressed(n, checkName) {
 		return
 	}
@@ -1232,7 +1232,7 @@ func (b *blockWalker) handleForeach(s *ir.ForeachStmt) bool {
 		b.untrackVarName(key.Name)
 
 		hint := fmt.Sprintf("can simplify $%s => $%s to just $%s", key.Name, variable.Name, variable.Name)
-		b.reportWithHing(s.Key, LevelWarning, "unused", `Foreach key $%s is unused`, hint, key.Name)
+		b.reportWithHint(s.Key, LevelWarning, "unused", `Foreach key $%s is unused`, hint, key.Name)
 	}
 
 	return false
@@ -2265,7 +2265,7 @@ func (b *blockWalker) flushUnused() {
 			}
 
 			visitedMap[n] = struct{}{}
-			b.reportWithHing(n, LevelWarning, "unused", `Variable $%s is unused`, "use `$_` to ignore (see --unused-var-regex flag)", name)
+			b.reportWithHint(n, LevelWarning, "unused", `Variable $%s is unused`, "use `$_` to ignore (see --unused-var-regex flag)", name)
 		}
 	}
 }

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -1142,6 +1142,7 @@ type Report struct {
 	CheckName string `json:"check_name"`
 	Level     int    `json:"level"`
 	Context   string `json:"context"`
+	Hint      string `json:"hint"`
 	Message   string `json:"message"`
 	Filename  string `json:"filename"`
 	Line      int    `json:"line"`

--- a/src/linter/root.go
+++ b/src/linter/root.go
@@ -1508,7 +1508,15 @@ func (d *rootWalker) ReportPHPDoc(phpDocLocation PHPDocLocation, level int, chec
 	d.ReportLocation(loc, level, checkName, msg, args...)
 }
 
+func (d *rootWalker) ReportWithHint(n ir.Node, level int, checkName, msg, hint string, args ...interface{}) {
+	d.report(n, level, checkName, msg, hint, args...)
+}
+
 func (d *rootWalker) Report(n ir.Node, level int, checkName, msg string, args ...interface{}) {
+	d.report(n, level, checkName, msg, "", args...)
+}
+
+func (d *rootWalker) report(n ir.Node, level int, checkName, msg, hint string, args ...interface{}) {
 	var pos position.Position
 
 	if n == nil {
@@ -1555,10 +1563,14 @@ func (d *rootWalker) Report(n ir.Node, level int, checkName, msg string, args ..
 		}
 	}
 
-	d.ReportLocation(loc, level, checkName, msg, args...)
+	d.reportLocation(loc, level, checkName, msg, hint, args...)
 }
 
 func (d *rootWalker) ReportLocation(loc ir.Location, level int, checkName, msg string, args ...interface{}) {
+	d.reportLocation(loc, level, checkName, msg, "", args...)
+}
+
+func (d *rootWalker) reportLocation(loc ir.Location, level int, checkName, msg, hint string, args ...interface{}) {
 	if !d.metaInfo().IsIndexingComplete() {
 		return
 	}
@@ -1605,6 +1617,7 @@ func (d *rootWalker) ReportLocation(loc ir.Location, level int, checkName, msg s
 		Level:     level,
 		Filename:  strings.ReplaceAll(d.ctx.st.CurrentFile, "\\", "/"), // To make output stable between platforms, see #572
 		Message:   fmt.Sprintf(msg, args...),
+		Hint:      hint,
 		Hash:      hash,
 	})
 }

--- a/src/linttest/golden_linttest.go
+++ b/src/linttest/golden_linttest.go
@@ -176,7 +176,11 @@ func (s *GoldenTestSuite) checkGoldenOutput(want []byte, reports []*linter.Repor
 			buf.WriteString(line)
 			buf.WriteString("\n")
 		}
-		ioutil.WriteFile(path, bytes.TrimSuffix(buf.Bytes(), []byte("\n")), 0644)
+		err := ioutil.WriteFile(path, bytes.TrimSuffix(buf.Bytes(), []byte("\n")), 0644)
+		if err != nil {
+			s.suite.t.Fatalf("write golden file: %v", err)
+			return
+		}
 		return
 	}
 

--- a/src/tests/checkers/arrow_functions_test.go
+++ b/src/tests/checkers/arrow_functions_test.go
@@ -74,10 +74,10 @@ function foo() {
 	test.Expect = []string{
 		`Cannot find referenced variable $undefined_variable`,
 		`Possibly undefined variable $maybe_defined`,
-		`Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
-		`Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
-		`Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
-		`Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
+		`Variable $a is unused`,
+		`Variable $a is unused`,
+		`Variable $a is unused`,
+		`Variable $a is unused`,
 		`Cannot find referenced variable $a`,
 		`Cannot find referenced variable $x`,
 		`Cannot find referenced variable $y`,
@@ -110,8 +110,8 @@ function f() {
 }
 `)
 	test.Expect = []string{
-		`Variable $a2 is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
-		`Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag)`,
+		`Variable $a2 is unused`,
+		`Variable $a is unused`,
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -191,8 +191,8 @@ function f() {
 }
 `)
 	test.Expect = []string{
-		`Foreach key $i is unused, can simplify $i => $v to just $v`,
-		`Foreach key $i is unused, can simplify $i => $v to just $v`,
+		`Foreach key $i is unused`,
+		`Foreach key $i is unused`,
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/golden/testdata/baseline-test/golden.txt
+++ b/src/tests/golden/testdata/baseline-test/golden.txt
@@ -1,6 +1,10 @@
 WARNING discardExpr: Expression evaluated but not used at testdata/baseline-test/src/file1.php:10
-  "this line is not suppressed";
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+10 |  "this line is not suppressed";
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   undefinedClass: Class or interface named \NonExisting does not exist at testdata/baseline-test/src/file2.php:5
-$bad = new NonExisting();
-           ^^^^^^^^^^^
+  |
+5 |$bad = new NonExisting();
+  |           ^^^^^^^^^^^
+

--- a/src/tests/golden/testdata/baseline-test/golden.txt
+++ b/src/tests/golden/testdata/baseline-test/golden.txt
@@ -1,10 +1,10 @@
 WARNING discardExpr: Expression evaluated but not used at testdata/baseline-test/src/file1.php:10
    |
 10 |  "this line is not suppressed";
-   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   undefinedClass: Class or interface named \NonExisting does not exist at testdata/baseline-test/src/file2.php:5
   |
 5 |$bad = new NonExisting();
-  |           ^^^^^^^^^^^
+  |           ^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/ctype/golden.txt
+++ b/src/tests/golden/testdata/ctype/golden.txt
@@ -1,18 +1,30 @@
 MAYBE   regexpSimplify: May re-write '/[^0-9]/' as '/\D/' at testdata/ctype/ctype.php:84
-        return \is_string($text) && '' !== $text && !preg_match('/[^0-9]/', $text);
-                                                                ^^^^^^^^^^
+   |
+84 |        return \is_string($text) && '' !== $text && !preg_match('/[^0-9]/', $text);
+   |                                                                ^^^^^^^^^^
+
 WARNING regexpVet: suspicious char range '!-~' in [^!-~] at testdata/ctype/ctype.php:100
-        return \is_string($text) && '' !== $text && !preg_match('/[^!-~]/', $text);
-                                                                ^^^^^^^^^^
+    |
+100 |        return \is_string($text) && '' !== $text && !preg_match('/[^!-~]/', $text);
+    |                                                                ^^^^^^^^^^
+
 WARNING regexpVet: suspicious char range ' -~' in [^ -~] at testdata/ctype/ctype.php:132
-        return \is_string($text) && '' !== $text && !preg_match('/[^ -~]/', $text);
-                                                                ^^^^^^^^^^
+    |
+132 |        return \is_string($text) && '' !== $text && !preg_match('/[^ -~]/', $text);
+    |                                                                ^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '/[^!-\/\:-@\[-`\{-~]/' as '/[^!-\/:-@\[-`\{-~]/' at testdata/ctype/ctype.php:148
-        return \is_string($text) && '' !== $text && !preg_match('/[^!-\/\:-@\[-`\{-~]/', $text);
-                                                                ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+148 |        return \is_string($text) && '' !== $text && !preg_match('/[^!-\/\:-@\[-`\{-~]/', $text);
+    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING regexpVet: suspicious char range '!-\/' in [^!-\/\:-@\[-`\{-~] at testdata/ctype/ctype.php:148
-        return \is_string($text) && '' !== $text && !preg_match('/[^!-\/\:-@\[-`\{-~]/', $text);
-                                                                ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+148 |        return \is_string($text) && '' !== $text && !preg_match('/[^!-\/\:-@\[-`\{-~]/', $text);
+    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '/[^\s]/' as '/\S/' at testdata/ctype/ctype.php:164
-        return \is_string($text) && '' !== $text && !preg_match('/[^\s]/', $text);
-                                                                ^^^^^^^^^
+    |
+164 |        return \is_string($text) && '' !== $text && !preg_match('/[^\s]/', $text);
+    |                                                                ^^^^^^^^^
+

--- a/src/tests/golden/testdata/ctype/golden.txt
+++ b/src/tests/golden/testdata/ctype/golden.txt
@@ -1,30 +1,30 @@
 MAYBE   regexpSimplify: May re-write '/[^0-9]/' as '/\D/' at testdata/ctype/ctype.php:84
    |
 84 |        return \is_string($text) && '' !== $text && !preg_match('/[^0-9]/', $text);
-   |                                                                ^^^^^^^^^^
+   |                                                                ^^^^^^^^^^ 
 
 WARNING regexpVet: suspicious char range '!-~' in [^!-~] at testdata/ctype/ctype.php:100
     |
 100 |        return \is_string($text) && '' !== $text && !preg_match('/[^!-~]/', $text);
-    |                                                                ^^^^^^^^^^
+    |                                                                ^^^^^^^^^^ 
 
 WARNING regexpVet: suspicious char range ' -~' in [^ -~] at testdata/ctype/ctype.php:132
     |
 132 |        return \is_string($text) && '' !== $text && !preg_match('/[^ -~]/', $text);
-    |                                                                ^^^^^^^^^^
+    |                                                                ^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '/[^!-\/\:-@\[-`\{-~]/' as '/[^!-\/:-@\[-`\{-~]/' at testdata/ctype/ctype.php:148
     |
 148 |        return \is_string($text) && '' !== $text && !preg_match('/[^!-\/\:-@\[-`\{-~]/', $text);
-    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^
+    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING regexpVet: suspicious char range '!-\/' in [^!-\/\:-@\[-`\{-~] at testdata/ctype/ctype.php:148
     |
 148 |        return \is_string($text) && '' !== $text && !preg_match('/[^!-\/\:-@\[-`\{-~]/', $text);
-    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^
+    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '/[^\s]/' as '/\S/' at testdata/ctype/ctype.php:164
     |
 164 |        return \is_string($text) && '' !== $text && !preg_match('/[^\s]/', $text);
-    |                                                                ^^^^^^^^^
+    |                                                                ^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/embeddedrules/golden.txt
+++ b/src/tests/golden/testdata/embeddedrules/golden.txt
@@ -1,520 +1,520 @@
 WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:5
   |
 5 |  $_ = strpos('/', $s);
-  |       ^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^^^^^^ 
 
 WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:6
   |
 6 |  $_ = strpos("/", $s);
-  |       ^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^^^^^^ 
 
 WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:21
    |
 21 |  $_ = stripos('/', $s);
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:22
    |
 22 |  $_ = stripos("/", $s);
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING argsOrder: Potentially incorrect replacement and subject arguments order at testdata/embeddedrules/argsOrder.php:32
    |
 32 |  $_ = preg_replace($pat, $subj, 'replacement');
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING argsOrder: Potentially incorrect delimiter and string arguments order at testdata/embeddedrules/argsOrder.php:41
    |
 41 |  $_ = explode($s, '/');
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING argsOrder: Potentially incorrect replace and string arguments order at testdata/embeddedrules/argsOrder.php:50
    |
 50 |  $_ = str_replace($search, $subj, ' ');
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING argsOrder: Potentially incorrect replace and string arguments order at testdata/embeddedrules/argsOrder.php:51
    |
 51 |  $_ = str_replace($search, $subj, '');
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a += $b` at testdata/embeddedrules/assignOp.php:6
   |
 6 |  $a = $a + $b; // Could rewrite
-  |  ^^^^^^^^^^^^
+  |  ^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a -= $b` at testdata/embeddedrules/assignOp.php:13
    |
 13 |  $a = $a - $b; // Could rewrite
-   |  ^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a *= $b` at testdata/embeddedrules/assignOp.php:20
    |
 20 |  $a = $a * $b; // Could rewrite
-   |  ^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a /= $b` at testdata/embeddedrules/assignOp.php:27
    |
 27 |  $a = $a / $b; // Could rewrite
-   |  ^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a %= $b` at testdata/embeddedrules/assignOp.php:34
    |
 34 |  $a = $a % $b; // Could rewrite
-   |  ^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a .= $b` at testdata/embeddedrules/assignOp.php:41
    |
 41 |  $a = $a . $b; // Could rewrite
-   |  ^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a &= $b` at testdata/embeddedrules/assignOp.php:48
    |
 48 |  $a = $a & $b; // Could rewrite
-   |  ^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a |= $b` at testdata/embeddedrules/assignOp.php:55
    |
 55 |  $a = $a | $b; // Could rewrite
-   |  ^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a ^= $b` at testdata/embeddedrules/assignOp.php:62
    |
 62 |  $a = $a ^ $b; // Could rewrite
-   |  ^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a <<= $b` at testdata/embeddedrules/assignOp.php:69
    |
 69 |  $a = $a << $b; // Could rewrite
-   |  ^^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a >>= $b` at testdata/embeddedrules/assignOp.php:76
    |
 76 |  $a = $a >> $b; // Could rewrite
-   |  ^^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$a ??= $b` at testdata/embeddedrules/assignOp.php:83
    |
 83 |  $a = $a ?? $b; // Could rewrite
-   |  ^^^^^^^^^^^^^
+   |  ^^^^^^^^^^^^^ 
 
 WARNING bitwiseOps: Used & bitwise operator over bool operands, perhaps && is intended? at testdata/embeddedrules/bitwiseOps.php:8
   |
 8 |  $_ = (($x > 0) & ($x != 15)); // Bad 1
-  |        ^^^^^^^^^^^^^^^^^^^^^
+  |        ^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING bitwiseOps: Used | bitwise operator over bool operands, perhaps || is intended? at testdata/embeddedrules/bitwiseOps.php:9
   |
 9 |  $_ = (($x == 1) | ($x == 2)); // Bad 2
-  |        ^^^^^^^^^^^^^^^^^^^^^
+  |        ^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to array_key_exists('abc', $array) at testdata/embeddedrules/callSimplify.php:7
   |
 7 |    $_ = in_array('abc', array_keys($array)); // bad
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $str[$index] at testdata/embeddedrules/callSimplify.php:14
    |
 14 |    $_ = substr($str, $index, 1);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to "hello"[$index] at testdata/embeddedrules/callSimplify.php:15
    |
 15 |    $_ = substr("hello", $index, 1);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to "hello"[2] at testdata/embeddedrules/callSimplify.php:16
    |
 16 |    $_ = substr("hello", 2, 1);
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $array[] = $val at testdata/embeddedrules/callSimplify.php:27
    |
 27 |    array_push($array, $val);
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $array[] = 10 at testdata/embeddedrules/callSimplify.php:28
    |
 28 |    array_push($array, 10);
-   |    ^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:14
    |
 14 |    $_ = $a{0};
-   |         ^^^^^
+   |         ^^^^^ 
 
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:15
    |
 15 |    $_ = $a[0]{0};
-   |         ^^^^^^^^
+   |         ^^^^^^^^ 
 
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:6
   |
 6 |$_ = $b{0};
-  |     ^^^^^
+  |     ^^^^^ 
 
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:7
   |
 7 |$_ = $b[0]{0};
-  |     ^^^^^^^^
+  |     ^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:21
    |
 21 |$_ = strpos($str, 10);
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:22
    |
 22 |$_ = strpos($str, getInt());
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:27
    |
 27 |$_ = strrpos($str, 10);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:28
    |
 28 |$_ = strrpos($str, getInt());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:33
    |
 33 |$_ = stripos($str, 10);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:34
    |
 34 |$_ = stripos($str, getInt());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:39
    |
 39 |$_ = strripos($str, 10);
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:40
    |
 40 |$_ = strripos($str, getInt());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:45
    |
 45 |$_ = strstr($str, 10);
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:46
    |
 46 |$_ = strstr($str, getInt());
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:51
    |
 51 |$_ = strchr($str, 10);
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:52
    |
 52 |$_ = strchr($str, getInt());
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:57
    |
 57 |$_ = strrchr($str, 10);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:58
    |
 58 |$_ = strrchr($str, getInt());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:63
    |
 63 |$_ = stristr($str, 10);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^ 
 
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:64
    |
 64 |$_ = stristr($str, getInt());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING langDeprecated: Since PHP 7.3, the definition of case insensitive constants has been deprecated at testdata/embeddedrules/langDeprecated.php:3
   |
 3 |define("Z_CONST", 1, true);
-  |^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING langDeprecated: Define defaults to a case sensitive constant, the third argument can be removed at testdata/embeddedrules/langDeprecated.php:4
   |
 4 |define("Z_CONST1", 2, false);
-  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING offBy1: Probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:11
    |
 11 |  $_ = $xs[count($xs)];
-   |       ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^ 
 
 WARNING offBy1: Probably intended to use sizeof-1 as an index at testdata/embeddedrules/offBy1.php:12
    |
 12 |  $_ = $xs[sizeof($xs)];
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING offBy1: Probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:14
    |
 14 |  if ($tabs[count($tabs)] == "") {
-   |      ^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: == has higher precedence than & at testdata/embeddedrules/precedence.php:4
   |
 4 |  $_ = 0 == $mask & $x;
-  |       ^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^^^^^^ 
 
 WARNING precedence: != has higher precedence than & at testdata/embeddedrules/precedence.php:5
   |
 5 |  $_ = 0 != $mask & $x;
-  |       ^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^^^^^^ 
 
 WARNING precedence: === has higher precedence than & at testdata/embeddedrules/precedence.php:6
   |
 6 |  $_ = 0 === $mask & $x;
-  |       ^^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: !== has higher precedence than & at testdata/embeddedrules/precedence.php:7
   |
 7 |  $_ = 0 !== $mask & $x;
-  |       ^^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: == has higher precedence than | at testdata/embeddedrules/precedence.php:9
   |
 9 |  $_ = 0 == $mask | $x;
-  |       ^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^^^^^^ 
 
 WARNING precedence: != has higher precedence than | at testdata/embeddedrules/precedence.php:10
    |
 10 |  $_ = 0 != $mask | $x;
-   |       ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^ 
 
 WARNING precedence: === has higher precedence than | at testdata/embeddedrules/precedence.php:11
    |
 11 |  $_ = 0 === $mask | $x;
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: !== has higher precedence than | at testdata/embeddedrules/precedence.php:12
    |
 12 |  $_ = 0 !== $mask | $x;
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: > has higher precedence than ?? at testdata/embeddedrules/precedence.php:14
    |
 14 |  $_ = $mask > $z ?? $x;
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: < has higher precedence than ?? at testdata/embeddedrules/precedence.php:15
    |
 15 |  $_ = $mask < $z ?? $x;
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: <= has higher precedence than ?? at testdata/embeddedrules/precedence.php:16
    |
 16 |  $_ = $mask <= $z ?? $x;
-   |       ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: >= has higher precedence than ?? at testdata/embeddedrules/precedence.php:17
    |
 17 |  $_ = $mask >= $z ?? $x;
-   |       ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: == has higher precedence than ?? at testdata/embeddedrules/precedence.php:18
    |
 18 |  $_ = $mask == $z ?? $x;
-   |       ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: != has higher precedence than ?? at testdata/embeddedrules/precedence.php:19
    |
 19 |  $_ = $mask != $z ?? $x;
-   |       ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: === has higher precedence than ?? at testdata/embeddedrules/precedence.php:20
    |
 20 |  $_ = $mask === $z ?? $x;
-   |       ^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: !== has higher precedence than ?? at testdata/embeddedrules/precedence.php:21
    |
 21 |  $_ = $mask !== $z ?? $x;
-   |       ^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: == has higher precedence than & at testdata/embeddedrules/precedence.php:25
    |
 25 |  $_ = $x & $mask == 0;
-   |       ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^ 
 
 WARNING precedence: != has higher precedence than & at testdata/embeddedrules/precedence.php:26
    |
 26 |  $_ = $x & $mask != 0;
-   |       ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^ 
 
 WARNING precedence: === has higher precedence than & at testdata/embeddedrules/precedence.php:27
    |
 27 |  $_ = $x & $mask === 0;
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: !== has higher precedence than & at testdata/embeddedrules/precedence.php:28
    |
 28 |  $_ = $x & $mask !== 0;
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: == has higher precedence than | at testdata/embeddedrules/precedence.php:30
    |
 30 |  $_ = $x | $mask == 0;
-   |       ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^ 
 
 WARNING precedence: != has higher precedence than | at testdata/embeddedrules/precedence.php:31
    |
 31 |  $_ = $x | $mask != 0;
-   |       ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^ 
 
 WARNING precedence: === has higher precedence than | at testdata/embeddedrules/precedence.php:32
    |
 32 |  $_ = $x | $mask === 0;
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING precedence: !== has higher precedence than | at testdata/embeddedrules/precedence.php:33
    |
 33 |  $_ = $x | $mask !== 0;
-   |       ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:6
   |
 6 |  $_ = ($x == false);
-  |        ^^^^^^^^^^^
+  |        ^^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:7
   |
 7 |  $_ = (false == $x);
-  |        ^^^^^^^^^^^
+  |        ^^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:8
   |
 8 |  $_ = ($x == true);
-  |        ^^^^^^^^^^
+  |        ^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:9
   |
 9 |  $_ = (true == $x);
-  |        ^^^^^^^^^^
+  |        ^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:10
    |
 10 |  $_ = ($x == null);
-   |        ^^^^^^^^^^
+   |        ^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:11
    |
 11 |  $_ = (null == $x);
-   |        ^^^^^^^^^^
+   |        ^^^^^^^^^^ 
 
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/embeddedrules/strictCmp.php:25
    |
 25 |  $_ = in_array("str", $a);
-   |       ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/embeddedrules/strictCmp.php:26
    |
 26 |  $_ = in_array(retString(), $a);
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: 3rd argument of array_search must be true when comparing strings at testdata/embeddedrules/strictCmp.php:27
    |
 27 |  $_ = array_search("str", $a);
-   |       ^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: 3rd argument of array_search must be true when comparing strings at testdata/embeddedrules/strictCmp.php:28
    |
 28 |  $_ = array_search(retString(), $a);
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:15
    |
 15 |$_ = (nonStrictComparison(0) != false);
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:16
    |
 16 |$_ = (false != nonStrictComparison(0));
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:17
    |
 17 |$_ = (nonStrictComparison(0) != true);
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:18
    |
 18 |$_ = (true != nonStrictComparison(0));
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:19
    |
 19 |$_ = (nonStrictComparison(0) != null);
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:20
    |
 20 |$_ = (null != nonStrictComparison(0));
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `(bool)$x` at testdata/embeddedrules/ternarySimplify.php:6
   |
 6 |    sink($x ? true : false);
-  |         ^^^^^^^^^^^^^^^^^
+  |         ^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could replace the ternary with just $x > $y at testdata/embeddedrules/ternarySimplify.php:9
   |
 9 |    sink($x > $y ? true : false);
-  |         ^^^^^^^^^^^^^^^^^^^^^^
+  |         ^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$x ?: $y` at testdata/embeddedrules/ternarySimplify.php:12
    |
 12 |    sink($x ? $x : $y);
-   |         ^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$x[1] ?? $y` at testdata/embeddedrules/ternarySimplify.php:15
    |
 15 |    sink(isset($x[1]) ? $x[1] : $y);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:22
    |
 22 |    sink($x_arr[10] !== null ? $x_arr[10] : $y);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:23
    |
 23 |    sink(null !== $x_arr[10] ? $x_arr[10] : $y);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:24
    |
 24 |    sink($x_arr[10] === null ? $y : $x_arr[10]);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:25
    |
 25 |    sink(null === $x_arr[10] ? $y : $x_arr[10]);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? null` at testdata/embeddedrules/ternarySimplify.php:27
    |
 27 |    sink(array_key_exists(10, $x_arr) ? $x_arr[10] : null);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? null` at testdata/embeddedrules/ternarySimplify.php:28
    |
 28 |    sink(! array_key_exists(10, $x_arr) ? null : $x_arr[10]);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `(bool)($flags & SOME_MASK)` at testdata/embeddedrules/ternarySimplify.php:46
    |
 46 |    sink(($flags & SOME_MASK) ? true : false);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/embeddedrules/golden.txt
+++ b/src/tests/golden/testdata/embeddedrules/golden.txt
@@ -1,312 +1,520 @@
 WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:5
-  $_ = strpos('/', $s);
-       ^^^^^^^^^^^^^^^
+  |
+5 |  $_ = strpos('/', $s);
+  |       ^^^^^^^^^^^^^^^
+
 WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:6
-  $_ = strpos("/", $s);
-       ^^^^^^^^^^^^^^^
+  |
+6 |  $_ = strpos("/", $s);
+  |       ^^^^^^^^^^^^^^^
+
 WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:21
-  $_ = stripos('/', $s);
-       ^^^^^^^^^^^^^^^^
+   |
+21 |  $_ = stripos('/', $s);
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING argsOrder: Potentially incorrect haystack and needle arguments order at testdata/embeddedrules/argsOrder.php:22
-  $_ = stripos("/", $s);
-       ^^^^^^^^^^^^^^^^
+   |
+22 |  $_ = stripos("/", $s);
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING argsOrder: Potentially incorrect replacement and subject arguments order at testdata/embeddedrules/argsOrder.php:32
-  $_ = preg_replace($pat, $subj, 'replacement');
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+32 |  $_ = preg_replace($pat, $subj, 'replacement');
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING argsOrder: Potentially incorrect delimiter and string arguments order at testdata/embeddedrules/argsOrder.php:41
-  $_ = explode($s, '/');
-       ^^^^^^^^^^^^^^^^
+   |
+41 |  $_ = explode($s, '/');
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING argsOrder: Potentially incorrect replace and string arguments order at testdata/embeddedrules/argsOrder.php:50
-  $_ = str_replace($search, $subj, ' ');
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+50 |  $_ = str_replace($search, $subj, ' ');
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING argsOrder: Potentially incorrect replace and string arguments order at testdata/embeddedrules/argsOrder.php:51
-  $_ = str_replace($search, $subj, '');
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+51 |  $_ = str_replace($search, $subj, '');
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a += $b` at testdata/embeddedrules/assignOp.php:6
-  $a = $a + $b; // Could rewrite
-  ^^^^^^^^^^^^
+  |
+6 |  $a = $a + $b; // Could rewrite
+  |  ^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a -= $b` at testdata/embeddedrules/assignOp.php:13
-  $a = $a - $b; // Could rewrite
-  ^^^^^^^^^^^^
+   |
+13 |  $a = $a - $b; // Could rewrite
+   |  ^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a *= $b` at testdata/embeddedrules/assignOp.php:20
-  $a = $a * $b; // Could rewrite
-  ^^^^^^^^^^^^
+   |
+20 |  $a = $a * $b; // Could rewrite
+   |  ^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a /= $b` at testdata/embeddedrules/assignOp.php:27
-  $a = $a / $b; // Could rewrite
-  ^^^^^^^^^^^^
+   |
+27 |  $a = $a / $b; // Could rewrite
+   |  ^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a %= $b` at testdata/embeddedrules/assignOp.php:34
-  $a = $a % $b; // Could rewrite
-  ^^^^^^^^^^^^
+   |
+34 |  $a = $a % $b; // Could rewrite
+   |  ^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a .= $b` at testdata/embeddedrules/assignOp.php:41
-  $a = $a . $b; // Could rewrite
-  ^^^^^^^^^^^^
+   |
+41 |  $a = $a . $b; // Could rewrite
+   |  ^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a &= $b` at testdata/embeddedrules/assignOp.php:48
-  $a = $a & $b; // Could rewrite
-  ^^^^^^^^^^^^
+   |
+48 |  $a = $a & $b; // Could rewrite
+   |  ^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a |= $b` at testdata/embeddedrules/assignOp.php:55
-  $a = $a | $b; // Could rewrite
-  ^^^^^^^^^^^^
+   |
+55 |  $a = $a | $b; // Could rewrite
+   |  ^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a ^= $b` at testdata/embeddedrules/assignOp.php:62
-  $a = $a ^ $b; // Could rewrite
-  ^^^^^^^^^^^^
+   |
+62 |  $a = $a ^ $b; // Could rewrite
+   |  ^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a <<= $b` at testdata/embeddedrules/assignOp.php:69
-  $a = $a << $b; // Could rewrite
-  ^^^^^^^^^^^^^
+   |
+69 |  $a = $a << $b; // Could rewrite
+   |  ^^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a >>= $b` at testdata/embeddedrules/assignOp.php:76
-  $a = $a >> $b; // Could rewrite
-  ^^^^^^^^^^^^^
+   |
+76 |  $a = $a >> $b; // Could rewrite
+   |  ^^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$a ??= $b` at testdata/embeddedrules/assignOp.php:83
-  $a = $a ?? $b; // Could rewrite
-  ^^^^^^^^^^^^^
+   |
+83 |  $a = $a ?? $b; // Could rewrite
+   |  ^^^^^^^^^^^^^
+
 WARNING bitwiseOps: Used & bitwise operator over bool operands, perhaps && is intended? at testdata/embeddedrules/bitwiseOps.php:8
-  $_ = (($x > 0) & ($x != 15)); // Bad 1
-        ^^^^^^^^^^^^^^^^^^^^^
+  |
+8 |  $_ = (($x > 0) & ($x != 15)); // Bad 1
+  |        ^^^^^^^^^^^^^^^^^^^^^
+
 WARNING bitwiseOps: Used | bitwise operator over bool operands, perhaps || is intended? at testdata/embeddedrules/bitwiseOps.php:9
-  $_ = (($x == 1) | ($x == 2)); // Bad 2
-        ^^^^^^^^^^^^^^^^^^^^^
+  |
+9 |  $_ = (($x == 1) | ($x == 2)); // Bad 2
+  |        ^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to array_key_exists('abc', $array) at testdata/embeddedrules/callSimplify.php:7
-    $_ = in_array('abc', array_keys($array)); // bad
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+7 |    $_ = in_array('abc', array_keys($array)); // bad
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $str[$index] at testdata/embeddedrules/callSimplify.php:14
-    $_ = substr($str, $index, 1);
-         ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+14 |    $_ = substr($str, $index, 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to "hello"[$index] at testdata/embeddedrules/callSimplify.php:15
-    $_ = substr("hello", $index, 1);
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+15 |    $_ = substr("hello", $index, 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to "hello"[2] at testdata/embeddedrules/callSimplify.php:16
-    $_ = substr("hello", 2, 1);
-         ^^^^^^^^^^^^^^^^^^^^^
+   |
+16 |    $_ = substr("hello", 2, 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $array[] = $val at testdata/embeddedrules/callSimplify.php:27
-    array_push($array, $val);
-    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+27 |    array_push($array, $val);
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $array[] = 10 at testdata/embeddedrules/callSimplify.php:28
-    array_push($array, 10);
-    ^^^^^^^^^^^^^^^^^^^^^^
+   |
+28 |    array_push($array, 10);
+   |    ^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:14
-    $_ = $a{0};
-         ^^^^^
+   |
+14 |    $_ = $a{0};
+   |         ^^^^^
+
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:15
-    $_ = $a[0]{0};
-         ^^^^^^^^
+   |
+15 |    $_ = $a[0]{0};
+   |         ^^^^^^^^
+
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:6
-$_ = $b{0};
-     ^^^^^
+  |
+6 |$_ = $b{0};
+  |     ^^^^^
+
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:7
-$_ = $b[0]{0};
-     ^^^^^^^^
+  |
+7 |$_ = $b[0]{0};
+  |     ^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:21
-$_ = strpos($str, 10);
-     ^^^^^^^^^^^^^^^^
+   |
+21 |$_ = strpos($str, 10);
+   |     ^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:22
-$_ = strpos($str, getInt());
-     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+22 |$_ = strpos($str, getInt());
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:27
-$_ = strrpos($str, 10);
-     ^^^^^^^^^^^^^^^^^
+   |
+27 |$_ = strrpos($str, 10);
+   |     ^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:28
-$_ = strrpos($str, getInt());
-     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+28 |$_ = strrpos($str, getInt());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:33
-$_ = stripos($str, 10);
-     ^^^^^^^^^^^^^^^^^
+   |
+33 |$_ = stripos($str, 10);
+   |     ^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:34
-$_ = stripos($str, getInt());
-     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+34 |$_ = stripos($str, getInt());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:39
-$_ = strripos($str, 10);
-     ^^^^^^^^^^^^^^^^^^
+   |
+39 |$_ = strripos($str, 10);
+   |     ^^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:40
-$_ = strripos($str, getInt());
-     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+40 |$_ = strripos($str, getInt());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:45
-$_ = strstr($str, 10);
-     ^^^^^^^^^^^^^^^^
+   |
+45 |$_ = strstr($str, 10);
+   |     ^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:46
-$_ = strstr($str, getInt());
-     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+46 |$_ = strstr($str, getInt());
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:51
-$_ = strchr($str, 10);
-     ^^^^^^^^^^^^^^^^
+   |
+51 |$_ = strchr($str, 10);
+   |     ^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:52
-$_ = strchr($str, getInt());
-     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+52 |$_ = strchr($str, getInt());
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:57
-$_ = strrchr($str, 10);
-     ^^^^^^^^^^^^^^^^^
+   |
+57 |$_ = strrchr($str, 10);
+   |     ^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:58
-$_ = strrchr($str, getInt());
-     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+58 |$_ = strrchr($str, getInt());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:63
-$_ = stristr($str, 10);
-     ^^^^^^^^^^^^^^^^^
+   |
+63 |$_ = stristr($str, 10);
+   |     ^^^^^^^^^^^^^^^^^
+
 WARNING intNeedle: Since PHP 7.3, passing the int parameter needle to string search functions has been deprecated, cast it explicitly to string or wrap it in a chr() function call at testdata/embeddedrules/intNeedle.php:64
-$_ = stristr($str, getInt());
-     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+64 |$_ = stristr($str, getInt());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING langDeprecated: Since PHP 7.3, the definition of case insensitive constants has been deprecated at testdata/embeddedrules/langDeprecated.php:3
-define("Z_CONST", 1, true);
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+3 |define("Z_CONST", 1, true);
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING langDeprecated: Define defaults to a case sensitive constant, the third argument can be removed at testdata/embeddedrules/langDeprecated.php:4
-define("Z_CONST1", 2, false);
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+4 |define("Z_CONST1", 2, false);
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING offBy1: Probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:11
-  $_ = $xs[count($xs)];
-       ^^^^^^^^^^^^^^^
+   |
+11 |  $_ = $xs[count($xs)];
+   |       ^^^^^^^^^^^^^^^
+
 WARNING offBy1: Probably intended to use sizeof-1 as an index at testdata/embeddedrules/offBy1.php:12
-  $_ = $xs[sizeof($xs)];
-       ^^^^^^^^^^^^^^^^
+   |
+12 |  $_ = $xs[sizeof($xs)];
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING offBy1: Probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:14
-  if ($tabs[count($tabs)] == "") {
-      ^^^^^^^^^^^^^^^^^^^
+   |
+14 |  if ($tabs[count($tabs)] == "") {
+   |      ^^^^^^^^^^^^^^^^^^^
+
 WARNING precedence: == has higher precedence than & at testdata/embeddedrules/precedence.php:4
-  $_ = 0 == $mask & $x;
-       ^^^^^^^^^^^^^^^
+  |
+4 |  $_ = 0 == $mask & $x;
+  |       ^^^^^^^^^^^^^^^
+
 WARNING precedence: != has higher precedence than & at testdata/embeddedrules/precedence.php:5
-  $_ = 0 != $mask & $x;
-       ^^^^^^^^^^^^^^^
+  |
+5 |  $_ = 0 != $mask & $x;
+  |       ^^^^^^^^^^^^^^^
+
 WARNING precedence: === has higher precedence than & at testdata/embeddedrules/precedence.php:6
-  $_ = 0 === $mask & $x;
-       ^^^^^^^^^^^^^^^^
+  |
+6 |  $_ = 0 === $mask & $x;
+  |       ^^^^^^^^^^^^^^^^
+
 WARNING precedence: !== has higher precedence than & at testdata/embeddedrules/precedence.php:7
-  $_ = 0 !== $mask & $x;
-       ^^^^^^^^^^^^^^^^
+  |
+7 |  $_ = 0 !== $mask & $x;
+  |       ^^^^^^^^^^^^^^^^
+
 WARNING precedence: == has higher precedence than | at testdata/embeddedrules/precedence.php:9
-  $_ = 0 == $mask | $x;
-       ^^^^^^^^^^^^^^^
+  |
+9 |  $_ = 0 == $mask | $x;
+  |       ^^^^^^^^^^^^^^^
+
 WARNING precedence: != has higher precedence than | at testdata/embeddedrules/precedence.php:10
-  $_ = 0 != $mask | $x;
-       ^^^^^^^^^^^^^^^
+   |
+10 |  $_ = 0 != $mask | $x;
+   |       ^^^^^^^^^^^^^^^
+
 WARNING precedence: === has higher precedence than | at testdata/embeddedrules/precedence.php:11
-  $_ = 0 === $mask | $x;
-       ^^^^^^^^^^^^^^^^
+   |
+11 |  $_ = 0 === $mask | $x;
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING precedence: !== has higher precedence than | at testdata/embeddedrules/precedence.php:12
-  $_ = 0 !== $mask | $x;
-       ^^^^^^^^^^^^^^^^
+   |
+12 |  $_ = 0 !== $mask | $x;
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING precedence: > has higher precedence than ?? at testdata/embeddedrules/precedence.php:14
-  $_ = $mask > $z ?? $x;
-       ^^^^^^^^^^^^^^^^
+   |
+14 |  $_ = $mask > $z ?? $x;
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING precedence: < has higher precedence than ?? at testdata/embeddedrules/precedence.php:15
-  $_ = $mask < $z ?? $x;
-       ^^^^^^^^^^^^^^^^
+   |
+15 |  $_ = $mask < $z ?? $x;
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING precedence: <= has higher precedence than ?? at testdata/embeddedrules/precedence.php:16
-  $_ = $mask <= $z ?? $x;
-       ^^^^^^^^^^^^^^^^^
+   |
+16 |  $_ = $mask <= $z ?? $x;
+   |       ^^^^^^^^^^^^^^^^^
+
 WARNING precedence: >= has higher precedence than ?? at testdata/embeddedrules/precedence.php:17
-  $_ = $mask >= $z ?? $x;
-       ^^^^^^^^^^^^^^^^^
+   |
+17 |  $_ = $mask >= $z ?? $x;
+   |       ^^^^^^^^^^^^^^^^^
+
 WARNING precedence: == has higher precedence than ?? at testdata/embeddedrules/precedence.php:18
-  $_ = $mask == $z ?? $x;
-       ^^^^^^^^^^^^^^^^^
+   |
+18 |  $_ = $mask == $z ?? $x;
+   |       ^^^^^^^^^^^^^^^^^
+
 WARNING precedence: != has higher precedence than ?? at testdata/embeddedrules/precedence.php:19
-  $_ = $mask != $z ?? $x;
-       ^^^^^^^^^^^^^^^^^
+   |
+19 |  $_ = $mask != $z ?? $x;
+   |       ^^^^^^^^^^^^^^^^^
+
 WARNING precedence: === has higher precedence than ?? at testdata/embeddedrules/precedence.php:20
-  $_ = $mask === $z ?? $x;
-       ^^^^^^^^^^^^^^^^^^
+   |
+20 |  $_ = $mask === $z ?? $x;
+   |       ^^^^^^^^^^^^^^^^^^
+
 WARNING precedence: !== has higher precedence than ?? at testdata/embeddedrules/precedence.php:21
-  $_ = $mask !== $z ?? $x;
-       ^^^^^^^^^^^^^^^^^^
+   |
+21 |  $_ = $mask !== $z ?? $x;
+   |       ^^^^^^^^^^^^^^^^^^
+
 WARNING precedence: == has higher precedence than & at testdata/embeddedrules/precedence.php:25
-  $_ = $x & $mask == 0;
-       ^^^^^^^^^^^^^^^
+   |
+25 |  $_ = $x & $mask == 0;
+   |       ^^^^^^^^^^^^^^^
+
 WARNING precedence: != has higher precedence than & at testdata/embeddedrules/precedence.php:26
-  $_ = $x & $mask != 0;
-       ^^^^^^^^^^^^^^^
+   |
+26 |  $_ = $x & $mask != 0;
+   |       ^^^^^^^^^^^^^^^
+
 WARNING precedence: === has higher precedence than & at testdata/embeddedrules/precedence.php:27
-  $_ = $x & $mask === 0;
-       ^^^^^^^^^^^^^^^^
+   |
+27 |  $_ = $x & $mask === 0;
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING precedence: !== has higher precedence than & at testdata/embeddedrules/precedence.php:28
-  $_ = $x & $mask !== 0;
-       ^^^^^^^^^^^^^^^^
+   |
+28 |  $_ = $x & $mask !== 0;
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING precedence: == has higher precedence than | at testdata/embeddedrules/precedence.php:30
-  $_ = $x | $mask == 0;
-       ^^^^^^^^^^^^^^^
+   |
+30 |  $_ = $x | $mask == 0;
+   |       ^^^^^^^^^^^^^^^
+
 WARNING precedence: != has higher precedence than | at testdata/embeddedrules/precedence.php:31
-  $_ = $x | $mask != 0;
-       ^^^^^^^^^^^^^^^
+   |
+31 |  $_ = $x | $mask != 0;
+   |       ^^^^^^^^^^^^^^^
+
 WARNING precedence: === has higher precedence than | at testdata/embeddedrules/precedence.php:32
-  $_ = $x | $mask === 0;
-       ^^^^^^^^^^^^^^^^
+   |
+32 |  $_ = $x | $mask === 0;
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING precedence: !== has higher precedence than | at testdata/embeddedrules/precedence.php:33
-  $_ = $x | $mask !== 0;
-       ^^^^^^^^^^^^^^^^
+   |
+33 |  $_ = $x | $mask !== 0;
+   |       ^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:6
-  $_ = ($x == false);
-        ^^^^^^^^^^^
+  |
+6 |  $_ = ($x == false);
+  |        ^^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:7
-  $_ = (false == $x);
-        ^^^^^^^^^^^
+  |
+7 |  $_ = (false == $x);
+  |        ^^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:8
-  $_ = ($x == true);
-        ^^^^^^^^^^
+  |
+8 |  $_ = ($x == true);
+  |        ^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:9
-  $_ = (true == $x);
-        ^^^^^^^^^^
+  |
+9 |  $_ = (true == $x);
+  |        ^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:10
-  $_ = ($x == null);
-        ^^^^^^^^^^
+   |
+10 |  $_ = ($x == null);
+   |        ^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use ===) at testdata/embeddedrules/strictCmp.php:11
-  $_ = (null == $x);
-        ^^^^^^^^^^
+   |
+11 |  $_ = (null == $x);
+   |        ^^^^^^^^^^
+
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/embeddedrules/strictCmp.php:25
-  $_ = in_array("str", $a);
-       ^^^^^^^^^^^^^^^^^^^
+   |
+25 |  $_ = in_array("str", $a);
+   |       ^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/embeddedrules/strictCmp.php:26
-  $_ = in_array(retString(), $a);
-       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+26 |  $_ = in_array(retString(), $a);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: 3rd argument of array_search must be true when comparing strings at testdata/embeddedrules/strictCmp.php:27
-  $_ = array_search("str", $a);
-       ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+27 |  $_ = array_search("str", $a);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: 3rd argument of array_search must be true when comparing strings at testdata/embeddedrules/strictCmp.php:28
-  $_ = array_search(retString(), $a);
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+28 |  $_ = array_search(retString(), $a);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:15
-$_ = (nonStrictComparison(0) != false);
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+15 |$_ = (nonStrictComparison(0) != false);
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:16
-$_ = (false != nonStrictComparison(0));
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+16 |$_ = (false != nonStrictComparison(0));
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:17
-$_ = (nonStrictComparison(0) != true);
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+17 |$_ = (nonStrictComparison(0) != true);
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:18
-$_ = (true != nonStrictComparison(0));
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+18 |$_ = (true != nonStrictComparison(0));
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:19
-$_ = (nonStrictComparison(0) != null);
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+19 |$_ = (nonStrictComparison(0) != null);
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: Non-strict comparison (use !==) at testdata/embeddedrules/strictCmp.php:20
-$_ = (null != nonStrictComparison(0));
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+20 |$_ = (null != nonStrictComparison(0));
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `(bool)$x` at testdata/embeddedrules/ternarySimplify.php:6
-    sink($x ? true : false);
-         ^^^^^^^^^^^^^^^^^
+  |
+6 |    sink($x ? true : false);
+  |         ^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could replace the ternary with just $x > $y at testdata/embeddedrules/ternarySimplify.php:9
-    sink($x > $y ? true : false);
-         ^^^^^^^^^^^^^^^^^^^^^^
+  |
+9 |    sink($x > $y ? true : false);
+  |         ^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$x ?: $y` at testdata/embeddedrules/ternarySimplify.php:12
-    sink($x ? $x : $y);
-         ^^^^^^^^^^^^
+   |
+12 |    sink($x ? $x : $y);
+   |         ^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$x[1] ?? $y` at testdata/embeddedrules/ternarySimplify.php:15
-    sink(isset($x[1]) ? $x[1] : $y);
-         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+15 |    sink(isset($x[1]) ? $x[1] : $y);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:22
-    sink($x_arr[10] !== null ? $x_arr[10] : $y);
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+22 |    sink($x_arr[10] !== null ? $x_arr[10] : $y);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:23
-    sink(null !== $x_arr[10] ? $x_arr[10] : $y);
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+23 |    sink(null !== $x_arr[10] ? $x_arr[10] : $y);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:24
-    sink($x_arr[10] === null ? $y : $x_arr[10]);
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+24 |    sink($x_arr[10] === null ? $y : $x_arr[10]);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? $y` at testdata/embeddedrules/ternarySimplify.php:25
-    sink(null === $x_arr[10] ? $y : $x_arr[10]);
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+25 |    sink(null === $x_arr[10] ? $y : $x_arr[10]);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? null` at testdata/embeddedrules/ternarySimplify.php:27
-    sink(array_key_exists(10, $x_arr) ? $x_arr[10] : null);
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+27 |    sink(array_key_exists(10, $x_arr) ? $x_arr[10] : null);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? null` at testdata/embeddedrules/ternarySimplify.php:28
-    sink(! array_key_exists(10, $x_arr) ? null : $x_arr[10]);
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+28 |    sink(! array_key_exists(10, $x_arr) ? null : $x_arr[10]);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `(bool)($flags & SOME_MASK)` at testdata/embeddedrules/ternarySimplify.php:46
-    sink(($flags & SOME_MASK) ? true : false);
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+46 |    sink(($flags & SOME_MASK) ? true : false);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/tests/golden/testdata/flysystem/golden.txt
+++ b/src/tests/golden/testdata/flysystem/golden.txt
@@ -1,129 +1,215 @@
 MAYBE   regexpSimplify: May re-write '/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/' as '/^\d{2,4}-\d{2}-\d{2}/' at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:536
-        return preg_match('/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/', $item) ? 'windows' : 'unix';
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+536 |        return preg_match('/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/', $item) ? 'windows' : 'unix';
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $permissions[0] at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:548
-        return substr($permissions, 0, 1) === 'd' ? 'dir' : 'file';
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+548 |        return substr($permissions, 0, 1) === 'd' ? 'dir' : 'file';
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:134
-            $this->connection = @ftp_ssl_connect($this->getHost(), $this->getPort(), $this->getTimeout());
-                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+134 |            $this->connection = @ftp_ssl_connect($this->getHost(), $this->getPort(), $this->getTimeout());
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:136
-            $this->connection = @ftp_connect($this->getHost(), $this->getPort(), $this->getTimeout());
-                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+136 |            $this->connection = @ftp_connect($this->getHost(), $this->getPort(), $this->getTimeout());
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:233
-            @ftp_close($this->connection);
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+233 |            @ftp_close($this->connection);
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:391
-        if (@ftp_chdir($this->getConnection(), $path) === true) {
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+391 |        if (@ftp_chdir($this->getConnection(), $path) === true) {
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '/^total [0-9]*$/' as '/^total \d*$/' at testdata/flysystem/src/Adapter/Ftp.php:407
-        if (preg_match('/^total [0-9]*$/', $listing[0])) {
-                       ^^^^^^^^^^^^^^^^^^
+    |
+407 |        if (preg_match('/^total [0-9]*$/', $listing[0])) {
+    |                       ^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:570
-        $response = @ftp_raw($this->connection, trim($command));
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+570 |        $response = @ftp_raw($this->connection, trim($command));
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftpd.php:15
-        if (@ftp_chdir($this->getConnection(), $path) === true) {
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+15 |        if (@ftp_chdir($this->getConnection(), $path) === true) {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:103
-            if ( ! @mkdir($root, $this->permissionMap['dir']['public'], true)) {
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+103 |            if ( ! @mkdir($root, $this->permissionMap['dir']['public'], true)) {
+    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:103
-            if ( ! @mkdir($root, $this->permissionMap['dir']['public'], true)) {
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+103 |            if ( ! @mkdir($root, $this->permissionMap['dir']['public'], true)) {
+    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$mkdirError['message'] ?? ''` at testdata/flysystem/src/Adapter/Local.php:111
-                $errorMessage = isset($mkdirError['message']) ? $mkdirError['message'] : '';
-                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+111 |                $errorMessage = isset($mkdirError['message']) ? $mkdirError['message'] : '';
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:222
-        $contents = @file_get_contents($location);
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+222 |        $contents = @file_get_contents($location);
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:263
-        return @unlink($location);
-               ^^^^^^^^^^^^^^^^^^
+    |
+263 |        return @unlink($location);
+    |               ^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/flysystem/src/Adapter/Local.php:324
-        if (in_array($mimetype, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+324 |        if (in_array($mimetype, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:387
-            if (false === @mkdir($location, $this->permissionMap['dir'][$visibility], true)
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+387 |            if (false === @mkdir($location, $this->permissionMap['dir'][$visibility], true)
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   invalidDocblockType: Void type can only be used as a standalone type for the return type at testdata/flysystem/src/Adapter/Local.php:444
-     * @return array|void
-               ^^^^^^^^^^
+    |
+444 |     * @return array|void
+    |               ^^^^^^^^^^
+
 WARNING invalidDocblockRef: @see tag refers to unknown symbol League\Flysystem\ReadInterface::readStream at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:17
-     * @see League\Flysystem\ReadInterface::readStream()
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+17 |     * @see League\Flysystem\ReadInterface::readStream()
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING invalidDocblockRef: @see tag refers to unknown symbol League\Flysystem\ReadInterface::read at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:41
-     * @see League\Flysystem\ReadInterface::read()
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+41 |     * @see League\Flysystem\ReadInterface::read()
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\Adapter\Polyfill\StreamedWritingTrait::write public method at testdata/flysystem/src/Adapter/Polyfill/StreamedWritingTrait.php:58
-    abstract public function write($pash, $contents, Config $config);
-                             ^^^^^
+   |
+58 |    abstract public function write($pash, $contents, Config $config);
+   |                             ^^^^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\Adapter\Polyfill\StreamedWritingTrait::update public method at testdata/flysystem/src/Adapter/Polyfill/StreamedWritingTrait.php:59
-    abstract public function update($pash, $contents, Config $config);
-                             ^^^^^^
+   |
+59 |    abstract public function update($pash, $contents, Config $config);
+   |                             ^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:63
-    public function write($path, $contents, array $config = [])
-                    ^^^^^
+   |
+63 |    public function write($path, $contents, array $config = [])
+   |                    ^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:75
-    public function writeStream($path, $resource, array $config = [])
-                    ^^^^^^^^^^^
+   |
+75 |    public function writeStream($path, $resource, array $config = [])
+   |                    ^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:93
-    public function put($path, $contents, array $config = [])
-                    ^^^
+   |
+93 |    public function put($path, $contents, array $config = [])
+   |                    ^^^
+
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:108
-    public function putStream($path, $resource, array $config = [])
-                    ^^^^^^^^^
+    |
+108 |    public function putStream($path, $resource, array $config = [])
+    |                    ^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:146
-    public function update($path, $contents, array $config = [])
-                    ^^^^^^
+    |
+146 |    public function update($path, $contents, array $config = [])
+    |                    ^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:159
-    public function updateStream($path, $resource, array $config = [])
-                    ^^^^^^^^^^^^
+    |
+159 |    public function updateStream($path, $resource, array $config = [])
+    |                    ^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:257
-    public function createDir($dirname, array $config = [])
-                    ^^^^^^^^^
+    |
+257 |    public function createDir($dirname, array $config = [])
+    |                    ^^^^^^^^^
+
 WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Handler.php:129
-        } catch (BadMethodCallException $e) {
-                                        ^^
+    |
+129 |        } catch (BadMethodCallException $e) {
+    |                                        ^^
+
 WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/MountManager.php:275
-        } catch (PluginNotFoundException $e) {
-                                         ^^
+    |
+275 |        } catch (PluginNotFoundException $e) {
+    |                                         ^^
+
 MAYBE   deprecatedUntagged: Call to deprecated method {\League\Flysystem\FilesystemInterface}->get() at testdata/flysystem/src/MountManager.php:646
-        return $this->getFilesystem($prefix)->get($path);
-                                              ^^^
+    |
+646 |        return $this->getFilesystem($prefix)->get($path);
+    |                                              ^^^
+
 WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Plugin/ForcedCopy.php:33
-        } catch (FileNotFoundException $e) {
-                                       ^^
+   |
+33 |        } catch (FileNotFoundException $e) {
+   |                                       ^^
+
 WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Plugin/ForcedRename.php:33
-        } catch (FileNotFoundException $e) {
-                                       ^^
+   |
+33 |        } catch (FileNotFoundException $e) {
+   |                                       ^^
+
 WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Plugin/PluggableTrait.php:89
-        } catch (PluginNotFoundException $e) {
-                                         ^^
+   |
+89 |        } catch (PluginNotFoundException $e) {
+   |                                         ^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\SafeStorage::storeSafely public method at testdata/flysystem/src/SafeStorage.php:23
-    public function storeSafely($key, $value)
-                    ^^^^^^^^^^^
+   |
+23 |    public function storeSafely($key, $value)
+   |                    ^^^^^^^^^^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\SafeStorage::retrieveSafely public method at testdata/flysystem/src/SafeStorage.php:28
-    public function retrieveSafely($key)
-                    ^^^^^^^^^^^^^^
+   |
+28 |    public function retrieveSafely($key)
+   |                    ^^^^^^^^^^^^^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\UnreadableFileException::forFileInfo public method at testdata/flysystem/src/UnreadableFileException.php:9
-    public static function forFileInfo(SplFileInfo $fileInfo)
-                           ^^^^^^^^^^^
+  |
+9 |    public static function forFileInfo(SplFileInfo $fileInfo)
+  |                           ^^^^^^^^^^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\Util::isSeekableStream public method at testdata/flysystem/src/Util.php:258
-    public static function isSeekableStream($resource)
-                           ^^^^^^^^^^^^^^^^
+    |
+258 |    public static function isSeekableStream($resource)
+    |                           ^^^^^^^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '#^[a-zA-Z]{1}:[^\\\/]#' as '#^[a-zA-Z]:[^\\/]#' at testdata/flysystem/src/Util.php:341
-        while (preg_match('#^[a-zA-Z]{1}:[^\\\/]#', $basename)) {
-                          ^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+341 |        while (preg_match('#^[a-zA-Z]{1}:[^\\\/]#', $basename)) {
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '#^[a-zA-Z]{1}:$#' as '#^[a-zA-Z]:$#' at testdata/flysystem/src/Util.php:346
-        if (preg_match('#^[a-zA-Z]{1}:$#', $basename)) {
-                       ^^^^^^^^^^^^^^^^^^
+    |
+346 |        if (preg_match('#^[a-zA-Z]{1}:$#', $basename)) {
+    |                       ^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $entry in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Util/ContentListingFormatter.php:52
-    private function addPathInfo(array $entry)
-                     ^^^^^^^^^^^
+   |
+52 |    private function addPathInfo(array $entry)
+   |                     ^^^^^^^^^^^
+
 WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Util/MimeType.php:208
-        } catch (ErrorException $e) {
-                                ^^
+    |
+208 |        } catch (ErrorException $e) {
+    |                                ^^
+
 MAYBE   ternarySimplify: Could rewrite as `static::$extensionToMimeTypeMap[$extension] ?? 'text/plain'` at testdata/flysystem/src/Util/MimeType.php:222
-        return isset(static::$extensionToMimeTypeMap[$extension])
-               ^^^^^^^^^^^
+    |
+222 |        return isset(static::$extensionToMimeTypeMap[$extension])
+    |               ^^^^^^^^^^^
+

--- a/src/tests/golden/testdata/flysystem/golden.txt
+++ b/src/tests/golden/testdata/flysystem/golden.txt
@@ -1,215 +1,215 @@
 MAYBE   regexpSimplify: May re-write '/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/' as '/^\d{2,4}-\d{2}-\d{2}/' at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:536
     |
 536 |        return preg_match('/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/', $item) ? 'windows' : 'unix';
-    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $permissions[0] at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:548
     |
 548 |        return substr($permissions, 0, 1) === 'd' ? 'dir' : 'file';
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:134
     |
 134 |            $this->connection = @ftp_ssl_connect($this->getHost(), $this->getPort(), $this->getTimeout());
-    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:136
     |
 136 |            $this->connection = @ftp_connect($this->getHost(), $this->getPort(), $this->getTimeout());
-    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:233
     |
 233 |            @ftp_close($this->connection);
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:391
     |
 391 |        if (@ftp_chdir($this->getConnection(), $path) === true) {
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '/^total [0-9]*$/' as '/^total \d*$/' at testdata/flysystem/src/Adapter/Ftp.php:407
     |
 407 |        if (preg_match('/^total [0-9]*$/', $listing[0])) {
-    |                       ^^^^^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:570
     |
 570 |        $response = @ftp_raw($this->connection, trim($command));
-    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftpd.php:15
    |
 15 |        if (@ftp_chdir($this->getConnection(), $path) === true) {
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:103
     |
 103 |            if ( ! @mkdir($root, $this->permissionMap['dir']['public'], true)) {
-    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:103
     |
 103 |            if ( ! @mkdir($root, $this->permissionMap['dir']['public'], true)) {
-    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$mkdirError['message'] ?? ''` at testdata/flysystem/src/Adapter/Local.php:111
     |
 111 |                $errorMessage = isset($mkdirError['message']) ? $mkdirError['message'] : '';
-    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:222
     |
 222 |        $contents = @file_get_contents($location);
-    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:263
     |
 263 |        return @unlink($location);
-    |               ^^^^^^^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/flysystem/src/Adapter/Local.php:324
     |
 324 |        if (in_array($mimetype, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Local.php:387
     |
 387 |            if (false === @mkdir($location, $this->permissionMap['dir'][$visibility], true)
-    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Void type can only be used as a standalone type for the return type at testdata/flysystem/src/Adapter/Local.php:444
     |
 444 |     * @return array|void
-    |               ^^^^^^^^^^
+    |               ^^^^^^^^^^ 
 
 WARNING invalidDocblockRef: @see tag refers to unknown symbol League\Flysystem\ReadInterface::readStream at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:17
    |
 17 |     * @see League\Flysystem\ReadInterface::readStream()
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING invalidDocblockRef: @see tag refers to unknown symbol League\Flysystem\ReadInterface::read at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:41
    |
 41 |     * @see League\Flysystem\ReadInterface::read()
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\Adapter\Polyfill\StreamedWritingTrait::write public method at testdata/flysystem/src/Adapter/Polyfill/StreamedWritingTrait.php:58
    |
 58 |    abstract public function write($pash, $contents, Config $config);
-   |                             ^^^^^
+   |                             ^^^^^ 
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\Adapter\Polyfill\StreamedWritingTrait::update public method at testdata/flysystem/src/Adapter/Polyfill/StreamedWritingTrait.php:59
    |
 59 |    abstract public function update($pash, $contents, Config $config);
-   |                             ^^^^^^
+   |                             ^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:63
    |
 63 |    public function write($path, $contents, array $config = [])
-   |                    ^^^^^
+   |                    ^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:75
    |
 75 |    public function writeStream($path, $resource, array $config = [])
-   |                    ^^^^^^^^^^^
+   |                    ^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:93
    |
 93 |    public function put($path, $contents, array $config = [])
-   |                    ^^^
+   |                    ^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:108
     |
 108 |    public function putStream($path, $resource, array $config = [])
-    |                    ^^^^^^^^^
+    |                    ^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:146
     |
 146 |    public function update($path, $contents, array $config = [])
-    |                    ^^^^^^
+    |                    ^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:159
     |
 159 |    public function updateStream($path, $resource, array $config = [])
-    |                    ^^^^^^^^^^^^
+    |                    ^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:257
     |
 257 |    public function createDir($dirname, array $config = [])
-    |                    ^^^^^^^^^
+    |                    ^^^^^^^^^ 
 
-WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Handler.php:129
+WARNING unused: Variable $e is unused at testdata/flysystem/src/Handler.php:129
     |
 129 |        } catch (BadMethodCallException $e) {
-    |                                        ^^
+    |                                        ^^ use `$_` to ignore (see --unused-var-regex flag)
 
-WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/MountManager.php:275
+WARNING unused: Variable $e is unused at testdata/flysystem/src/MountManager.php:275
     |
 275 |        } catch (PluginNotFoundException $e) {
-    |                                         ^^
+    |                                         ^^ use `$_` to ignore (see --unused-var-regex flag)
 
 MAYBE   deprecatedUntagged: Call to deprecated method {\League\Flysystem\FilesystemInterface}->get() at testdata/flysystem/src/MountManager.php:646
     |
 646 |        return $this->getFilesystem($prefix)->get($path);
-    |                                              ^^^
+    |                                              ^^^ 
 
-WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Plugin/ForcedCopy.php:33
+WARNING unused: Variable $e is unused at testdata/flysystem/src/Plugin/ForcedCopy.php:33
    |
 33 |        } catch (FileNotFoundException $e) {
-   |                                       ^^
+   |                                       ^^ use `$_` to ignore (see --unused-var-regex flag)
 
-WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Plugin/ForcedRename.php:33
+WARNING unused: Variable $e is unused at testdata/flysystem/src/Plugin/ForcedRename.php:33
    |
 33 |        } catch (FileNotFoundException $e) {
-   |                                       ^^
+   |                                       ^^ use `$_` to ignore (see --unused-var-regex flag)
 
-WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Plugin/PluggableTrait.php:89
+WARNING unused: Variable $e is unused at testdata/flysystem/src/Plugin/PluggableTrait.php:89
    |
 89 |        } catch (PluginNotFoundException $e) {
-   |                                         ^^
+   |                                         ^^ use `$_` to ignore (see --unused-var-regex flag)
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\SafeStorage::storeSafely public method at testdata/flysystem/src/SafeStorage.php:23
    |
 23 |    public function storeSafely($key, $value)
-   |                    ^^^^^^^^^^^
+   |                    ^^^^^^^^^^^ 
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\SafeStorage::retrieveSafely public method at testdata/flysystem/src/SafeStorage.php:28
    |
 28 |    public function retrieveSafely($key)
-   |                    ^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^ 
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\UnreadableFileException::forFileInfo public method at testdata/flysystem/src/UnreadableFileException.php:9
   |
 9 |    public static function forFileInfo(SplFileInfo $fileInfo)
-  |                           ^^^^^^^^^^^
+  |                           ^^^^^^^^^^^ 
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\Util::isSeekableStream public method at testdata/flysystem/src/Util.php:258
     |
 258 |    public static function isSeekableStream($resource)
-    |                           ^^^^^^^^^^^^^^^^
+    |                           ^^^^^^^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '#^[a-zA-Z]{1}:[^\\\/]#' as '#^[a-zA-Z]:[^\\/]#' at testdata/flysystem/src/Util.php:341
     |
 341 |        while (preg_match('#^[a-zA-Z]{1}:[^\\\/]#', $basename)) {
-    |                          ^^^^^^^^^^^^^^^^^^^^^^^^
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '#^[a-zA-Z]{1}:$#' as '#^[a-zA-Z]:$#' at testdata/flysystem/src/Util.php:346
     |
 346 |        if (preg_match('#^[a-zA-Z]{1}:$#', $basename)) {
-    |                       ^^^^^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $entry in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Util/ContentListingFormatter.php:52
    |
 52 |    private function addPathInfo(array $entry)
-   |                     ^^^^^^^^^^^
+   |                     ^^^^^^^^^^^ 
 
-WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Util/MimeType.php:208
+WARNING unused: Variable $e is unused at testdata/flysystem/src/Util/MimeType.php:208
     |
 208 |        } catch (ErrorException $e) {
-    |                                ^^
+    |                                ^^ use `$_` to ignore (see --unused-var-regex flag)
 
 MAYBE   ternarySimplify: Could rewrite as `static::$extensionToMimeTypeMap[$extension] ?? 'text/plain'` at testdata/flysystem/src/Util/MimeType.php:222
     |
 222 |        return isset(static::$extensionToMimeTypeMap[$extension])
-    |               ^^^^^^^^^^^
+    |               ^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/gitignore-test/golden.txt
+++ b/src/tests/golden/testdata/gitignore-test/golden.txt
@@ -1,3 +1,5 @@
 WARNING discardExpr: Expression evaluated but not used at testdata/gitignore-test/src/b/src-a-ignore.php:3
-"not ignored, since it's not under src/a";
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+3 |"not ignored, since it's not under src/a";
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/tests/golden/testdata/gitignore-test/golden.txt
+++ b/src/tests/golden/testdata/gitignore-test/golden.txt
@@ -1,5 +1,5 @@
 WARNING discardExpr: Expression evaluated but not used at testdata/gitignore-test/src/b/src-a-ignore.php:3
   |
 3 |"not ignored, since it's not under src/a";
-  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/idn/golden.txt
+++ b/src/tests/golden/testdata/idn/golden.txt
@@ -1,51 +1,85 @@
 MAYBE   missingPhpdoc: Missing PHPDoc for \Symfony\Polyfill\Intl\Idn\Idn::idn_to_ascii public method at testdata/idn/idn.php:64
-    public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
-                           ^^^^^^^^^^^^
+   |
+64 |    public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
+   |                           ^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:64
-    public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
-                                                                                   ^^^^^^^
+   |
+64 |    public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
+   |                                                                                   ^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/idn/idn.php:67
-            @trigger_error('idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+67 |            @trigger_error('idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:87
-        $idna_info = array(
-                     
+   |
+87 |        $idna_info = array(
+   |                     
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \Symfony\Polyfill\Intl\Idn\Idn::idn_to_utf8 public method at testdata/idn/idn.php:96
-    public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
-                           ^^^^^^^^^^^
+   |
+96 |    public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
+   |                           ^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:96
-    public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
-                                                                                  ^^^^^^^
+   |
+96 |    public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
+   |                                                                                  ^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/idn/idn.php:99
-            @trigger_error('idn_to_utf8(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+99 |            @trigger_error('idn_to_utf8(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:119
-        $idna_info = array(
-                     
+    |
+119 |        $idna_info = array(
+    |                     
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:195
-            'all' => array(),
-                     ^^^^^^^
+    |
+195 |            'all' => array(),
+    |                     ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:196
-            'basic' => array(),
-                       ^^^^^^^
+    |
+196 |            'basic' => array(),
+    |                       ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:197
-            'nonBasic' => array(),
-                          ^^^^^^^
+    |
+197 |            'nonBasic' => array(),
+    |                          ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:194
-        $codePoints = array(
-                      
+    |
+194 |        $codePoints = array(
+    |                      
+
 MAYBE   redundantCast: Expression already has int type at testdata/idn/idn.php:233
-            $delta = (int) ($delta / 35);
-                           ^^^^^^^^^^^^^
+    |
+233 |            $delta = (int) ($delta / 35);
+    |                           ^^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$k += 36` at testdata/idn/idn.php:234
-            $k = $k + 36;
-            ^^^^^^^^^^^^
+    |
+234 |            $k = $k + 36;
+    |            ^^^^^^^^^^^^
+
 MAYBE   redundantCast: Expression already has int type at testdata/idn/idn.php:237
-        return $k + (int) (36 * $delta / ($delta + 38));
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+237 |        return $k + (int) (36 * $delta / ($delta + 38));
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$n += (int) ($i / $outputLength)` at testdata/idn/idn.php:274
-            $n = $n + (int) ($i / $outputLength);
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+274 |            $n = $n + (int) ($i / $outputLength);
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$i %= $outputLength` at testdata/idn/idn.php:275
-            $i = $i % $outputLength;
-            ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+275 |            $i = $i % $outputLength;
+    |            ^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/tests/golden/testdata/idn/golden.txt
+++ b/src/tests/golden/testdata/idn/golden.txt
@@ -1,85 +1,85 @@
 MAYBE   missingPhpdoc: Missing PHPDoc for \Symfony\Polyfill\Intl\Idn\Idn::idn_to_ascii public method at testdata/idn/idn.php:64
    |
 64 |    public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
-   |                           ^^^^^^^^^^^^
+   |                           ^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:64
    |
 64 |    public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
-   |                                                                                   ^^^^^^^
+   |                                                                                   ^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/idn/idn.php:67
    |
 67 |            @trigger_error('idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:87
    |
 87 |        $idna_info = array(
-   |                     
+   |                      
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \Symfony\Polyfill\Intl\Idn\Idn::idn_to_utf8 public method at testdata/idn/idn.php:96
    |
 96 |    public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
-   |                           ^^^^^^^^^^^
+   |                           ^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:96
    |
 96 |    public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
-   |                                                                                  ^^^^^^^
+   |                                                                                  ^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/idn/idn.php:99
    |
 99 |            @trigger_error('idn_to_utf8(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:119
     |
 119 |        $idna_info = array(
-    |                     
+    |                      
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:195
     |
 195 |            'all' => array(),
-    |                     ^^^^^^^
+    |                     ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:196
     |
 196 |            'basic' => array(),
-    |                       ^^^^^^^
+    |                       ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:197
     |
 197 |            'nonBasic' => array(),
-    |                          ^^^^^^^
+    |                          ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/idn/idn.php:194
     |
 194 |        $codePoints = array(
-    |                      
+    |                       
 
 MAYBE   redundantCast: Expression already has int type at testdata/idn/idn.php:233
     |
 233 |            $delta = (int) ($delta / 35);
-    |                           ^^^^^^^^^^^^^
+    |                           ^^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$k += 36` at testdata/idn/idn.php:234
     |
 234 |            $k = $k + 36;
-    |            ^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^ 
 
 MAYBE   redundantCast: Expression already has int type at testdata/idn/idn.php:237
     |
 237 |        return $k + (int) (36 * $delta / ($delta + 38));
-    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$n += (int) ($i / $outputLength)` at testdata/idn/idn.php:274
     |
 274 |            $n = $n + (int) ($i / $outputLength);
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$i %= $outputLength` at testdata/idn/idn.php:275
     |
 275 |            $i = $i % $outputLength;
-    |            ^^^^^^^^^^^^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/inflector/golden.txt
+++ b/src/tests/golden/testdata/inflector/golden.txt
@@ -1,40 +1,40 @@
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:54
    |
 54 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:64
    |
 64 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:76
    |
 76 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:110
     |
 110 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please use the "ucwords" function instead.', __METHOD__), E_USER_DEPRECATED);
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:123
     |
 123 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Use bool type instead of boolean at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:142
     |
 142 |     * @param boolean $reset        If true, will unset default inflections for all
-    |              ^^^^^^^
+    |              ^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:165
     |
 165 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:181
     |
 181 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/inflector/golden.txt
+++ b/src/tests/golden/testdata/inflector/golden.txt
@@ -1,24 +1,40 @@
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:54
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+54 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:64
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+64 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:76
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+76 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:110
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please use the "ucwords" function instead.', __METHOD__), E_USER_DEPRECATED);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+110 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please use the "ucwords" function instead.', __METHOD__), E_USER_DEPRECATED);
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:123
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+123 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   invalidDocblockType: Use bool type instead of boolean at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:142
-     * @param boolean $reset        If true, will unset default inflections for all
-              ^^^^^^^
+    |
+142 |     * @param boolean $reset        If true, will unset default inflections for all
+    |              ^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:165
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+165 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:181
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+181 |        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/tests/golden/testdata/math/golden.txt
+++ b/src/tests/golden/testdata/math/golden.txt
@@ -1,51 +1,85 @@
 WARNING unused: Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/math/src/BigDecimal.php:292
-        [$a, $b] = $this->scaleValues($this, $that);
-         ^^
+    |
+292 |        [$a, $b] = $this->scaleValues($this, $that);
+    |         ^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/math/src/BigInteger.php:435
-            new BigInteger($remainder)
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+435 |            new BigInteger($remainder)
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$matches['fractional'] ?? ''` at testdata/math/src/BigNumber.php:90
-            $fractional = isset($matches['fractional']) ? $matches['fractional'] : '';
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+90 |            $fractional = isset($matches['fractional']) ? $matches['fractional'] : '';
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   implicitModifiers: Specify the access modifier for \Brick\Math\Internal\Calculator::powmod method explicitly at testdata/math/src/Internal/Calculator.php:260
-    abstract function powmod(string $base, string $exp, string $mod) : string;
-                      ^^^^^^
+    |
+260 |    abstract function powmod(string $base, string $exp, string $mod) : string;
+    |                      ^^^^^^
+
 MAYBE   assignOp: Could rewrite as `$number ^= $xor` at testdata/math/src/Internal/Calculator.php:622
-        $number = $number ^ $xor;
-        ^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+622 |        $number = $number ^ $xor;
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/math/src/Internal/Calculator/GmpCalculator.php:67
-            \gmp_strval($r)
-            ^^^^^^^^^^^^^^^
+   |
+67 |            \gmp_strval($r)
+   |            ^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/math/src/Internal/Calculator/NativeCalculator.php:187
-                    (string) $r
-                    ^^^^^^^^^^^
+    |
+187 |                    (string) $r
+    |                    ^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant UNNECESSARY must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:33
-    public const UNNECESSARY = 0;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+33 |    public const UNNECESSARY = 0;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:41
-    public const UP = 1;
-    ^^^^^^^^^^^^^^^^^^^^
+   |
+41 |    public const UP = 1;
+   |    ^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:49
-    public const DOWN = 2;
-    ^^^^^^^^^^^^^^^^^^^^^^
+   |
+49 |    public const DOWN = 2;
+   |    ^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:57
-    public const CEILING = 3;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+57 |    public const CEILING = 3;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:65
-    public const FLOOR = 4;
-    ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+65 |    public const FLOOR = 4;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant HALF_UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:73
-    public const HALF_UP = 5;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+73 |    public const HALF_UP = 5;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant HALF_DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:80
-    public const HALF_DOWN = 6;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+80 |    public const HALF_DOWN = 6;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant HALF_CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:87
-    public const HALF_CEILING = 7;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+87 |    public const HALF_CEILING = 7;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant HALF_FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:94
-    public const HALF_FLOOR = 8;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+94 |    public const HALF_FLOOR = 8;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant HALF_EVEN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:106
-    public const HALF_EVEN = 9;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+106 |    public const HALF_EVEN = 9;
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/tests/golden/testdata/math/golden.txt
+++ b/src/tests/golden/testdata/math/golden.txt
@@ -1,85 +1,85 @@
-WARNING unused: Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/math/src/BigDecimal.php:292
+WARNING unused: Variable $a is unused at testdata/math/src/BigDecimal.php:292
     |
 292 |        [$a, $b] = $this->scaleValues($this, $that);
-    |         ^^
+    |         ^^ use `$_` to ignore (see --unused-var-regex flag)
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/math/src/BigInteger.php:435
     |
 435 |            new BigInteger($remainder)
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$matches['fractional'] ?? ''` at testdata/math/src/BigNumber.php:90
    |
 90 |            $fractional = isset($matches['fractional']) ? $matches['fractional'] : '';
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   implicitModifiers: Specify the access modifier for \Brick\Math\Internal\Calculator::powmod method explicitly at testdata/math/src/Internal/Calculator.php:260
     |
 260 |    abstract function powmod(string $base, string $exp, string $mod) : string;
-    |                      ^^^^^^
+    |                      ^^^^^^ 
 
 MAYBE   assignOp: Could rewrite as `$number ^= $xor` at testdata/math/src/Internal/Calculator.php:622
     |
 622 |        $number = $number ^ $xor;
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/math/src/Internal/Calculator/GmpCalculator.php:67
    |
 67 |            \gmp_strval($r)
-   |            ^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/math/src/Internal/Calculator/NativeCalculator.php:187
     |
 187 |                    (string) $r
-    |                    ^^^^^^^^^^^
+    |                    ^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant UNNECESSARY must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:33
    |
 33 |    public const UNNECESSARY = 0;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:41
    |
 41 |    public const UP = 1;
-   |    ^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:49
    |
 49 |    public const DOWN = 2;
-   |    ^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:57
    |
 57 |    public const CEILING = 3;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:65
    |
 65 |    public const FLOOR = 4;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant HALF_UP must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:73
    |
 73 |    public const HALF_UP = 5;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant HALF_DOWN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:80
    |
 80 |    public const HALF_DOWN = 6;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant HALF_CEILING must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:87
    |
 87 |    public const HALF_CEILING = 7;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant HALF_FLOOR must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:94
    |
 94 |    public const HALF_FLOOR = 8;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant HALF_EVEN must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:106
     |
 106 |    public const HALF_EVEN = 9;
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -1,290 +1,290 @@
 MAYBE   ternarySimplify: Could rewrite as `$baseDir ?: 0` at testdata/mustache/src/Mustache/Autoloader.php:56
    |
 56 |        $key = $baseDir ? $baseDir : 0;
-   |               ^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   undefinedClass: Class or interface named \Psr\Log\LoggerInterface does not exist at testdata/mustache/src/Mustache/Cache/AbstractCache.php:26
    |
 26 |     * @return Mustache_Logger|Psr\Log\LoggerInterface
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   undefinedClass: Class or interface named \Psr\Log\LoggerInterface does not exist at testdata/mustache/src/Mustache/Cache/AbstractCache.php:36
    |
 36 |     * @param Mustache_Logger|Psr\Log\LoggerInterface $logger
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:110
     |
 110 |            @mkdir($dirName, 0777, true);
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:140
     |
 140 |        if (false !== @file_put_contents($tempFile, $value)) {
-    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:141
     |
 141 |            if (@rename($tempFile, $fileName)) {
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$this->fileMode ?? (0666 & ~umask())` at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:142
     |
 142 |                $mode = isset($this->fileMode) ? $this->fileMode : (0666 & ~umask());
-    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:143
     |
 143 |                @chmod($fileName, $mode);
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING useEval: Don't use the 'eval' function at testdata/mustache/src/Mustache/Cache/NoopCache.php:45
    |
 45 |        eval('?>' . $value);
-   |        ^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:99
    |
 99 |                        isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:112
     |
 112 |                        isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
-    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::INDENT] ?? ''` at testdata/mustache/src/Mustache/Compiler.php:120
     |
 120 |                        isset($node[Mustache_Tokenizer::INDENT]) ? $node[Mustache_Tokenizer::INDENT] : '',
-    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::INDENT] ?? ''` at testdata/mustache/src/Mustache/Compiler.php:128
     |
 128 |                        isset($node[Mustache_Tokenizer::INDENT]) ? $node[Mustache_Tokenizer::INDENT] : '',
-    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:166
     |
 166 |                        isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
-    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
-WARNING unused: Variable $keystr is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/mustache/src/Mustache/Compiler.php:289
+WARNING unused: Variable $keystr is unused at testdata/mustache/src/Mustache/Compiler.php:289
     |
 289 |        $keystr = var_export($key, true);
-    |        ^^^^^^^
+    |        ^^^^^^^ use `$_` to ignore (see --unused-var-regex flag)
 
 MAYBE   callSimplify: Could simplify to $id[0] at testdata/mustache/src/Mustache/Compiler.php:646
     |
 646 |            if (substr($id, 0, 1) === '.') {
-    |                ^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant KLASS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:184
     |
 184 |    const KLASS = '<?php
-    |    ^^^^^^^
+    |    ^^^^^^^ 
 
 ERROR   classMembersOrder: Constant KLASS_NO_LAMBDAS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:202
     |
 202 |    const KLASS_NO_LAMBDAS = '<?php
-    |    ^^^^^^^
+    |    ^^^^^^^ 
 
 ERROR   classMembersOrder: Constant STRICT_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:215
     |
 215 |    const STRICT_CALLABLE = 'protected $strictCallables = true;';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant BLOCK_VAR must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:237
     |
 237 |    const BLOCK_VAR = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant BLOCK_VAR_ELSE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:244
     |
 244 |    const BLOCK_VAR_ELSE = '} else {%s';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant BLOCK_ARG must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:271
     |
 271 |    const BLOCK_ARG = '%s => array($this, \'block%s\'),';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant BLOCK_FUNCTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:295
     |
 295 |    const BLOCK_FUNCTION = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant SECTION_CALL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:323
     |
 323 |    const SECTION_CALL = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:329
     |
 329 |    const SECTION = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant INVERTED_SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:398
     |
 398 |    const INVERTED_SECTION = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant PARTIAL_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:425
     |
 425 |    const PARTIAL_INDENT = ', $indent . %s';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant PARTIAL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:426
     |
 426 |    const PARTIAL = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant PARENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:456
     |
 456 |    const PARENT = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant PARENT_NO_CONTEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:465
     |
 465 |    const PARENT_NO_CONTEXT = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant VARIABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:508
     |
 508 |    const VARIABLE = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant FILTER must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:533
     |
 533 |    const FILTER = '
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Constant LINE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:564
     |
 564 |    const LINE = '$buffer .= "\n";';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant TEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:565
     |
 565 |    const TEXT = '$buffer .= %s%s;';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant DEFAULT_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:607
     |
 607 |    const DEFAULT_ESCAPE = 'htmlspecialchars(%s, %s, %s)';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant CUSTOM_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:608
     |
 608 |    const CUSTOM_ESCAPE  = 'call_user_func($this->mustache->getEscape(), %s)';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:658
     |
 658 |    const IS_CALLABLE        = '!is_string(%s) && is_callable(%s)';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant STRICT_IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:659
     |
 659 |    const STRICT_IS_CALLABLE = 'is_object(%s) && is_callable(%s)';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant LINE_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:675
     |
 675 |    const LINE_INDENT = '$indent . ';
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $this->stack[] = $value at testdata/mustache/src/Mustache/Context.php:39
    |
 39 |        array_push($this->stack, $value);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $this->blockStack[] = $value at testdata/mustache/src/Mustache/Context.php:49
    |
 49 |        array_push($this->blockStack, $value);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/mustache/src/Mustache/Context.php:213
     |
 213 |            switch (gettype($frame)) {
-    |            ^
+    |            ^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$options['cache_file_mode'] ?? null` at testdata/mustache/src/Mustache/Engine.php:156
     |
 156 |                $mode  = isset($options['cache_file_mode']) ? $options['cache_file_mode'] : null;
-    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   misspellComment: "entitity" is a misspelling of "entity" at testdata/mustache/src/Mustache/Engine.php:254
     |
 254 |    public function getEntityFlags()
-    |                    ^^^^^^^^^^^^^^
+    |                    ^^^^^^^^^^^^^^ 
 
 ERROR   undefinedClass: Class or interface named \Psr\Log\LoggerInterface does not exist at testdata/mustache/src/Mustache/Engine.php:451
     |
 451 |     * @param Mustache_Logger|Psr\Log\LoggerInterface $logger
-    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   undefinedMethod: Call to undefined method {\Mustache_Cache}->getLogger() at testdata/mustache/src/Mustache/Engine.php:459
     |
 459 |        if ($this->getCache()->getLogger() === null) {
-    |                               ^^^^^^^^^
+    |                               ^^^^^^^^^ 
 
 ERROR   undefinedMethod: Call to undefined method {\Mustache_Cache}->setLogger() at testdata/mustache/src/Mustache/Engine.php:460
     |
 460 |            $this->getCache()->setLogger($logger);
-    |                               ^^^^^^^^^
+    |                               ^^^^^^^^^ 
 
 ERROR   undefinedClass: Class or interface named \Psr\Log\LoggerInterface does not exist at testdata/mustache/src/Mustache/Engine.php:469
     |
 469 |     * @return Mustache_Logger|Psr\Log\LoggerInterface
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   undefinedMethod: Call to undefined method {\Mustache_Cache}->getLogger() at testdata/mustache/src/Mustache/Engine.php:561
     |
 561 |        if (isset($this->logger) && $cache->getLogger() === null) {
-    |                                            ^^^^^^^^^
+    |                                            ^^^^^^^^^ 
 
 ERROR   undefinedMethod: Call to undefined method {\Mustache_Cache}->setLogger() at testdata/mustache/src/Mustache/Engine.php:562
     |
 562 |            $cache->setLogger($this->getLogger());
-    |                    ^^^^^^^^^
+    |                    ^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$this->delimiters ?: '{{ }}'` at testdata/mustache/src/Mustache/Engine.php:628
     |
 628 |            'delimiters'      => $this->delimiters ? $this->delimiters : '{{ }}',
-    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \Mustache_Exception_UnknownFilterException::getFilterName public method at testdata/mustache/src/Mustache/Exception/UnknownFilterException.php:34
    |
 34 |    public function getFilterName()
-   |                    ^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^ 
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \Mustache_Exception_UnknownHelperException::getHelperName public method at testdata/mustache/src/Mustache/Exception/UnknownHelperException.php:34
    |
 34 |    public function getHelperName()
-   |                    ^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^ 
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \Mustache_Exception_UnknownTemplateException::getTemplateName public method at testdata/mustache/src/Mustache/Exception/UnknownTemplateException.php:34
    |
 34 |    public function getTemplateName()
-   |                    ^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^ 
 
 WARNING regexpVet: '\w' intersects with '\d' in [\w\d\.] at testdata/mustache/src/Mustache/Loader/InlineLoader.php:115
     |
 115 |            foreach (preg_split("/^@@(?= [\w\d\.]+$)/m", $data, -1) as $chunk) {
-    |                                ^^^^^^^^^^^^^^^^^^^^^^^
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/mustache/src/Mustache/Parser.php:307
     |
 307 |        switch ($name) {
-    |        ^
+    |        ^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Source/FilesystemSource.php:53
    |
 53 |                $this->stat = @stat($this->fileName);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^
+   |                              ^^^^^^^^^^^^^^^^^^^^^^ 
 
-WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/mustache/src/Mustache/Template.php:122
+WARNING unused: Variable $v is unused at testdata/mustache/src/Mustache/Template.php:122
     |
 122 |                foreach ($value as $k => $v) {
-    |                                         ^^
+    |                                         ^^ use `$_` to ignore (see --unused-var-regex flag)
 

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -1,174 +1,290 @@
 MAYBE   ternarySimplify: Could rewrite as `$baseDir ?: 0` at testdata/mustache/src/Mustache/Autoloader.php:56
-        $key = $baseDir ? $baseDir : 0;
-               ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+56 |        $key = $baseDir ? $baseDir : 0;
+   |               ^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   undefinedClass: Class or interface named \Psr\Log\LoggerInterface does not exist at testdata/mustache/src/Mustache/Cache/AbstractCache.php:26
-     * @return Mustache_Logger|Psr\Log\LoggerInterface
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+26 |     * @return Mustache_Logger|Psr\Log\LoggerInterface
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   undefinedClass: Class or interface named \Psr\Log\LoggerInterface does not exist at testdata/mustache/src/Mustache/Cache/AbstractCache.php:36
-     * @param Mustache_Logger|Psr\Log\LoggerInterface $logger
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+36 |     * @param Mustache_Logger|Psr\Log\LoggerInterface $logger
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:110
-            @mkdir($dirName, 0777, true);
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+110 |            @mkdir($dirName, 0777, true);
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:140
-        if (false !== @file_put_contents($tempFile, $value)) {
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+140 |        if (false !== @file_put_contents($tempFile, $value)) {
+    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:141
-            if (@rename($tempFile, $fileName)) {
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+141 |            if (@rename($tempFile, $fileName)) {
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$this->fileMode ?? (0666 & ~umask())` at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:142
-                $mode = isset($this->fileMode) ? $this->fileMode : (0666 & ~umask());
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+142 |                $mode = isset($this->fileMode) ? $this->fileMode : (0666 & ~umask());
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Cache/FilesystemCache.php:143
-                @chmod($fileName, $mode);
-                ^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+143 |                @chmod($fileName, $mode);
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING useEval: Don't use the 'eval' function at testdata/mustache/src/Mustache/Cache/NoopCache.php:45
-        eval('?>' . $value);
-        ^^^^^^^^^^^^^^^^^^^
+   |
+45 |        eval('?>' . $value);
+   |        ^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:99
-                        isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+99 |                        isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:112
-                        isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+112 |                        isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::INDENT] ?? ''` at testdata/mustache/src/Mustache/Compiler.php:120
-                        isset($node[Mustache_Tokenizer::INDENT]) ? $node[Mustache_Tokenizer::INDENT] : '',
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+120 |                        isset($node[Mustache_Tokenizer::INDENT]) ? $node[Mustache_Tokenizer::INDENT] : '',
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::INDENT] ?? ''` at testdata/mustache/src/Mustache/Compiler.php:128
-                        isset($node[Mustache_Tokenizer::INDENT]) ? $node[Mustache_Tokenizer::INDENT] : '',
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+128 |                        isset($node[Mustache_Tokenizer::INDENT]) ? $node[Mustache_Tokenizer::INDENT] : '',
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$node[Mustache_Tokenizer::FILTERS] ?? array()` at testdata/mustache/src/Mustache/Compiler.php:166
-                        isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+166 |                        isset($node[Mustache_Tokenizer::FILTERS]) ? $node[Mustache_Tokenizer::FILTERS] : array(),
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING unused: Variable $keystr is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/mustache/src/Mustache/Compiler.php:289
-        $keystr = var_export($key, true);
-        ^^^^^^^
+    |
+289 |        $keystr = var_export($key, true);
+    |        ^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $id[0] at testdata/mustache/src/Mustache/Compiler.php:646
-            if (substr($id, 0, 1) === '.') {
-                ^^^^^^^^^^^^^^^^^
+    |
+646 |            if (substr($id, 0, 1) === '.') {
+    |                ^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant KLASS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:184
-    const KLASS = '<?php
-    ^^^^^^^
+    |
+184 |    const KLASS = '<?php
+    |    ^^^^^^^
+
 ERROR   classMembersOrder: Constant KLASS_NO_LAMBDAS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:202
-    const KLASS_NO_LAMBDAS = '<?php
-    ^^^^^^^
+    |
+202 |    const KLASS_NO_LAMBDAS = '<?php
+    |    ^^^^^^^
+
 ERROR   classMembersOrder: Constant STRICT_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:215
-    const STRICT_CALLABLE = 'protected $strictCallables = true;';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+215 |    const STRICT_CALLABLE = 'protected $strictCallables = true;';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant BLOCK_VAR must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:237
-    const BLOCK_VAR = '
-    ^^
+    |
+237 |    const BLOCK_VAR = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant BLOCK_VAR_ELSE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:244
-    const BLOCK_VAR_ELSE = '} else {%s';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+244 |    const BLOCK_VAR_ELSE = '} else {%s';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant BLOCK_ARG must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:271
-    const BLOCK_ARG = '%s => array($this, \'block%s\'),';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+271 |    const BLOCK_ARG = '%s => array($this, \'block%s\'),';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant BLOCK_FUNCTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:295
-    const BLOCK_FUNCTION = '
-    ^^
+    |
+295 |    const BLOCK_FUNCTION = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant SECTION_CALL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:323
-    const SECTION_CALL = '
-    ^^
+    |
+323 |    const SECTION_CALL = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:329
-    const SECTION = '
-    ^^
+    |
+329 |    const SECTION = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant INVERTED_SECTION must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:398
-    const INVERTED_SECTION = '
-    ^^
+    |
+398 |    const INVERTED_SECTION = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant PARTIAL_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:425
-    const PARTIAL_INDENT = ', $indent . %s';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+425 |    const PARTIAL_INDENT = ', $indent . %s';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant PARTIAL must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:426
-    const PARTIAL = '
-    ^^
+    |
+426 |    const PARTIAL = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant PARENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:456
-    const PARENT = '
-    ^^
+    |
+456 |    const PARENT = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant PARENT_NO_CONTEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:465
-    const PARENT_NO_CONTEXT = '
-    ^^
+    |
+465 |    const PARENT_NO_CONTEXT = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant VARIABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:508
-    const VARIABLE = '
-    ^^
+    |
+508 |    const VARIABLE = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant FILTER must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:533
-    const FILTER = '
-    ^^
+    |
+533 |    const FILTER = '
+    |    ^^
+
 ERROR   classMembersOrder: Constant LINE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:564
-    const LINE = '$buffer .= "\n";';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+564 |    const LINE = '$buffer .= "\n";';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant TEXT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:565
-    const TEXT = '$buffer .= %s%s;';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+565 |    const TEXT = '$buffer .= %s%s;';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant DEFAULT_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:607
-    const DEFAULT_ESCAPE = 'htmlspecialchars(%s, %s, %s)';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+607 |    const DEFAULT_ESCAPE = 'htmlspecialchars(%s, %s, %s)';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant CUSTOM_ESCAPE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:608
-    const CUSTOM_ESCAPE  = 'call_user_func($this->mustache->getEscape(), %s)';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+608 |    const CUSTOM_ESCAPE  = 'call_user_func($this->mustache->getEscape(), %s)';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:658
-    const IS_CALLABLE        = '!is_string(%s) && is_callable(%s)';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+658 |    const IS_CALLABLE        = '!is_string(%s) && is_callable(%s)';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant STRICT_IS_CALLABLE must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:659
-    const STRICT_IS_CALLABLE = 'is_object(%s) && is_callable(%s)';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+659 |    const STRICT_IS_CALLABLE = 'is_object(%s) && is_callable(%s)';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant LINE_INDENT must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:675
-    const LINE_INDENT = '$indent . ';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+675 |    const LINE_INDENT = '$indent . ';
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $this->stack[] = $value at testdata/mustache/src/Mustache/Context.php:39
-        array_push($this->stack, $value);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+39 |        array_push($this->stack, $value);
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $this->blockStack[] = $value at testdata/mustache/src/Mustache/Context.php:49
-        array_push($this->blockStack, $value);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+49 |        array_push($this->blockStack, $value);
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/mustache/src/Mustache/Context.php:213
-            switch (gettype($frame)) {
-            ^
+    |
+213 |            switch (gettype($frame)) {
+    |            ^
+
 MAYBE   ternarySimplify: Could rewrite as `$options['cache_file_mode'] ?? null` at testdata/mustache/src/Mustache/Engine.php:156
-                $mode  = isset($options['cache_file_mode']) ? $options['cache_file_mode'] : null;
-                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+156 |                $mode  = isset($options['cache_file_mode']) ? $options['cache_file_mode'] : null;
+    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   misspellComment: "entitity" is a misspelling of "entity" at testdata/mustache/src/Mustache/Engine.php:254
-    public function getEntityFlags()
-                    ^^^^^^^^^^^^^^
+    |
+254 |    public function getEntityFlags()
+    |                    ^^^^^^^^^^^^^^
+
 ERROR   undefinedClass: Class or interface named \Psr\Log\LoggerInterface does not exist at testdata/mustache/src/Mustache/Engine.php:451
-     * @param Mustache_Logger|Psr\Log\LoggerInterface $logger
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+451 |     * @param Mustache_Logger|Psr\Log\LoggerInterface $logger
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   undefinedMethod: Call to undefined method {\Mustache_Cache}->getLogger() at testdata/mustache/src/Mustache/Engine.php:459
-        if ($this->getCache()->getLogger() === null) {
-                               ^^^^^^^^^
+    |
+459 |        if ($this->getCache()->getLogger() === null) {
+    |                               ^^^^^^^^^
+
 ERROR   undefinedMethod: Call to undefined method {\Mustache_Cache}->setLogger() at testdata/mustache/src/Mustache/Engine.php:460
-            $this->getCache()->setLogger($logger);
-                               ^^^^^^^^^
+    |
+460 |            $this->getCache()->setLogger($logger);
+    |                               ^^^^^^^^^
+
 ERROR   undefinedClass: Class or interface named \Psr\Log\LoggerInterface does not exist at testdata/mustache/src/Mustache/Engine.php:469
-     * @return Mustache_Logger|Psr\Log\LoggerInterface
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+469 |     * @return Mustache_Logger|Psr\Log\LoggerInterface
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   undefinedMethod: Call to undefined method {\Mustache_Cache}->getLogger() at testdata/mustache/src/Mustache/Engine.php:561
-        if (isset($this->logger) && $cache->getLogger() === null) {
-                                            ^^^^^^^^^
+    |
+561 |        if (isset($this->logger) && $cache->getLogger() === null) {
+    |                                            ^^^^^^^^^
+
 ERROR   undefinedMethod: Call to undefined method {\Mustache_Cache}->setLogger() at testdata/mustache/src/Mustache/Engine.php:562
-            $cache->setLogger($this->getLogger());
-                    ^^^^^^^^^
+    |
+562 |            $cache->setLogger($this->getLogger());
+    |                    ^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$this->delimiters ?: '{{ }}'` at testdata/mustache/src/Mustache/Engine.php:628
-            'delimiters'      => $this->delimiters ? $this->delimiters : '{{ }}',
-                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+628 |            'delimiters'      => $this->delimiters ? $this->delimiters : '{{ }}',
+    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \Mustache_Exception_UnknownFilterException::getFilterName public method at testdata/mustache/src/Mustache/Exception/UnknownFilterException.php:34
-    public function getFilterName()
-                    ^^^^^^^^^^^^^
+   |
+34 |    public function getFilterName()
+   |                    ^^^^^^^^^^^^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \Mustache_Exception_UnknownHelperException::getHelperName public method at testdata/mustache/src/Mustache/Exception/UnknownHelperException.php:34
-    public function getHelperName()
-                    ^^^^^^^^^^^^^
+   |
+34 |    public function getHelperName()
+   |                    ^^^^^^^^^^^^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \Mustache_Exception_UnknownTemplateException::getTemplateName public method at testdata/mustache/src/Mustache/Exception/UnknownTemplateException.php:34
-    public function getTemplateName()
-                    ^^^^^^^^^^^^^^^
+   |
+34 |    public function getTemplateName()
+   |                    ^^^^^^^^^^^^^^^
+
 WARNING regexpVet: '\w' intersects with '\d' in [\w\d\.] at testdata/mustache/src/Mustache/Loader/InlineLoader.php:115
-            foreach (preg_split("/^@@(?= [\w\d\.]+$)/m", $data, -1) as $chunk) {
-                                ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+115 |            foreach (preg_split("/^@@(?= [\w\d\.]+$)/m", $data, -1) as $chunk) {
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/mustache/src/Mustache/Parser.php:307
-        switch ($name) {
-        ^
+    |
+307 |        switch ($name) {
+    |        ^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/mustache/src/Mustache/Source/FilesystemSource.php:53
-                $this->stat = @stat($this->fileName);
-                              ^^^^^^^^^^^^^^^^^^^^^^
+   |
+53 |                $this->stat = @stat($this->fileName);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/mustache/src/Mustache/Template.php:122
-                foreach ($value as $k => $v) {
-                                         ^^
+    |
+122 |                foreach ($value as $k => $v) {
+    |                                         ^^
+

--- a/src/tests/golden/testdata/options-resolver/golden.txt
+++ b/src/tests/golden/testdata/options-resolver/golden.txt
@@ -1,48 +1,80 @@
 MAYBE   typeHint: Specify the return type for the function getNormalizers in PHPDoc, 'array' type hint too generic at testdata/options-resolver/Debug/OptionsResolverIntrospector.php:94
-    public function getNormalizers(string $option): array
-                    ^^^^^^^^^^^^^^
+   |
+94 |    public function getNormalizers(string $option): array
+   |                    ^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the return type for the function getDeprecation in PHPDoc, 'array' type hint too generic at testdata/options-resolver/Debug/OptionsResolverIntrospector.php:116
-    public function getDeprecation(string $option): array
-                    ^^^^^^^^^^^^^^
+    |
+116 |    public function getDeprecation(string $option): array
+    |                    ^^^^^^^^^^^^^^
+
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:188
-            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
-                                                                    ^^^^^^^^
+    |
+188 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
+    |                                                                    ^^^^^^^^
+
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:188
-            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
-                                                                    ^^^^^^^^
+    |
+188 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
+    |                                                                    ^^^^^^^^
+
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
-            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
-                                                                    ^^^^^^^^
+    |
+209 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
+    |                                                                    ^^^^^^^^
+
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
-            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
-                                                                                                                                                                          ^^^^^^^^
+    |
+209 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
+    |                                                                                                                                                                          ^^^^^^^^
+
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
-            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
-                                                                    ^^^^^^^^
+    |
+209 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
+    |                                                                    ^^^^^^^^
+
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
-            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
-                                                                                                                                                                          ^^^^^^^^
+    |
+209 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
+    |                                                                                                                                                                          ^^^^^^^^
+
 WARNING invalidDocblock: @param for non-existing argument $package at testdata/options-resolver/OptionsResolver.php:424
-     * @param string          $package The name of the composer package that is triggering the deprecation
-                              ^^^^^^^^
+    |
+424 |     * @param string          $package The name of the composer package that is triggering the deprecation
+    |                              ^^^^^^^^
+
 WARNING invalidDocblock: @param for non-existing argument $version at testdata/options-resolver/OptionsResolver.php:425
-     * @param string          $version The version of the package that introduced the deprecation
-                              ^^^^^^^^
+    |
+425 |     * @param string          $version The version of the package that introduced the deprecation
+    |                              ^^^^^^^^
+
 WARNING invalidDocblock: @param for non-existing argument $message at testdata/options-resolver/OptionsResolver.php:426
-     * @param string|\Closure $message The deprecation message to use
-                              ^^^^^^^^
+    |
+426 |     * @param string|\Closure $message The deprecation message to use
+    |                              ^^^^^^^^
+
 MAYBE   complexity: Too big method: more than 150 lines at testdata/options-resolver/OptionsResolver.php:917
-    public function offsetGet($option, bool $triggerDeprecation = true)
-                    ^^^^^^^^^
+    |
+917 |    public function offsetGet($option, bool $triggerDeprecation = true)
+    |                    ^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $invalidTypes in PHPDoc, 'array' type hint too generic at testdata/options-resolver/OptionsResolver.php:1123
-    private function verifyTypes(string $type, $value, array &$invalidTypes, int $level = 0): bool
-                     ^^^^^^^^^^^
+     |
+1123 |    private function verifyTypes(string $type, $value, array &$invalidTypes, int $level = 0): bool
+     |                     ^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $values in PHPDoc, 'array' type hint too generic at testdata/options-resolver/OptionsResolver.php:1259
-    private function formatValues(array $values): string
-                     ^^^^^^^^^^^^
+     |
+1259 |    private function formatValues(array $values): string
+     |                     ^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $options in PHPDoc, 'array' type hint too generic at testdata/options-resolver/OptionsResolver.php:1268
-    private function formatOptions(array $options): string
-                     ^^^^^^^^^^^^^
+     |
+1268 |    private function formatOptions(array $options): string
+     |                     ^^^^^^^^^^^^^
+
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/options-resolver/function.php:25
-        @trigger_error(($package || $version ? "Since $package $version: " : '').($args ? vsprintf($message, $args) : $message), E_USER_DEPRECATED);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+25 |        @trigger_error(($package || $version ? "Since $package $version: " : '').($args ? vsprintf($message, $args) : $message), E_USER_DEPRECATED);
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/tests/golden/testdata/options-resolver/golden.txt
+++ b/src/tests/golden/testdata/options-resolver/golden.txt
@@ -1,80 +1,80 @@
 MAYBE   typeHint: Specify the return type for the function getNormalizers in PHPDoc, 'array' type hint too generic at testdata/options-resolver/Debug/OptionsResolverIntrospector.php:94
    |
 94 |    public function getNormalizers(string $option): array
-   |                    ^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the return type for the function getDeprecation in PHPDoc, 'array' type hint too generic at testdata/options-resolver/Debug/OptionsResolverIntrospector.php:116
     |
 116 |    public function getDeprecation(string $option): array
-    |                    ^^^^^^^^^^^^^^
+    |                    ^^^^^^^^^^^^^^ 
 
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:188
     |
 188 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
-    |                                                                    ^^^^^^^^
+    |                                                                    ^^^^^^^^ 
 
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:188
     |
 188 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
-    |                                                                    ^^^^^^^^
+    |                                                                    ^^^^^^^^ 
 
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
     |
 209 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
-    |                                                                    ^^^^^^^^
+    |                                                                    ^^^^^^^^ 
 
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
     |
 209 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
-    |                                                                                                                                                                          ^^^^^^^^
+    |                                                                                                                                                                          ^^^^^^^^ 
 
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
     |
 209 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
-    |                                                                    ^^^^^^^^
+    |                                                                    ^^^^^^^^ 
 
 MAYBE   deprecated: Call to deprecated method {\ReflectionParameter}->getClass() (since: 8.0, reason: Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead) at testdata/options-resolver/OptionsResolver.php:209
     |
 209 |            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
-    |                                                                                                                                                                          ^^^^^^^^
+    |                                                                                                                                                                          ^^^^^^^^ 
 
 WARNING invalidDocblock: @param for non-existing argument $package at testdata/options-resolver/OptionsResolver.php:424
     |
 424 |     * @param string          $package The name of the composer package that is triggering the deprecation
-    |                              ^^^^^^^^
+    |                              ^^^^^^^^ 
 
 WARNING invalidDocblock: @param for non-existing argument $version at testdata/options-resolver/OptionsResolver.php:425
     |
 425 |     * @param string          $version The version of the package that introduced the deprecation
-    |                              ^^^^^^^^
+    |                              ^^^^^^^^ 
 
 WARNING invalidDocblock: @param for non-existing argument $message at testdata/options-resolver/OptionsResolver.php:426
     |
 426 |     * @param string|\Closure $message The deprecation message to use
-    |                              ^^^^^^^^
+    |                              ^^^^^^^^ 
 
 MAYBE   complexity: Too big method: more than 150 lines at testdata/options-resolver/OptionsResolver.php:917
     |
 917 |    public function offsetGet($option, bool $triggerDeprecation = true)
-    |                    ^^^^^^^^^
+    |                    ^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $invalidTypes in PHPDoc, 'array' type hint too generic at testdata/options-resolver/OptionsResolver.php:1123
      |
 1123 |    private function verifyTypes(string $type, $value, array &$invalidTypes, int $level = 0): bool
-     |                     ^^^^^^^^^^^
+     |                     ^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $values in PHPDoc, 'array' type hint too generic at testdata/options-resolver/OptionsResolver.php:1259
      |
 1259 |    private function formatValues(array $values): string
-     |                     ^^^^^^^^^^^^
+     |                     ^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $options in PHPDoc, 'array' type hint too generic at testdata/options-resolver/OptionsResolver.php:1268
      |
 1268 |    private function formatOptions(array $options): string
-     |                     ^^^^^^^^^^^^^
+     |                     ^^^^^^^^^^^^^ 
 
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/options-resolver/function.php:25
    |
 25 |        @trigger_error(($package || $version ? "Since $package $version: " : '').($args ? vsprintf($message, $args) : $message), E_USER_DEPRECATED);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/output-test/golden.txt
+++ b/src/tests/golden/testdata/output-test/golden.txt
@@ -1,35 +1,35 @@
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:3
   |
 3 |/** @linter disable */
-  |            ^^^^^^^
+  |            ^^^^^^^ 
 
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:6
   |
 6 | * @linter disable
-  |           ^^^^^^^
+  |           ^^^^^^^ 
 
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:10
    |
 10 | * @linter disable
-   |           ^^^^^^^
+   |           ^^^^^^^ 
 
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:11
    |
 11 | * @linter disable
-   |           ^^^^^^^
+   |           ^^^^^^^ 
 
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:12
    |
 12 | * @linter disable
-   |           ^^^^^^^
+   |           ^^^^^^^ 
 
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:13
    |
 13 | * @linter disable
-   |           ^^^^^^^
+   |           ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/output-test/output_test.php:16
    |
 16 |$_ = array(); // warning in last line
-   |     ^^^^^^^
+   |     ^^^^^^^ 
 

--- a/src/tests/golden/testdata/output-test/golden.txt
+++ b/src/tests/golden/testdata/output-test/golden.txt
@@ -1,21 +1,35 @@
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:3
-/** @linter disable */
-            ^^^^^^^
+  |
+3 |/** @linter disable */
+  |            ^^^^^^^
+
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:6
- * @linter disable
-           ^^^^^^^
+  |
+6 | * @linter disable
+  |           ^^^^^^^
+
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:10
- * @linter disable
-           ^^^^^^^
+   |
+10 | * @linter disable
+   |           ^^^^^^^
+
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:11
- * @linter disable
-           ^^^^^^^
+   |
+11 | * @linter disable
+   |           ^^^^^^^
+
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:12
- * @linter disable
-           ^^^^^^^
+   |
+12 | * @linter disable
+   |           ^^^^^^^
+
 WARNING linterError: You are not allowed to disable linter at testdata/output-test/output_test.php:13
- * @linter disable
-           ^^^^^^^
+   |
+13 | * @linter disable
+   |           ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/output-test/output_test.php:16
-$_ = array(); // warning in last line
-     ^^^^^^^
+   |
+16 |$_ = array(); // warning in last line
+   |     ^^^^^^^
+

--- a/src/tests/golden/testdata/parsedown/golden.txt
+++ b/src/tests/golden/testdata/parsedown/golden.txt
@@ -1,380 +1,380 @@
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::text method explicitly at testdata/parsedown/parsedown.php:24
    |
 24 |    function text($text)
-   |             ^^^^
+   |             ^^^^ 
 
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setBreaksEnabled method explicitly at testdata/parsedown/parsedown.php:59
    |
 59 |    function setBreaksEnabled($breaksEnabled)
-   |             ^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^ 
 
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setMarkupEscaped method explicitly at testdata/parsedown/parsedown.php:68
    |
 68 |    function setMarkupEscaped($markupEscaped)
-   |             ^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^ 
 
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setUrlsLinked method explicitly at testdata/parsedown/parsedown.php:77
    |
 77 |    function setUrlsLinked($urlsLinked)
-   |             ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^ 
 
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setSafeMode method explicitly at testdata/parsedown/parsedown.php:86
    |
 86 |    function setSafeMode($safeMode)
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^^^^ 
 
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setStrictMode method explicitly at testdata/parsedown/parsedown.php:95
    |
 95 |    function setStrictMode($strictMode)
-   |             ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $lines in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:162
     |
 162 |    protected function lines(array $lines)
-    |                       ^^^^^
+    |                       ^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $lines in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:167
     |
 167 |    protected function linesElements(array $lines)
-    |                       ^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Component in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:319
     |
 319 |    protected function extractElement(array $Component)
-    |                       ^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:428
     |
 428 |    protected function blockCommentContinue($Line, array $Block)
-    |                       ^^^^^^^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:560
     |
 560 |                'handler' => array(
-    |                ^
+    |                ^ 
 
 MAYBE   typeHint: Specify the type for the parameter $CurrentBlock in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:574
     |
 574 |    protected function blockList($Line, array $CurrentBlock = null)
-    |                       ^^^^^^^^^
+    |                       ^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:633
     |
 633 |                    'destination' => 'elements'
-    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:630
     |
 630 |                'handler' => array(
-    |                ^
+    |                ^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:643
     |
 643 |    protected function blockListContinue($Line, array $Block)
-    |                       ^^^^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$matches[1] ?? ''` at testdata/parsedown/parsedown.php:674
     |
 674 |            $text = isset($matches[1]) ? $matches[1] : '';
-    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:683
     |
 683 |                    'destination' => 'elements'
-    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:680
     |
 680 |                'handler' => array(
-    |                ^
+    |                ^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:729
     |
 729 |    protected function blockListComplete(array $Block)
-    |                       ^^^^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '/^>[ ]?+(.*+)/' as '/^> ?+(.*+)/' at testdata/parsedown/parsedown.php:750
     |
 750 |        if (preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
-    |                       ^^^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:755
     |
 755 |                    'handler' => array(
-    |                    ^
+    |                    ^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:767
     |
 767 |    protected function blockQuoteContinue($Line, array $Block)
-    |                       ^^^^^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '/^>[ ]?+(.*+)/' as '/^> ?+(.*+)/' at testdata/parsedown/parsedown.php:774
     |
 774 |        if ($Line['text'][0] === '>' and preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
-    |                                                    ^^^^^^^^^^^^^^^^
+    |                                                    ^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:811
     |
 811 |    protected function blockSetextHeader($Line, array $Block = null)
-    |                       ^^^^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/parsedown/parsedown.php:840
     |
 840 |            if (in_array($element, $this->textLevelElements))
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:857
     |
 857 |    protected function blockMarkupContinue($Line, array $Block)
-    |                       ^^^^^^^^^^^^^^^^^^^
+    |                       ^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/' as '/^\[(.+?)\]: *+<?(\S+?)>?(?: +["'(](.+)["')])? *+$/' at testdata/parsedown/parsedown.php:875
     |
 875 |            and preg_match('/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/', $Line['text'], $matches)
-    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$matches[3] ?? null` at testdata/parsedown/parsedown.php:881
     |
 881 |                'title' => isset($matches[3]) ? $matches[3] : null,
-    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:897
     |
 897 |    protected function blockTable($Line, array $Block = null)
-    |                       ^^^^^^^^^^
+    |                       ^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:973
     |
 973 |                'handler' => array(
-    |                ^
+    |                ^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1020
      |
 1020 |    protected function blockTableContinue($Line, array $Block)
-     |                       ^^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:1046
      |
 1046 |                    'handler' => array(
-     |                    ^
+     |                    ^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1093
      |
 1093 |    protected function paragraphContinue($Line, array $Block)
-     |                       ^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '/[ ]*+\n/' as '/ *+\n/' at testdata/parsedown/parsedown.php:1265
      |
 1265 |            $text = preg_replace('/[ ]*+\n/', ' ', $text);
-     |                                 ^^^^^^^^^^^
+     |                                 ^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:1333
      |
 1333 |                'handler' => array(
-     |                ^
+     |                ^ 
 
 MAYBE   regexpSimplify: May re-write '/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/' as '/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?: +("[^"]*+"|'[^']*+'))?\s*+[)]/' at testdata/parsedown/parsedown.php:1421
      |
 1421 |        if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/', $remainder, $matches))
-     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   regexpSimplify: May re-write '/^<\/\w[\w-]*+[ ]*+>/s' as '/^<\/\w[\w-]*+ *+>/s' at testdata/parsedown/parsedown.php:1470
      |
 1470 |        if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*+[ ]*+>/s', $Excerpt['text'], $matches))
-     |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^
+     |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $Excerpt['text'][1] at testdata/parsedown/parsedown.php:1497
      |
 1497 |        if (substr($Excerpt['text'], 1, 1) !== ' ' and strpos($Excerpt['text'], ';') !== false
-     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:1522
      |
 1522 |                    'handler' => array(
-     |                    ^
+     |                    ^ 
 
 MAYBE   regexpSimplify: May re-write '/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui' as '~\bhttps?+:/{2}[^\s<]+\b/*+~ui' at testdata/parsedown/parsedown.php:1540
      |
 1540 |            and preg_match('/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE)
-     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1591
      |
 1591 |    protected function handle(array $Element)
-     |                       ^^^^^^
+     |                       ^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1627
      |
 1627 |    protected function handleElementRecursive(array $Element)
-     |                       ^^^^^^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Elements in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1632
      |
 1632 |    protected function handleElementsRecursive(array $Elements)
-     |                       ^^^^^^^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1637
      |
 1637 |    protected function elementApplyRecursive($closure, array $Element)
-     |                       ^^^^^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1653
      |
 1653 |    protected function elementApplyRecursiveDepthFirst($closure, array $Element)
-     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Elements in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1669
      |
 1669 |    protected function elementsApplyRecursive($closure, array $Elements)
-     |                       ^^^^^^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Elements in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1679
      |
 1679 |    protected function elementsApplyRecursiveDepthFirst($closure, array $Elements)
-     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1689
      |
 1689 |    protected function element(array $Element)
-     |                       ^^^^^^^
+     |                       ^^^^^^^ 
 
 WARNING maybeUndefined: Possibly undefined variable $text at testdata/parsedown/parsedown.php:1755
      |
 1755 |                    $markup .= self::escape($text, true);
-     |                                            ^^^^^
+     |                                            ^^^^^ 
 
 WARNING maybeUndefined: Possibly undefined variable $text at testdata/parsedown/parsedown.php:1759
      |
 1759 |                    $markup .= $text;
-     |                               ^^^^^
+     |                               ^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Elements in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1773
      |
 1773 |    protected function elements(array $Elements)
-     |                       ^^^^^^^^
+     |                       ^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$Element['autobreak'] ?? isset($Element['name'])` at testdata/parsedown/parsedown.php:1786
      |
 1786 |            $autoBreakNext = (isset($Element['autobreak'])
-     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/parsedown/parsedown.php:1807
      |
 1807 |        if ( ! in_array('', $lines)
-     |               ^^^^^^^^^^^^^^^^^^^^
+     |               ^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::parse method explicitly at testdata/parsedown/parsedown.php:1854
      |
 1854 |    function parse($text)
-     |             ^^^^^
+     |             ^^^^^ 
 
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1861
      |
 1861 |    protected function sanitiseElement(array $Element)
-     |                       ^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^ 
 
-WARNING unused: Variable $val is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/parsedown/parsedown.php:1882
+WARNING unused: Variable $val is unused at testdata/parsedown/parsedown.php:1882
      |
 1882 |            foreach ($Element['attributes'] as $att => $val)
-     |                                                       ^^^^
+     |                                                       ^^^^ use `$_` to ignore (see --unused-var-regex flag)
 
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1900
      |
 1900 |    protected function filterUnsafeUrlInAttribute(array $Element, $attribute)
-     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::instance method explicitly at testdata/parsedown/parsedown.php:1938
      |
 1938 |    static function instance($name = 'default')
-     |                    ^^^^^^^^
+     |                    ^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $breaksEnabled must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:66
    |
 66 |    protected $breaksEnabled;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $markupEscaped must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:75
    |
 75 |    protected $markupEscaped;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $urlsLinked must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:84
    |
 84 |    protected $urlsLinked = true;
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $safeMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:93
    |
 93 |    protected $safeMode;
-   |    ^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $strictMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:102
     |
 102 |    protected $strictMode;
-    |    ^^^^^^^^^^^^^^^^^^^^^^
+    |    ^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $safeLinksWhitelist must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:104
     |
 104 |    protected $safeLinksWhitelist = array(
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Property $BlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:126
     |
 126 |    protected $BlockTypes = array(
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Property $unmarkedBlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:154
     |
 154 |    protected $unmarkedBlockTypes = array(
-    |    ^^
+    |    ^^ 
 
 ERROR   classMembersOrder: Property $InlineTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1109
      |
 1109 |    protected $InlineTypes = array(
-     |    ^^
+     |    ^^ 
 
 ERROR   classMembersOrder: Property $inlineMarkerList must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1124
      |
 1124 |    protected $inlineMarkerList = '!*_&[:<`~\\';
-     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $instances must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1952
      |
 1952 |    private static $instances = array();
-     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $DefinitionData must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1958
      |
 1958 |    protected $DefinitionData;
-     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $specialCharacters must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1963
      |
 1963 |    protected $specialCharacters = array(
-     |    ^^
+     |    ^^ 
 
 ERROR   classMembersOrder: Property $StrongRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1967
      |
 1967 |    protected $StrongRegex = array(
-     |    ^^
+     |    ^^ 
 
 ERROR   classMembersOrder: Property $EmRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1972
      |
 1972 |    protected $EmRegex = array(
-     |    ^^
+     |    ^^ 
 
 ERROR   classMembersOrder: Property $regexHtmlAttribute must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1977
      |
 1977 |    protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*+(?:\s*+=\s*+(?:[^"\'=<>`\s]+|"[^"]*+"|\'[^\']*+\'))?+';
-     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $voidElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1979
      |
 1979 |    protected $voidElements = array(
-     |    ^^
+     |    ^^ 
 
 ERROR   classMembersOrder: Property $textLevelElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1983
      |
 1983 |    protected $textLevelElements = array(
-     |    ^^
+     |    ^^ 
 

--- a/src/tests/golden/testdata/parsedown/golden.txt
+++ b/src/tests/golden/testdata/parsedown/golden.txt
@@ -1,228 +1,380 @@
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::text method explicitly at testdata/parsedown/parsedown.php:24
-    function text($text)
-             ^^^^
+   |
+24 |    function text($text)
+   |             ^^^^
+
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setBreaksEnabled method explicitly at testdata/parsedown/parsedown.php:59
-    function setBreaksEnabled($breaksEnabled)
-             ^^^^^^^^^^^^^^^^
+   |
+59 |    function setBreaksEnabled($breaksEnabled)
+   |             ^^^^^^^^^^^^^^^^
+
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setMarkupEscaped method explicitly at testdata/parsedown/parsedown.php:68
-    function setMarkupEscaped($markupEscaped)
-             ^^^^^^^^^^^^^^^^
+   |
+68 |    function setMarkupEscaped($markupEscaped)
+   |             ^^^^^^^^^^^^^^^^
+
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setUrlsLinked method explicitly at testdata/parsedown/parsedown.php:77
-    function setUrlsLinked($urlsLinked)
-             ^^^^^^^^^^^^^
+   |
+77 |    function setUrlsLinked($urlsLinked)
+   |             ^^^^^^^^^^^^^
+
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setSafeMode method explicitly at testdata/parsedown/parsedown.php:86
-    function setSafeMode($safeMode)
-             ^^^^^^^^^^^
+   |
+86 |    function setSafeMode($safeMode)
+   |             ^^^^^^^^^^^
+
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::setStrictMode method explicitly at testdata/parsedown/parsedown.php:95
-    function setStrictMode($strictMode)
-             ^^^^^^^^^^^^^
+   |
+95 |    function setStrictMode($strictMode)
+   |             ^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $lines in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:162
-    protected function lines(array $lines)
-                       ^^^^^
+    |
+162 |    protected function lines(array $lines)
+    |                       ^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $lines in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:167
-    protected function linesElements(array $lines)
-                       ^^^^^^^^^^^^^
+    |
+167 |    protected function linesElements(array $lines)
+    |                       ^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Component in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:319
-    protected function extractElement(array $Component)
-                       ^^^^^^^^^^^^^^
+    |
+319 |    protected function extractElement(array $Component)
+    |                       ^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:428
-    protected function blockCommentContinue($Line, array $Block)
-                       ^^^^^^^^^^^^^^^^^^^^
+    |
+428 |    protected function blockCommentContinue($Line, array $Block)
+    |                       ^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:560
-                'handler' => array(
-                ^
+    |
+560 |                'handler' => array(
+    |                ^
+
 MAYBE   typeHint: Specify the type for the parameter $CurrentBlock in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:574
-    protected function blockList($Line, array $CurrentBlock = null)
-                       ^^^^^^^^^
+    |
+574 |    protected function blockList($Line, array $CurrentBlock = null)
+    |                       ^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:633
-                    'destination' => 'elements'
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+633 |                    'destination' => 'elements'
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:630
-                'handler' => array(
-                ^
+    |
+630 |                'handler' => array(
+    |                ^
+
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:643
-    protected function blockListContinue($Line, array $Block)
-                       ^^^^^^^^^^^^^^^^^
+    |
+643 |    protected function blockListContinue($Line, array $Block)
+    |                       ^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$matches[1] ?? ''` at testdata/parsedown/parsedown.php:674
-            $text = isset($matches[1]) ? $matches[1] : '';
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+674 |            $text = isset($matches[1]) ? $matches[1] : '';
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:683
-                    'destination' => 'elements'
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+683 |                    'destination' => 'elements'
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:680
-                'handler' => array(
-                ^
+    |
+680 |                'handler' => array(
+    |                ^
+
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:729
-    protected function blockListComplete(array $Block)
-                       ^^^^^^^^^^^^^^^^^
+    |
+729 |    protected function blockListComplete(array $Block)
+    |                       ^^^^^^^^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '/^>[ ]?+(.*+)/' as '/^> ?+(.*+)/' at testdata/parsedown/parsedown.php:750
-        if (preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
-                       ^^^^^^^^^^^^^^^^
+    |
+750 |        if (preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
+    |                       ^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:755
-                    'handler' => array(
-                    ^
+    |
+755 |                    'handler' => array(
+    |                    ^
+
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:767
-    protected function blockQuoteContinue($Line, array $Block)
-                       ^^^^^^^^^^^^^^^^^^
+    |
+767 |    protected function blockQuoteContinue($Line, array $Block)
+    |                       ^^^^^^^^^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '/^>[ ]?+(.*+)/' as '/^> ?+(.*+)/' at testdata/parsedown/parsedown.php:774
-        if ($Line['text'][0] === '>' and preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
-                                                    ^^^^^^^^^^^^^^^^
+    |
+774 |        if ($Line['text'][0] === '>' and preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
+    |                                                    ^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:811
-    protected function blockSetextHeader($Line, array $Block = null)
-                       ^^^^^^^^^^^^^^^^^
+    |
+811 |    protected function blockSetextHeader($Line, array $Block = null)
+    |                       ^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/parsedown/parsedown.php:840
-            if (in_array($element, $this->textLevelElements))
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+840 |            if (in_array($element, $this->textLevelElements))
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:857
-    protected function blockMarkupContinue($Line, array $Block)
-                       ^^^^^^^^^^^^^^^^^^^
+    |
+857 |    protected function blockMarkupContinue($Line, array $Block)
+    |                       ^^^^^^^^^^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/' as '/^\[(.+?)\]: *+<?(\S+?)>?(?: +["'(](.+)["')])? *+$/' at testdata/parsedown/parsedown.php:875
-            and preg_match('/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/', $Line['text'], $matches)
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+875 |            and preg_match('/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/', $Line['text'], $matches)
+    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$matches[3] ?? null` at testdata/parsedown/parsedown.php:881
-                'title' => isset($matches[3]) ? $matches[3] : null,
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+881 |                'title' => isset($matches[3]) ? $matches[3] : null,
+    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:897
-    protected function blockTable($Line, array $Block = null)
-                       ^^^^^^^^^^
+    |
+897 |    protected function blockTable($Line, array $Block = null)
+    |                       ^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:973
-                'handler' => array(
-                ^
+    |
+973 |                'handler' => array(
+    |                ^
+
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1020
-    protected function blockTableContinue($Line, array $Block)
-                       ^^^^^^^^^^^^^^^^^^
+     |
+1020 |    protected function blockTableContinue($Line, array $Block)
+     |                       ^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:1046
-                    'handler' => array(
-                    ^
+     |
+1046 |                    'handler' => array(
+     |                    ^
+
 MAYBE   typeHint: Specify the type for the parameter $Block in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1093
-    protected function paragraphContinue($Line, array $Block)
-                       ^^^^^^^^^^^^^^^^^
+     |
+1093 |    protected function paragraphContinue($Line, array $Block)
+     |                       ^^^^^^^^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '/[ ]*+\n/' as '/ *+\n/' at testdata/parsedown/parsedown.php:1265
-            $text = preg_replace('/[ ]*+\n/', ' ', $text);
-                                 ^^^^^^^^^^^
+     |
+1265 |            $text = preg_replace('/[ ]*+\n/', ' ', $text);
+     |                                 ^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:1333
-                'handler' => array(
-                ^
+     |
+1333 |                'handler' => array(
+     |                ^
+
 MAYBE   regexpSimplify: May re-write '/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/' as '/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?: +("[^"]*+"|'[^']*+'))?\s*+[)]/' at testdata/parsedown/parsedown.php:1421
-        if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/', $remainder, $matches))
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1421 |        if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/', $remainder, $matches))
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   regexpSimplify: May re-write '/^<\/\w[\w-]*+[ ]*+>/s' as '/^<\/\w[\w-]*+ *+>/s' at testdata/parsedown/parsedown.php:1470
-        if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*+[ ]*+>/s', $Excerpt['text'], $matches))
-                                                       ^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1470 |        if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*+[ ]*+>/s', $Excerpt['text'], $matches))
+     |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $Excerpt['text'][1] at testdata/parsedown/parsedown.php:1497
-        if (substr($Excerpt['text'], 1, 1) !== ' ' and strpos($Excerpt['text'], ';') !== false
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1497 |        if (substr($Excerpt['text'], 1, 1) !== ' ' and strpos($Excerpt['text'], ';') !== false
+     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/parsedown/parsedown.php:1522
-                    'handler' => array(
-                    ^
+     |
+1522 |                    'handler' => array(
+     |                    ^
+
 MAYBE   regexpSimplify: May re-write '/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui' as '~\bhttps?+:/{2}[^\s<]+\b/*+~ui' at testdata/parsedown/parsedown.php:1540
-            and preg_match('/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE)
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1540 |            and preg_match('/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE)
+     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1591
-    protected function handle(array $Element)
-                       ^^^^^^
+     |
+1591 |    protected function handle(array $Element)
+     |                       ^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1627
-    protected function handleElementRecursive(array $Element)
-                       ^^^^^^^^^^^^^^^^^^^^^^
+     |
+1627 |    protected function handleElementRecursive(array $Element)
+     |                       ^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Elements in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1632
-    protected function handleElementsRecursive(array $Elements)
-                       ^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1632 |    protected function handleElementsRecursive(array $Elements)
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1637
-    protected function elementApplyRecursive($closure, array $Element)
-                       ^^^^^^^^^^^^^^^^^^^^^
+     |
+1637 |    protected function elementApplyRecursive($closure, array $Element)
+     |                       ^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1653
-    protected function elementApplyRecursiveDepthFirst($closure, array $Element)
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1653 |    protected function elementApplyRecursiveDepthFirst($closure, array $Element)
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Elements in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1669
-    protected function elementsApplyRecursive($closure, array $Elements)
-                       ^^^^^^^^^^^^^^^^^^^^^^
+     |
+1669 |    protected function elementsApplyRecursive($closure, array $Elements)
+     |                       ^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Elements in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1679
-    protected function elementsApplyRecursiveDepthFirst($closure, array $Elements)
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1679 |    protected function elementsApplyRecursiveDepthFirst($closure, array $Elements)
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1689
-    protected function element(array $Element)
-                       ^^^^^^^
+     |
+1689 |    protected function element(array $Element)
+     |                       ^^^^^^^
+
 WARNING maybeUndefined: Possibly undefined variable $text at testdata/parsedown/parsedown.php:1755
-                    $markup .= self::escape($text, true);
-                                            ^^^^^
+     |
+1755 |                    $markup .= self::escape($text, true);
+     |                                            ^^^^^
+
 WARNING maybeUndefined: Possibly undefined variable $text at testdata/parsedown/parsedown.php:1759
-                    $markup .= $text;
-                               ^^^^^
+     |
+1759 |                    $markup .= $text;
+     |                               ^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Elements in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1773
-    protected function elements(array $Elements)
-                       ^^^^^^^^
+     |
+1773 |    protected function elements(array $Elements)
+     |                       ^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$Element['autobreak'] ?? isset($Element['name'])` at testdata/parsedown/parsedown.php:1786
-            $autoBreakNext = (isset($Element['autobreak'])
-                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1786 |            $autoBreakNext = (isset($Element['autobreak'])
+     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/parsedown/parsedown.php:1807
-        if ( ! in_array('', $lines)
-               ^^^^^^^^^^^^^^^^^^^^
+     |
+1807 |        if ( ! in_array('', $lines)
+     |               ^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::parse method explicitly at testdata/parsedown/parsedown.php:1854
-    function parse($text)
-             ^^^^^
+     |
+1854 |    function parse($text)
+     |             ^^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1861
-    protected function sanitiseElement(array $Element)
-                       ^^^^^^^^^^^^^^^
+     |
+1861 |    protected function sanitiseElement(array $Element)
+     |                       ^^^^^^^^^^^^^^^
+
 WARNING unused: Variable $val is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/parsedown/parsedown.php:1882
-            foreach ($Element['attributes'] as $att => $val)
-                                                       ^^^^
+     |
+1882 |            foreach ($Element['attributes'] as $att => $val)
+     |                                                       ^^^^
+
 MAYBE   typeHint: Specify the type for the parameter $Element in PHPDoc, 'array' type hint too generic at testdata/parsedown/parsedown.php:1900
-    protected function filterUnsafeUrlInAttribute(array $Element, $attribute)
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1900 |    protected function filterUnsafeUrlInAttribute(array $Element, $attribute)
+     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   implicitModifiers: Specify the access modifier for \Parsedown::instance method explicitly at testdata/parsedown/parsedown.php:1938
-    static function instance($name = 'default')
-                    ^^^^^^^^
+     |
+1938 |    static function instance($name = 'default')
+     |                    ^^^^^^^^
+
 ERROR   classMembersOrder: Property $breaksEnabled must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:66
-    protected $breaksEnabled;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+66 |    protected $breaksEnabled;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $markupEscaped must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:75
-    protected $markupEscaped;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+75 |    protected $markupEscaped;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $urlsLinked must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:84
-    protected $urlsLinked = true;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+84 |    protected $urlsLinked = true;
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $safeMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:93
-    protected $safeMode;
-    ^^^^^^^^^^^^^^^^^^^^
+   |
+93 |    protected $safeMode;
+   |    ^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $strictMode must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:102
-    protected $strictMode;
-    ^^^^^^^^^^^^^^^^^^^^^^
+    |
+102 |    protected $strictMode;
+    |    ^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $safeLinksWhitelist must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:104
-    protected $safeLinksWhitelist = array(
-    ^^
+    |
+104 |    protected $safeLinksWhitelist = array(
+    |    ^^
+
 ERROR   classMembersOrder: Property $BlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:126
-    protected $BlockTypes = array(
-    ^^
+    |
+126 |    protected $BlockTypes = array(
+    |    ^^
+
 ERROR   classMembersOrder: Property $unmarkedBlockTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:154
-    protected $unmarkedBlockTypes = array(
-    ^^
+    |
+154 |    protected $unmarkedBlockTypes = array(
+    |    ^^
+
 ERROR   classMembersOrder: Property $InlineTypes must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1109
-    protected $InlineTypes = array(
-    ^^
+     |
+1109 |    protected $InlineTypes = array(
+     |    ^^
+
 ERROR   classMembersOrder: Property $inlineMarkerList must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1124
-    protected $inlineMarkerList = '!*_&[:<`~\\';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1124 |    protected $inlineMarkerList = '!*_&[:<`~\\';
+     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $instances must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1952
-    private static $instances = array();
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1952 |    private static $instances = array();
+     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $DefinitionData must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1958
-    protected $DefinitionData;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1958 |    protected $DefinitionData;
+     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $specialCharacters must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1963
-    protected $specialCharacters = array(
-    ^^
+     |
+1963 |    protected $specialCharacters = array(
+     |    ^^
+
 ERROR   classMembersOrder: Property $StrongRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1967
-    protected $StrongRegex = array(
-    ^^
+     |
+1967 |    protected $StrongRegex = array(
+     |    ^^
+
 ERROR   classMembersOrder: Property $EmRegex must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1972
-    protected $EmRegex = array(
-    ^^
+     |
+1972 |    protected $EmRegex = array(
+     |    ^^
+
 ERROR   classMembersOrder: Property $regexHtmlAttribute must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1977
-    protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*+(?:\s*+=\s*+(?:[^"\'=<>`\s]+|"[^"]*+"|\'[^\']*+\'))?+';
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1977 |    protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*+(?:\s*+=\s*+(?:[^"\'=<>`\s]+|"[^"]*+"|\'[^\']*+\'))?+';
+     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $voidElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1979
-    protected $voidElements = array(
-    ^^
+     |
+1979 |    protected $voidElements = array(
+     |    ^^
+
 ERROR   classMembersOrder: Property $textLevelElements must go before methods in the class Parsedown at testdata/parsedown/parsedown.php:1983
-    protected $textLevelElements = array(
-    ^^
+     |
+1983 |    protected $textLevelElements = array(
+     |    ^^
+

--- a/src/tests/golden/testdata/phpdoc/golden.txt
+++ b/src/tests/golden/testdata/phpdoc/golden.txt
@@ -1,90 +1,150 @@
 WARNING invalidDocblock: @method requires return type and method name fields at testdata/phpdoc/phpdoc.php:4
- * @method
-   ^^^^^^^
+  |
+4 | * @method
+  |   ^^^^^^^
+
 WARNING invalidDocblock: @method requires return type and method name fields at testdata/phpdoc/phpdoc.php:5
- * @method int
-   ^^^^^^^^^^^
+  |
+5 | * @method int
+  |   ^^^^^^^^^^^
+
 WARNING invalidDocblock: @method missing parentheses after method name at testdata/phpdoc/phpdoc.php:6
- * @method int    method1
-                  ^^^^^^^
+  |
+6 | * @method int    method1
+  |                  ^^^^^^^
+
 WARNING invalidDocblock: @method missing parentheses after method name at testdata/phpdoc/phpdoc.php:7
- * @method ?string  method2
-                    ^^^^^^^
+  |
+7 | * @method ?string  method2
+  |                    ^^^^^^^
+
 WARNING invalidDocblock: @property requires type and property name fields at testdata/phpdoc/phpdoc.php:11
- * @property
-   ^^^^^^^^^
+   |
+11 | * @property
+   |   ^^^^^^^^^
+
 WARNING invalidDocblock: @property requires type and property name fields at testdata/phpdoc/phpdoc.php:12
- * @property   int
-   ^^^^^^^^^^^^^^^
+   |
+12 | * @property   int
+   |   ^^^^^^^^^^^^^^^
+
 WARNING invalidDocblock: Non-canonical order of name and type at testdata/phpdoc/phpdoc.php:14
- * @property       $b  int
-   ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+14 | * @property       $b  int
+   |   ^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING invalidDocblock: @property c field name must start with '$' at testdata/phpdoc/phpdoc.php:15
- * @property int c
-                 ^
+   |
+15 | * @property int c
+   |                 ^
+
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:18
-  /*
-^^^^
+   |
+18 |  /*
+   |^^^^
+
 MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:24
-   * @var ?int|null
-          ^^^^^^^^^
+   |
+24 |   * @var ?int|null
+   |          ^^^^^^^^^
+
 MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:25
-   * @var $b ?int|null
-             ^^^^^^^^^
+   |
+25 |   * @var $b ?int|null
+   |             ^^^^^^^^^
+
 MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:26
-   * @var ?int|null $b
-          ^^^^^^^^^
+   |
+26 |   * @var ?int|null $b
+   |          ^^^^^^^^^
+
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
-/*
-^^
+   |
+31 |/*
+   |^^
+
 WARNING invalidDocblockRef: @see tag refers to unknown symbol FooUnExisting at testdata/phpdoc/phpdoc.php:54
- * @see  FooUnExisting
-         ^^^^^^^^^^^^^
+   |
+54 | * @see  FooUnExisting
+   |         ^^^^^^^^^^^^^
+
 WARNING invalidDocblockRef: @see tag refers to unknown symbol FooUnExisting at testdata/phpdoc/phpdoc.php:55
- * @see       FooUnExisting
-              ^^^^^^^^^^^^^
+   |
+55 | * @see       FooUnExisting
+   |              ^^^^^^^^^^^^^
+
 MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:44
- * @param    ?int|null $d
-             ^^^^^^^^^
+   |
+44 | * @param    ?int|null $d
+   |             ^^^^^^^^^
+
 MAYBE   invalidDocblockType: Expected a type, found '-'; if you want to express 'any' type, use 'mixed' at testdata/phpdoc/phpdoc.php:46
- * @param - $e the y param
-          ^
+   |
+46 | * @param - $e the y param
+   |          ^
+
 MAYBE   invalidDocblockType: Expected a type, found '-'; if you want to express 'any' type, use 'mixed' at testdata/phpdoc/phpdoc.php:47
- * @param    $f - the z param
-             ^^
+   |
+47 | * @param    $f - the z param
+   |             ^^
+
 MAYBE   invalidDocblockType: Use int type instead of integer at testdata/phpdoc/phpdoc.php:49
- * @param integer   $g
-          ^^^^^^^
+   |
+49 | * @param integer   $g
+   |          ^^^^^^^
+
 MAYBE   invalidDocblockType: Array syntax is T[], not []T at testdata/phpdoc/phpdoc.php:50
- * @param  []int   $h
-           ^^^^^
+   |
+50 | * @param  []int   $h
+   |           ^^^^^
+
 MAYBE   invalidDocblockType: Nullable syntax is ?T, not T? at testdata/phpdoc/phpdoc.php:51
- * @param   int? $a1
-            ^^^^
+   |
+51 | * @param   int? $a1
+   |            ^^^^
+
 WARNING invalidDocblock: @param for non-existing argument $unexisting at testdata/phpdoc/phpdoc.php:40
- * @param    int    $unexisting
-                    ^^^^^^^^^^^
+   |
+40 | * @param    int    $unexisting
+   |                    ^^^^^^^^^^^
+
 WARNING invalidDocblock: Malformed @param tag (maybe var is missing?) at testdata/phpdoc/phpdoc.php:41
- * @param int
-          ^^^
+   |
+41 | * @param int
+   |          ^^^
+
 WARNING invalidDocblock: Non-canonical order of variable and type at testdata/phpdoc/phpdoc.php:42
- * @param $b       int
-   ^^^^^^^^^^^^^^^^^^^
+   |
+42 | * @param $b       int
+   |   ^^^^^^^^^^^^^^^^^^^
+
 WARNING invalidDocblock: Malformed @param $c tag (maybe type is missing?) at testdata/phpdoc/phpdoc.php:43
- * @param $c
-          ^^
+   |
+43 | * @param $c
+   |          ^^
+
 WARNING invalidDocblock: Non-canonical order of variable and type at testdata/phpdoc/phpdoc.php:47
- * @param    $f - the z param
-   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+47 | * @param    $f - the z param
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   invalidDocblockType: Invalid shape key: x[] at testdata/phpdoc/phpdoc.php:62
-  /** @var    shape(x[]:a) */
-              ^^^^^^^^^^^^
+   |
+62 |  /** @var    shape(x[]:a) */
+   |              ^^^^^^^^^^^^
+
 MAYBE   invalidDocblockType: Shape param #1: want key:type, found x at testdata/phpdoc/phpdoc.php:66
-  /** @var shape(x)    $a */
-           ^^^^^^^^
+   |
+66 |  /** @var shape(x)    $a */
+   |           ^^^^^^^^
+
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:70
-  /*
-^^^^
+   |
+70 |  /*
+   |^^^^
+
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
-/*
-^^
+   |
+31 |/*
+   |^^
+

--- a/src/tests/golden/testdata/phpdoc/golden.txt
+++ b/src/tests/golden/testdata/phpdoc/golden.txt
@@ -1,150 +1,150 @@
 WARNING invalidDocblock: @method requires return type and method name fields at testdata/phpdoc/phpdoc.php:4
   |
 4 | * @method
-  |   ^^^^^^^
+  |   ^^^^^^^ 
 
 WARNING invalidDocblock: @method requires return type and method name fields at testdata/phpdoc/phpdoc.php:5
   |
 5 | * @method int
-  |   ^^^^^^^^^^^
+  |   ^^^^^^^^^^^ 
 
 WARNING invalidDocblock: @method missing parentheses after method name at testdata/phpdoc/phpdoc.php:6
   |
 6 | * @method int    method1
-  |                  ^^^^^^^
+  |                  ^^^^^^^ 
 
 WARNING invalidDocblock: @method missing parentheses after method name at testdata/phpdoc/phpdoc.php:7
   |
 7 | * @method ?string  method2
-  |                    ^^^^^^^
+  |                    ^^^^^^^ 
 
 WARNING invalidDocblock: @property requires type and property name fields at testdata/phpdoc/phpdoc.php:11
    |
 11 | * @property
-   |   ^^^^^^^^^
+   |   ^^^^^^^^^ 
 
 WARNING invalidDocblock: @property requires type and property name fields at testdata/phpdoc/phpdoc.php:12
    |
 12 | * @property   int
-   |   ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^ 
 
 WARNING invalidDocblock: Non-canonical order of name and type at testdata/phpdoc/phpdoc.php:14
    |
 14 | * @property       $b  int
-   |   ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING invalidDocblock: @property c field name must start with '$' at testdata/phpdoc/phpdoc.php:15
    |
 15 | * @property int c
-   |                 ^
+   |                 ^ 
 
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:18
    |
 18 |  /*
-   |^^^^
+   |^^^^ 
 
 MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:24
    |
 24 |   * @var ?int|null
-   |          ^^^^^^^^^
+   |          ^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:25
    |
 25 |   * @var $b ?int|null
-   |             ^^^^^^^^^
+   |             ^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:26
    |
 26 |   * @var ?int|null $b
-   |          ^^^^^^^^^
+   |          ^^^^^^^^^ 
 
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
    |
 31 |/*
-   |^^
+   |^^ 
 
 WARNING invalidDocblockRef: @see tag refers to unknown symbol FooUnExisting at testdata/phpdoc/phpdoc.php:54
    |
 54 | * @see  FooUnExisting
-   |         ^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^ 
 
 WARNING invalidDocblockRef: @see tag refers to unknown symbol FooUnExisting at testdata/phpdoc/phpdoc.php:55
    |
 55 | * @see       FooUnExisting
-   |              ^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/phpdoc/phpdoc.php:44
    |
 44 | * @param    ?int|null $d
-   |             ^^^^^^^^^
+   |             ^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Expected a type, found '-'; if you want to express 'any' type, use 'mixed' at testdata/phpdoc/phpdoc.php:46
    |
 46 | * @param - $e the y param
-   |          ^
+   |          ^ 
 
 MAYBE   invalidDocblockType: Expected a type, found '-'; if you want to express 'any' type, use 'mixed' at testdata/phpdoc/phpdoc.php:47
    |
 47 | * @param    $f - the z param
-   |             ^^
+   |             ^^ 
 
 MAYBE   invalidDocblockType: Use int type instead of integer at testdata/phpdoc/phpdoc.php:49
    |
 49 | * @param integer   $g
-   |          ^^^^^^^
+   |          ^^^^^^^ 
 
 MAYBE   invalidDocblockType: Array syntax is T[], not []T at testdata/phpdoc/phpdoc.php:50
    |
 50 | * @param  []int   $h
-   |           ^^^^^
+   |           ^^^^^ 
 
 MAYBE   invalidDocblockType: Nullable syntax is ?T, not T? at testdata/phpdoc/phpdoc.php:51
    |
 51 | * @param   int? $a1
-   |            ^^^^
+   |            ^^^^ 
 
 WARNING invalidDocblock: @param for non-existing argument $unexisting at testdata/phpdoc/phpdoc.php:40
    |
 40 | * @param    int    $unexisting
-   |                    ^^^^^^^^^^^
+   |                    ^^^^^^^^^^^ 
 
 WARNING invalidDocblock: Malformed @param tag (maybe var is missing?) at testdata/phpdoc/phpdoc.php:41
    |
 41 | * @param int
-   |          ^^^
+   |          ^^^ 
 
 WARNING invalidDocblock: Non-canonical order of variable and type at testdata/phpdoc/phpdoc.php:42
    |
 42 | * @param $b       int
-   |   ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^ 
 
 WARNING invalidDocblock: Malformed @param $c tag (maybe type is missing?) at testdata/phpdoc/phpdoc.php:43
    |
 43 | * @param $c
-   |          ^^
+   |          ^^ 
 
 WARNING invalidDocblock: Non-canonical order of variable and type at testdata/phpdoc/phpdoc.php:47
    |
 47 | * @param    $f - the z param
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Invalid shape key: x[] at testdata/phpdoc/phpdoc.php:62
    |
 62 |  /** @var    shape(x[]:a) */
-   |              ^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Shape param #1: want key:type, found x at testdata/phpdoc/phpdoc.php:66
    |
 66 |  /** @var shape(x)    $a */
-   |           ^^^^^^^^
+   |           ^^^^^^^^ 
 
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:70
    |
 70 |  /*
-   |^^^^
+   |^^^^ 
 
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
    |
 31 |/*
-   |^^
+   |^^ 
 

--- a/src/tests/golden/testdata/phprocksyd/golden.txt
+++ b/src/tests/golden/testdata/phprocksyd/golden.txt
@@ -1,145 +1,145 @@
 WARNING useSleep: Don't use the 'sleep' function at testdata/phprocksyd/Phprocksyd.php:8
   |
 8 |        sleep(10);
-  |        ^^^^^^^^^
+  |        ^^^^^^^^^ 
 
 WARNING useSleep: Don't use the 'sleep' function at testdata/phprocksyd/Phprocksyd.php:18
    |
 18 |        sleep(100);
-   |        ^^^^^^^^^^
+   |        ^^^^^^^^^^ 
 
 MAYBE   deprecated: Call to deprecated function dl (since: 5.3) at testdata/phprocksyd/Phprocksyd.php:73
    |
 73 |            if (!extension_loaded($ext) && !dl($ext . '.so')) {
-   |                                            ^^
+   |                                            ^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:75
    |
 75 |                exit(1);
-   |                ^^^^^^^
+   |                ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:82
    |
 82 |            exit(1);
-   |            ^^^^^^^
+   |            ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:87
    |
 87 |            exit(0);
-   |            ^^^^^^^
+   |            ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:93
    |
 93 |            exit(1);
-   |            ^^^^^^^
+   |            ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:98
    |
 98 |            exit(1);
-   |            ^^^^^^^
+   |            ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:118
     |
 118 |            exit(1);
-    |            ^^^^^^^
+    |            ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:129
     |
 129 |                exit(1);
-    |                ^^^^^^^
+    |                ^^^^^^^ 
 
 ERROR   constCase: Constant 'NULL' should be used in lower case as 'null' at testdata/phprocksyd/Phprocksyd.php:321
     |
 321 |            $n = stream_select($read, $write, $except, NULL);
-    |                                                       ^^^^
+    |                                                       ^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:325
     |
 325 |                exit(1);
-    |                ^^^^^^^
+    |                ^^^^^^^ 
 
 WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:364
     |
 364 |     * @param $stream_id
-    |              ^^^^^^^^^^
+    |              ^^^^^^^^^^ 
 
 WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:365
     |
 365 |     * @param $req
-    |              ^^^^
+    |              ^^^^ 
 
 WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:389
     |
 389 |     * @param $stream_id
-    |              ^^^^^^^^^^
+    |              ^^^^^^^^^^ 
 
 WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:390
     |
 390 |     * @param $req
-    |              ^^^^
+    |              ^^^^ 
 
-WARNING unused: Variable $status is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/phprocksyd/Phprocksyd.php:394
+WARNING unused: Variable $status is unused at testdata/phprocksyd/Phprocksyd.php:394
     |
 394 |        $status = null;
-    |        ^^^^^^^
+    |        ^^^^^^^ use `$_` to ignore (see --unused-var-regex flag)
 
 WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:421
     |
 421 |     * @param $stream_id
-    |              ^^^^^^^^^^
+    |              ^^^^^^^^^^ 
 
 WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:422
     |
 422 |     * @param $req
-    |              ^^^^
+    |              ^^^^ 
 
 WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:443
     |
 443 |     * @param $stream_id
-    |              ^^^^^^^^^^
+    |              ^^^^^^^^^^ 
 
 WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:444
     |
 444 |     * @param $req
-    |              ^^^^
+    |              ^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:481
     |
 481 |                exit(0);
-    |                ^^^^^^^
+    |                ^^^^^^^ 
 
 ERROR   undefinedMethod: Call to undefined method {mixed}->run() at testdata/phprocksyd/Phprocksyd.php:479
     |
 479 |                $instance->run($req['params']);
-    |                           ^^^
+    |                           ^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:557
     |
 557 |                        exit(1);
-    |                        ^^^^^^^
+    |                        ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:590
     |
 590 |            exit(0);
-    |            ^^^^^^^
+    |            ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:619
     |
 619 |        exit(1);
-    |        ^^^^^^^
+    |        ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:685
     |
 685 |        exit(0);
-    |        ^^^^^^^
+    |        ^^^^^^^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Simple.php:38
    |
 38 |            exit(1);
-   |            ^^^^^^^
+   |            ^^^^^^^ 
 
 ERROR   constCase: Constant 'NULL' should be used in lower case as 'null' at testdata/phprocksyd/Simple.php:158
     |
 158 |            $n = stream_select($read, $write, $except, NULL);
-    |                                                       ^^^^
+    |                                                       ^^^^ 
 

--- a/src/tests/golden/testdata/phprocksyd/golden.txt
+++ b/src/tests/golden/testdata/phprocksyd/golden.txt
@@ -1,87 +1,145 @@
 WARNING useSleep: Don't use the 'sleep' function at testdata/phprocksyd/Phprocksyd.php:8
-        sleep(10);
-        ^^^^^^^^^
+  |
+8 |        sleep(10);
+  |        ^^^^^^^^^
+
 WARNING useSleep: Don't use the 'sleep' function at testdata/phprocksyd/Phprocksyd.php:18
-        sleep(100);
-        ^^^^^^^^^^
+   |
+18 |        sleep(100);
+   |        ^^^^^^^^^^
+
 MAYBE   deprecated: Call to deprecated function dl (since: 5.3) at testdata/phprocksyd/Phprocksyd.php:73
-            if (!extension_loaded($ext) && !dl($ext . '.so')) {
-                                            ^^
+   |
+73 |            if (!extension_loaded($ext) && !dl($ext . '.so')) {
+   |                                            ^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:75
-                exit(1);
-                ^^^^^^^
+   |
+75 |                exit(1);
+   |                ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:82
-            exit(1);
-            ^^^^^^^
+   |
+82 |            exit(1);
+   |            ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:87
-            exit(0);
-            ^^^^^^^
+   |
+87 |            exit(0);
+   |            ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:93
-            exit(1);
-            ^^^^^^^
+   |
+93 |            exit(1);
+   |            ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:98
-            exit(1);
-            ^^^^^^^
+   |
+98 |            exit(1);
+   |            ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:118
-            exit(1);
-            ^^^^^^^
+    |
+118 |            exit(1);
+    |            ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:129
-                exit(1);
-                ^^^^^^^
+    |
+129 |                exit(1);
+    |                ^^^^^^^
+
 ERROR   constCase: Constant 'NULL' should be used in lower case as 'null' at testdata/phprocksyd/Phprocksyd.php:321
-            $n = stream_select($read, $write, $except, NULL);
-                                                       ^^^^
+    |
+321 |            $n = stream_select($read, $write, $except, NULL);
+    |                                                       ^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:325
-                exit(1);
-                ^^^^^^^
+    |
+325 |                exit(1);
+    |                ^^^^^^^
+
 WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:364
-     * @param $stream_id
-              ^^^^^^^^^^
+    |
+364 |     * @param $stream_id
+    |              ^^^^^^^^^^
+
 WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:365
-     * @param $req
-              ^^^^
+    |
+365 |     * @param $req
+    |              ^^^^
+
 WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:389
-     * @param $stream_id
-              ^^^^^^^^^^
+    |
+389 |     * @param $stream_id
+    |              ^^^^^^^^^^
+
 WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:390
-     * @param $req
-              ^^^^
+    |
+390 |     * @param $req
+    |              ^^^^
+
 WARNING unused: Variable $status is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/phprocksyd/Phprocksyd.php:394
-        $status = null;
-        ^^^^^^^
+    |
+394 |        $status = null;
+    |        ^^^^^^^
+
 WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:421
-     * @param $stream_id
-              ^^^^^^^^^^
+    |
+421 |     * @param $stream_id
+    |              ^^^^^^^^^^
+
 WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:422
-     * @param $req
-              ^^^^
+    |
+422 |     * @param $req
+    |              ^^^^
+
 WARNING invalidDocblock: Malformed @param $stream_id tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:443
-     * @param $stream_id
-              ^^^^^^^^^^
+    |
+443 |     * @param $stream_id
+    |              ^^^^^^^^^^
+
 WARNING invalidDocblock: Malformed @param $req tag (maybe type is missing?) at testdata/phprocksyd/Phprocksyd.php:444
-     * @param $req
-              ^^^^
+    |
+444 |     * @param $req
+    |              ^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:481
-                exit(0);
-                ^^^^^^^
+    |
+481 |                exit(0);
+    |                ^^^^^^^
+
 ERROR   undefinedMethod: Call to undefined method {mixed}->run() at testdata/phprocksyd/Phprocksyd.php:479
-                $instance->run($req['params']);
-                           ^^^
+    |
+479 |                $instance->run($req['params']);
+    |                           ^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:557
-                        exit(1);
-                        ^^^^^^^
+    |
+557 |                        exit(1);
+    |                        ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:590
-            exit(0);
-            ^^^^^^^
+    |
+590 |            exit(0);
+    |            ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:619
-        exit(1);
-        ^^^^^^^
+    |
+619 |        exit(1);
+    |        ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Phprocksyd.php:685
-        exit(0);
-        ^^^^^^^
+    |
+685 |        exit(0);
+    |        ^^^^^^^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/phprocksyd/Simple.php:38
-            exit(1);
-            ^^^^^^^
+   |
+38 |            exit(1);
+   |            ^^^^^^^
+
 ERROR   constCase: Constant 'NULL' should be used in lower case as 'null' at testdata/phprocksyd/Simple.php:158
-            $n = stream_select($read, $write, $except, NULL);
-                                                       ^^^^
+    |
+158 |            $n = stream_select($read, $write, $except, NULL);
+    |                                                       ^^^^
+

--- a/src/tests/golden/testdata/qrcode/golden.txt
+++ b/src/tests/golden/testdata/qrcode/golden.txt
@@ -1,195 +1,195 @@
 MAYBE   missingPhpdoc: Missing PHPDoc for \QRCode::output_image public method at testdata/qrcode/qrcode.php:45
    |
 45 |  public function output_image() {
-   |                  ^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^ 
 
 MAYBE   missingPhpdoc: Missing PHPDoc for \QRCode::render_image public method at testdata/qrcode/qrcode.php:53
    |
 53 |  public function render_image() {
-   |                  ^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$this->options['bc'] ?? 'FFFFFF'` at testdata/qrcode/qrcode.php:59
    |
 59 |    $bgcolor = (isset($this->options['bc']) ? $this->options['bc'] : 'FFFFFF');
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$this->options['fc'] ?? '000000'` at testdata/qrcode/qrcode.php:63
    |
 63 |    $fgcolor = (isset($this->options['fc']) ? $this->options['fc'] : '000000');
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING deadCode: Unreachable code at testdata/qrcode/qrcode.php:155
     |
 155 |    return null;
-    |           ^^^^
+    |           ^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/qrcode/qrcode.php:185
     |
 185 |      'b' => $mtx
-    |      ^^^^^^^^^^^
+    |      ^^^^^^^^^^^ 
 
-WARNING unused: Variable $mode is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/qrcode/qrcode.php:177
+WARNING unused: Variable $mode is unused at testdata/qrcode/qrcode.php:177
     |
 177 |    list($mode, $vers, $ec, $data) = $this->qr_encode_data($data, $ecl);
-    |         ^^^^^
+    |         ^^^^^ use `$_` to ignore (see --unused-var-regex flag)
 
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:203
     |
 203 |    switch ($mode) {
-    |    ^
+    |    ^ 
 
 WARNING maybeUndefined: Possibly undefined variable $code at testdata/qrcode/qrcode.php:221
     |
 221 |    while (count($code) % 8) {
-    |                 ^^^^^
+    |                 ^^^^^ 
 
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:297
     |
 297 |      case 2:  /* 27 - 40 */
-    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:300
     |
 300 |      case 1:  /* 10 - 26 */
-    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:296
     |
 296 |    switch ($version_group) {
-    |    ^
+    |    ^ 
 
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:318
     |
 318 |        case 3:
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:322
     |
 322 |        case 2:
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:317
     |
 317 |      switch (strlen($group)) {
-    |      ^
+    |      ^ 
 
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:341
     |
 341 |      case 2:  /* 27 - 40 */
-    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:344
     |
 344 |      case 1:  /* 10 - 26 */
-    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:340
     |
 340 |    switch ($version_group) {
-    |    ^
+    |    ^ 
 
 MAYBE   callSimplify: Could simplify to $group[0] at testdata/qrcode/qrcode.php:361
     |
 361 |        $c1     = strpos($alphabet, substr($group, 0, 1));
-    |                                    ^^^^^^^^^^^^^^^^^^^^
+    |                                    ^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $group[1] at testdata/qrcode/qrcode.php:362
     |
 362 |        $c2     = strpos($alphabet, substr($group, 1, 1));
-    |                                    ^^^^^^^^^^^^^^^^^^^^
+    |                                    ^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:393
     |
 393 |      case 1:  /* 10 - 26 */
-    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:391
     |
 391 |    switch ($version_group) {
-    |    ^
+    |    ^ 
 
 MAYBE   callSimplify: Could simplify to $data[$i] at testdata/qrcode/qrcode.php:413
     |
 413 |      $ch     = ord(substr($data, $i, 1));
-    |                    ^^^^^^^^^^^^^^^^^^^^
+    |                    ^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:430
     |
 430 |      case 2:  /* 27 - 40 */
-    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:433
     |
 433 |      case 1:  /* 10 - 26 */
-    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:429
     |
 429 |    switch ($version_group) {
-    |    ^
+    |    ^ 
 
 MAYBE   callSimplify: Could simplify to $group[0] at testdata/qrcode/qrcode.php:448
     |
 448 |      $c1    = ord(substr($group, 0, 1));
-    |                   ^^^^^^^^^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $group[1] at testdata/qrcode/qrcode.php:449
     |
 449 |      $c2    = ord(substr($group, 1, 1));
-    |                   ^^^^^^^^^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^^^^^^^^^ 
 
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:697
     |
 697 |    switch ($mask) {
-    |    ^
+    |    ^ 
 
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/qrcode/qrcode.php:33
    |
 33 |  exit(0);
-   |  ^^^^^^^
+   |  ^^^^^^^ 
 
 ERROR   classMembersOrder: Property $qr_capacity must go before methods in the class QRCode at testdata/qrcode/qrcode.php:890
     |
 890 |  private $qr_capacity = [
-    |  ^^
+    |  ^^ 
 
 ERROR   classMembersOrder: Property $qr_ec_params must go before methods in the class QRCode at testdata/qrcode/qrcode.php:943
     |
 943 |  private $qr_ec_params = [
-    |  ^^
+    |  ^^ 
 
 ERROR   classMembersOrder: Property $qr_ec_polynomials must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1106
      |
 1106 |  private $qr_ec_polynomials = [
-     |  ^^
+     |  ^^ 
 
 ERROR   classMembersOrder: Property $qr_log must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1162
      |
 1162 |  private $qr_log = [
-     |  ^^
+     |  ^^ 
 
 ERROR   classMembersOrder: Property $qr_exp must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1197
      |
 1197 |  private $qr_exp = [
-     |  ^^
+     |  ^^ 
 
 ERROR   classMembersOrder: Property $qr_remainder_bits must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1232
      |
 1232 |  private $qr_remainder_bits = [
-     |  ^^
+     |  ^^ 
 
 ERROR   classMembersOrder: Property $qr_alignment_patterns must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1237
      |
 1237 |  private $qr_alignment_patterns = [
-     |  ^^
+     |  ^^ 
 
 ERROR   classMembersOrder: Property $qr_format_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1282
      |
 1282 |  private $qr_format_info = [
-     |  ^^
+     |  ^^ 
 
 ERROR   classMembersOrder: Property $qr_version_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1318
      |
 1318 |  private $qr_version_info = [
-     |  ^^
+     |  ^^ 
 

--- a/src/tests/golden/testdata/qrcode/golden.txt
+++ b/src/tests/golden/testdata/qrcode/golden.txt
@@ -1,117 +1,195 @@
 MAYBE   missingPhpdoc: Missing PHPDoc for \QRCode::output_image public method at testdata/qrcode/qrcode.php:45
-  public function output_image() {
-                  ^^^^^^^^^^^^
+   |
+45 |  public function output_image() {
+   |                  ^^^^^^^^^^^^
+
 MAYBE   missingPhpdoc: Missing PHPDoc for \QRCode::render_image public method at testdata/qrcode/qrcode.php:53
-  public function render_image() {
-                  ^^^^^^^^^^^^
+   |
+53 |  public function render_image() {
+   |                  ^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$this->options['bc'] ?? 'FFFFFF'` at testdata/qrcode/qrcode.php:59
-    $bgcolor = (isset($this->options['bc']) ? $this->options['bc'] : 'FFFFFF');
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+59 |    $bgcolor = (isset($this->options['bc']) ? $this->options['bc'] : 'FFFFFF');
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$this->options['fc'] ?? '000000'` at testdata/qrcode/qrcode.php:63
-    $fgcolor = (isset($this->options['fc']) ? $this->options['fc'] : '000000');
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+63 |    $fgcolor = (isset($this->options['fc']) ? $this->options['fc'] : '000000');
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING deadCode: Unreachable code at testdata/qrcode/qrcode.php:155
-    return null;
-           ^^^^
+    |
+155 |    return null;
+    |           ^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/qrcode/qrcode.php:185
-      'b' => $mtx
-      ^^^^^^^^^^^
+    |
+185 |      'b' => $mtx
+    |      ^^^^^^^^^^^
+
 WARNING unused: Variable $mode is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/qrcode/qrcode.php:177
-    list($mode, $vers, $ec, $data) = $this->qr_encode_data($data, $ecl);
-         ^^^^^
+    |
+177 |    list($mode, $vers, $ec, $data) = $this->qr_encode_data($data, $ecl);
+    |         ^^^^^
+
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:203
-    switch ($mode) {
-    ^
+    |
+203 |    switch ($mode) {
+    |    ^
+
 WARNING maybeUndefined: Possibly undefined variable $code at testdata/qrcode/qrcode.php:221
-    while (count($code) % 8) {
-                 ^^^^^
+    |
+221 |    while (count($code) % 8) {
+    |                 ^^^^^
+
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:297
-      case 2:  /* 27 - 40 */
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+297 |      case 2:  /* 27 - 40 */
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:300
-      case 1:  /* 10 - 26 */
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+300 |      case 1:  /* 10 - 26 */
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:296
-    switch ($version_group) {
-    ^
+    |
+296 |    switch ($version_group) {
+    |    ^
+
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:318
-        case 3:
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+318 |        case 3:
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:322
-        case 2:
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+322 |        case 2:
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:317
-      switch (strlen($group)) {
-      ^
+    |
+317 |      switch (strlen($group)) {
+    |      ^
+
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:341
-      case 2:  /* 27 - 40 */
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+341 |      case 2:  /* 27 - 40 */
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:344
-      case 1:  /* 10 - 26 */
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+344 |      case 1:  /* 10 - 26 */
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:340
-    switch ($version_group) {
-    ^
+    |
+340 |    switch ($version_group) {
+    |    ^
+
 MAYBE   callSimplify: Could simplify to $group[0] at testdata/qrcode/qrcode.php:361
-        $c1     = strpos($alphabet, substr($group, 0, 1));
-                                    ^^^^^^^^^^^^^^^^^^^^
+    |
+361 |        $c1     = strpos($alphabet, substr($group, 0, 1));
+    |                                    ^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $group[1] at testdata/qrcode/qrcode.php:362
-        $c2     = strpos($alphabet, substr($group, 1, 1));
-                                    ^^^^^^^^^^^^^^^^^^^^
+    |
+362 |        $c2     = strpos($alphabet, substr($group, 1, 1));
+    |                                    ^^^^^^^^^^^^^^^^^^^^
+
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:393
-      case 1:  /* 10 - 26 */
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+393 |      case 1:  /* 10 - 26 */
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:391
-    switch ($version_group) {
-    ^
+    |
+391 |    switch ($version_group) {
+    |    ^
+
 MAYBE   callSimplify: Could simplify to $data[$i] at testdata/qrcode/qrcode.php:413
-      $ch     = ord(substr($data, $i, 1));
-                    ^^^^^^^^^^^^^^^^^^^^
+    |
+413 |      $ch     = ord(substr($data, $i, 1));
+    |                    ^^^^^^^^^^^^^^^^^^^^
+
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:430
-      case 2:  /* 27 - 40 */
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+430 |      case 2:  /* 27 - 40 */
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING caseBreak: Add break or '// fallthrough' to the end of the case at testdata/qrcode/qrcode.php:433
-      case 1:  /* 10 - 26 */
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+433 |      case 1:  /* 10 - 26 */
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:429
-    switch ($version_group) {
-    ^
+    |
+429 |    switch ($version_group) {
+    |    ^
+
 MAYBE   callSimplify: Could simplify to $group[0] at testdata/qrcode/qrcode.php:448
-      $c1    = ord(substr($group, 0, 1));
-                   ^^^^^^^^^^^^^^^^^^^^
+    |
+448 |      $c1    = ord(substr($group, 0, 1));
+    |                   ^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $group[1] at testdata/qrcode/qrcode.php:449
-      $c2    = ord(substr($group, 1, 1));
-                   ^^^^^^^^^^^^^^^^^^^^
+    |
+449 |      $c2    = ord(substr($group, 1, 1));
+    |                   ^^^^^^^^^^^^^^^^^^^^
+
 WARNING switchDefault: Add 'default' branch to avoid unexpected unhandled condition values at testdata/qrcode/qrcode.php:697
-    switch ($mask) {
-    ^
+    |
+697 |    switch ($mask) {
+    |    ^
+
 WARNING useExitOrDie: Don't use the 'exit' function at testdata/qrcode/qrcode.php:33
-  exit(0);
-  ^^^^^^^
+   |
+33 |  exit(0);
+   |  ^^^^^^^
+
 ERROR   classMembersOrder: Property $qr_capacity must go before methods in the class QRCode at testdata/qrcode/qrcode.php:890
-  private $qr_capacity = [
-  ^^
+    |
+890 |  private $qr_capacity = [
+    |  ^^
+
 ERROR   classMembersOrder: Property $qr_ec_params must go before methods in the class QRCode at testdata/qrcode/qrcode.php:943
-  private $qr_ec_params = [
-  ^^
+    |
+943 |  private $qr_ec_params = [
+    |  ^^
+
 ERROR   classMembersOrder: Property $qr_ec_polynomials must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1106
-  private $qr_ec_polynomials = [
-  ^^
+     |
+1106 |  private $qr_ec_polynomials = [
+     |  ^^
+
 ERROR   classMembersOrder: Property $qr_log must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1162
-  private $qr_log = [
-  ^^
+     |
+1162 |  private $qr_log = [
+     |  ^^
+
 ERROR   classMembersOrder: Property $qr_exp must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1197
-  private $qr_exp = [
-  ^^
+     |
+1197 |  private $qr_exp = [
+     |  ^^
+
 ERROR   classMembersOrder: Property $qr_remainder_bits must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1232
-  private $qr_remainder_bits = [
-  ^^
+     |
+1232 |  private $qr_remainder_bits = [
+     |  ^^
+
 ERROR   classMembersOrder: Property $qr_alignment_patterns must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1237
-  private $qr_alignment_patterns = [
-  ^^
+     |
+1237 |  private $qr_alignment_patterns = [
+     |  ^^
+
 ERROR   classMembersOrder: Property $qr_format_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1282
-  private $qr_format_info = [
-  ^^
+     |
+1282 |  private $qr_format_info = [
+     |  ^^
+
 ERROR   classMembersOrder: Property $qr_version_info must go before methods in the class QRCode at testdata/qrcode/qrcode.php:1318
-  private $qr_version_info = [
-  ^^
+     |
+1318 |  private $qr_version_info = [
+     |  ^^
+

--- a/src/tests/golden/testdata/twitter-api-php/golden.txt
+++ b/src/tests/golden/testdata/twitter-api-php/golden.txt
@@ -1,33 +1,55 @@
 WARNING invalidDocblock: @package name must be a start part of class namespace at testdata/twitter-api-php/TwitterAPIExchange.php:9
- * @package  Twitter-API-PHP
-   ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+9 | * @package  Twitter-API-PHP
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   callSimplify: Could simplify to $array['status'][0] at testdata/twitter-api-php/TwitterAPIExchange.php:117
-        if (isset($array['status']) && substr($array['status'], 0, 1) === '@')
-                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+117 |        if (isset($array['status']) && substr($array['status'], 0, 1) === '@')
+    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARNING unused: Variable $key is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/twitter-api-php/TwitterAPIExchange.php:122
-        foreach ($array as $key => &$value)
-                           ^^^^
+    |
+122 |        foreach ($array as $key => &$value)
+    |                           ^^^^
+
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/twitter-api-php/TwitterAPIExchange.php:207
-        if (!in_array(strtolower($requestMethod), array('post', 'get', 'put', 'delete')))
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+207 |        if (!in_array(strtolower($requestMethod), array('post', 'get', 'put', 'delete')))
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/TwitterAPIExchange.php:223
-            'oauth_version' => '1.0'
-            ^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+223 |            'oauth_version' => '1.0'
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   invalidDocblockType: Use bool type instead of boolean at testdata/twitter-api-php/TwitterAPIExchange.php:267
-     * @param boolean $return      If true, returns data. This is left in for backward compatibility reasons
-              ^^^^^^^
+    |
+267 |     * @param boolean $return      If true, returns data. This is left in for backward compatibility reasons
+    |              ^^^^^^^
+
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/twitter-api-php/TwitterAPIExchange.php:286
-        if (in_array(strtolower($this->requestMethod), array('put', 'delete')))
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+286 |        if (in_array(strtolower($this->requestMethod), array('put', 'delete')))
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/TwitterAPIExchange.php:366
-                'oauth_signature_method', 'oauth_timestamp', 'oauth_token', 'oauth_version'))) {
-                                                                            ^^^^^^^^^^^^^^^
+    |
+366 |                'oauth_signature_method', 'oauth_timestamp', 'oauth_token', 'oauth_version'))) {
+    |                                                                            ^^^^^^^^^^^^^^^
+
 MAYBE   invalidDocblockType: Use int type instead of integer at testdata/twitter-api-php/TwitterAPIExchange.php:404
-     * @return integer
-               ^^^^^^^
+    |
+404 |     * @return integer
+    |               ^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/index.php:10
-    'consumer_secret' => ""
-    ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+10 |    'consumer_secret' => ""
+   |    ^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/index.php:20
-    'skip_status' => '1'
-    ^^^^^^^^^^^^^^^^^^^^
+   |
+20 |    'skip_status' => '1'
+   |    ^^^^^^^^^^^^^^^^^^^^
+

--- a/src/tests/golden/testdata/twitter-api-php/golden.txt
+++ b/src/tests/golden/testdata/twitter-api-php/golden.txt
@@ -1,55 +1,55 @@
 WARNING invalidDocblock: @package name must be a start part of class namespace at testdata/twitter-api-php/TwitterAPIExchange.php:9
   |
 9 | * @package  Twitter-API-PHP
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   callSimplify: Could simplify to $array['status'][0] at testdata/twitter-api-php/TwitterAPIExchange.php:117
     |
 117 |        if (isset($array['status']) && substr($array['status'], 0, 1) === '@')
-    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
-WARNING unused: Variable $key is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/twitter-api-php/TwitterAPIExchange.php:122
+WARNING unused: Variable $key is unused at testdata/twitter-api-php/TwitterAPIExchange.php:122
     |
 122 |        foreach ($array as $key => &$value)
-    |                           ^^^^
+    |                           ^^^^ use `$_` to ignore (see --unused-var-regex flag)
 
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/twitter-api-php/TwitterAPIExchange.php:207
     |
 207 |        if (!in_array(strtolower($requestMethod), array('post', 'get', 'put', 'delete')))
-    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/TwitterAPIExchange.php:223
     |
 223 |            'oauth_version' => '1.0'
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Use bool type instead of boolean at testdata/twitter-api-php/TwitterAPIExchange.php:267
     |
 267 |     * @param boolean $return      If true, returns data. This is left in for backward compatibility reasons
-    |              ^^^^^^^
+    |              ^^^^^^^ 
 
 WARNING strictCmp: 3rd argument of in_array must be true when comparing strings at testdata/twitter-api-php/TwitterAPIExchange.php:286
     |
 286 |        if (in_array(strtolower($this->requestMethod), array('put', 'delete')))
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/TwitterAPIExchange.php:366
     |
 366 |                'oauth_signature_method', 'oauth_timestamp', 'oauth_token', 'oauth_version'))) {
-    |                                                                            ^^^^^^^^^^^^^^^
+    |                                                                            ^^^^^^^^^^^^^^^ 
 
 MAYBE   invalidDocblockType: Use int type instead of integer at testdata/twitter-api-php/TwitterAPIExchange.php:404
     |
 404 |     * @return integer
-    |               ^^^^^^^
+    |               ^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/index.php:10
    |
 10 |    'consumer_secret' => ""
-   |    ^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/index.php:20
    |
 20 |    'skip_status' => '1'
-   |    ^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/underscore/golden.txt
+++ b/src/tests/golden/testdata/underscore/golden.txt
@@ -1,370 +1,370 @@
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:60
    |
 60 |    if(is_null($collection)) return self::_wrap(array());
-   |                                                ^^^^^^^
+   |                                                ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:63
    |
 63 |    if(count($collection) === 0) self::_wrap(array());
-   |                                             ^^^^^^^
+   |                                             ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:65
    |
 65 |    $return = array();
-   |              ^^^^^^^
+   |              ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:113
     |
 113 |    $return = array();
-    |              ^^^^^^^
+    |              ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:193
     |
 193 |    $return = array();
-    |              ^^^^^^^
+    |              ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:207
     |
 207 |    $return = array();
-    |              ^^^^^^^
+    |              ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:248
     |
 248 |    if($n === 0) return self::_wrap(array());
-    |                                    ^^^^^^^
+    |                                    ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:284
     |
 284 |    if($n === 0) $result = array();
-    |                           ^^^^^^^
+    |                           ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:314
     |
 314 |    $return = array();
-    |              ^^^^^^^
+    |              ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:360
     |
 360 |    $return = array();
-    |              ^^^^^^^
+    |              ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:363
     |
 363 |    $calculated = array();
-    |                  ^^^^^^^
+    |                  ^^^^^^^ 
 
-WARNING unused: Variable $is_sorted is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:356
+WARNING unused: Variable $is_sorted is unused at testdata/underscore/underscore.php:356
     |
 356 |    list($collection, $is_sorted, $iterator) = self::_wrapArgs(func_get_args(), 3);
-    |                      ^^^^^^^^^^
+    |                      ^^^^^^^^^^ use `$_` to ignore (see --unused-var-regex flag)
 
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:448
     |
 448 |        list($start, $stop, $step) = array(0, $args[0], 1);
-    |                                              ^^^^^
+    |                                              ^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:448
     |
 448 |        list($start, $stop, $step) = array(0, $args[0], 1);
-    |                                     ^^^^^^^^^^^^^^^^^^^^^
+    |                                     ^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:451
     |
 451 |        list($start, $stop, $step) = array($args[0], $args[1], 1);
-    |                                           ^^^^^
+    |                                           ^^^^^ 
 
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:451
     |
 451 |        list($start, $stop, $step) = array($args[0], $args[1], 1);
-    |                                                     ^^^^^
+    |                                                     ^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:451
     |
 451 |        list($start, $stop, $step) = array($args[0], $args[1], 1);
-    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:452
     |
 452 |        if($stop < $start) return self::_wrap(array());
-    |                                              ^^^^^^^
+    |                                              ^^^^^^^ 
 
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:455
     |
 455 |        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
-    |                                           ^^^^^
+    |                                           ^^^^^ 
 
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:455
     |
 455 |        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
-    |                                                     ^^^^^
+    |                                                     ^^^^^ 
 
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:455
     |
 455 |        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
-    |                                                               ^^^^^
+    |                                                               ^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:455
     |
 455 |        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
-    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:456
     |
 456 |        if($step > 0 && $step > $stop) return self::_wrap(array($start));
-    |                                                          ^^^^^^^^^^^^^
+    |                                                          ^^^^^^^^^^^^^ 
 
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:480
     |
 480 |      if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
-    |                   ^^^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:480
     |
 480 |      if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
-    |                                                             ^^^^^^^
+    |                                                             ^^^^^^^ 
 
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:480
     |
 480 |      if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
-    |                                        ^^^^^^^^^^^^^^
+    |                                        ^^^^^^^^^^^^^^ 
 
 MAYBE   ternarySimplify: Could rewrite as `$array[$k] ?? null` at testdata/underscore/underscore.php:483
     |
 483 |        $return_arrays[$k][$a] = array_key_exists($k, $array) ? $array[$k] : null;
-    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   arrayAccess: Array access to non-array type \__|empty_array[]|mixed at testdata/underscore/underscore.php:483
     |
 483 |        $return_arrays[$k][$a] = array_key_exists($k, $array) ? $array[$k] : null;
-    |        ^^^^^^^^^^^^^^
+    |        ^^^^^^^^^^^^^^ 
 
 ERROR   varShadow: Variable $array shadow existing variable $array from current function params at testdata/underscore/underscore.php:482
     |
 482 |      foreach($arrays as $a=>$array) {
-    |                             ^^^^^^
+    |                             ^^^^^^ 
 
-WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:479
+WARNING unused: Variable $v is unused at testdata/underscore/underscore.php:479
     |
 479 |    foreach($return_arrays as $k=>$v) {
-    |                                  ^^
+    |                                  ^^ use `$_` to ignore (see --unused-var-regex flag)
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:497
     |
 497 |    $results = array();
-    |               ^^^^^^^
+    |               ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:514
     |
 514 |    $results = array();
-    |               ^^^^^^^
+    |               ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:529
     |
 529 |    $results = array();
-    |               ^^^^^^^
+    |               ^^^^^^^ 
 
-WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:534
+WARNING unused: Variable $v is unused at testdata/underscore/underscore.php:534
     |
 534 |    foreach($results as $k=>$v) {
-    |                            ^^
+    |                            ^^ use `$_` to ignore (see --unused-var-regex flag)
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:545
     |
 545 |    $result = array();
-    |              ^^^^^^^
+    |              ^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:549
     |
 549 |      if(!array_key_exists($key, $result)) $result[$key] = array();
-    |                                                           ^^^^^^^
+    |                                                           ^^^^^^^ 
 
-WARNING unused: Variable $__ is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:561
+WARNING unused: Variable $__ is unused at testdata/underscore/underscore.php:561
     |
 561 |    $__ = new self;
-    |    ^^^
+    |    ^^^ use `$_` to ignore (see --unused-var-regex flag)
 
-WARNING unused: Variable $args is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:615
+WARNING unused: Variable $args is unused at testdata/underscore/underscore.php:615
     |
 615 |    $args = self::_wrapArgs(func_get_args(), 1);
-    |    ^^^^^
+    |    ^^^^^ use `$_` to ignore (see --unused-var-regex flag)
 
 ERROR   undefinedProperty: Property {\__|mixed|null}->isEqual does not exist at testdata/underscore/underscore.php:723
     |
 723 |      if(is_object($a) && isset($a->isEqual)) return self::_wrap($a->isEqual($b));
-    |                                    ^^^^^^^
+    |                                    ^^^^^^^ 
 
 ERROR   undefinedProperty: Property {mixed|null}->isEqual does not exist at testdata/underscore/underscore.php:724
     |
 724 |      if(is_object($b) && isset($b->isEqual)) return self::_wrap($b->isEqual($a));
-    |                                    ^^^^^^^
+    |                                    ^^^^^^^ 
 
 ERROR   undefinedMethod: Call to undefined method {mixed|null}->isEqual() at testdata/underscore/underscore.php:724
     |
 724 |      if(is_object($b) && isset($b->isEqual)) return self::_wrap($b->isEqual($a));
-    |                                                                     ^^^^^^^
+    |                                                                     ^^^^^^^ 
 
 MAYBE   arrayAccess: Array access to non-array type \__|mixed|null at testdata/underscore/underscore.php:725
     |
 725 |      if(is_array($a) && array_key_exists('isEqual', $a)) return self::_wrap($a['isEqual']($b));
-    |                                                                             ^^
+    |                                                                             ^^ 
 
 ERROR   undefinedProperty: Property {mixed}->_uniqueId does not exist at testdata/underscore/underscore.php:822
     |
 822 |    $_instance->_uniqueId++;
-    |                ^^^^^^^^^
+    |                ^^^^^^^^^ 
 
 ERROR   undefinedProperty: Property {mixed}->_uniqueId does not exist at testdata/underscore/underscore.php:824
     |
 824 |    return (is_null($prefix)) ? self::_wrap($_instance->_uniqueId) : self::_wrap($prefix . $_instance->_uniqueId);
-    |                                                        ^^^^^^^^^
+    |                                                        ^^^^^^^^^ 
 
 ERROR   undefinedProperty: Property {mixed}->_uniqueId does not exist at testdata/underscore/underscore.php:824
     |
 824 |    return (is_null($prefix)) ? self::_wrap($_instance->_uniqueId) : self::_wrap($prefix . $_instance->_uniqueId);
-    |                                                                                                       ^^^^^^^^^
+    |                                                                                                       ^^^^^^^^^ 
 
 ERROR   undefinedProperty: Property {mixed}->_mixins does not exist at testdata/underscore/underscore.php:843
     |
 843 |    $mixins =& self::getInstance()->_mixins;
-    |                                    ^^^^^^^
+    |                                    ^^^^^^^ 
 
 ERROR   undefinedProperty: Property {mixed}->_mixins does not exist at testdata/underscore/underscore.php:853
     |
 853 |    $mixins =& self::getInstance()->_mixins;
-    |                                    ^^^^^^^
+    |                                    ^^^^^^^ 
 
 ERROR   undefinedProperty: Property {mixed}->_mixins does not exist at testdata/underscore/underscore.php:859
     |
 859 |    $mixins =& self::getInstance()->_mixins;
-    |                                    ^^^^^^^
+    |                                    ^^^^^^^ 
 
 ERROR   undefinedProperty: Property {mixed}->_template_settings does not exist at testdata/underscore/underscore.php:882
     |
 882 |    $_template_settings =& self::getInstance()->_template_settings;
-    |                                                ^^^^^^^^^^^^^^^^^^
+    |                                                ^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:885
     |
 885 |      $_template_settings = array(
-    |                            
+    |                             
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/underscore/underscore.php:888
     |
 888 |        'escape'      => self::TEMPLATE_DEFAULT_ESCAPE
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   undefinedProperty: Property {mixed}->_template_settings does not exist at testdata/underscore/underscore.php:909
     |
 909 |      $ts = $class_name::getInstance()->_template_settings;
-    |                                        ^^^^^^^^^^^^^^^^^^
+    |                                        ^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   deprecated: Call to deprecated function create_function (since: 7.2, reason: Use anonymous functions instead, removed: 8.0) at testdata/underscore/underscore.php:940
     |
 940 |      $func = create_function('$context', $code);
-    |              ^^^^^^^^^^^^^^^
+    |              ^^^^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:970
     |
 970 |        return md5(join('_', array(
-    |                             
+    |                              
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/underscore/underscore.php:972
     |
 972 |          var_export($args, true)
-    |          ^^^^^^^^^^^^^^^^^^^^^^^
+    |          ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:995
     |
 995 |      $key = md5(join('', array(
-    |                          
+    |                           
 
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/underscore/underscore.php:997
     |
 997 |        $wait
-    |        ^^^^^
+    |        ^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:1036
      |
 1036 |      $args = array_merge(array($function), func_get_args());
-     |                          ^^^^^^^^^^^^^^^^
+     |                          ^^^^^^^^^^^^^^^^ 
 
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:1102
      |
 1102 |    $filled_args = array();
-     |                   ^^^^^^^
+     |                   ^^^^^^^ 
 
-WARNING unused: Foreach key $k is unused, can simplify $k => $v to just $v at testdata/underscore/underscore.php:1107
+WARNING unused: Foreach key $k is unused at testdata/underscore/underscore.php:1107
      |
 1107 |      foreach($caller_args as $k=>$v) {
-     |                              ^^
+     |                              ^^ can simplify $k => $v to just $v
 
 ERROR   classMembersOrder: Property $_uniqueId must go before methods in the class __ at testdata/underscore/underscore.php:817
     |
 817 |  public $_uniqueId = -1;
-    |  ^^^^^^^^^^^^^^^^^^^^^^^
+    |  ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $_mixins must go before methods in the class __ at testdata/underscore/underscore.php:839
     |
 839 |  private $_mixins = array();
-    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant TEMPLATE_OPEN_TAG must go before methods in the class __ at testdata/underscore/underscore.php:868
     |
 868 |  const TEMPLATE_OPEN_TAG = '760e7dab2836853c63805033e514668301fa9c47';
-    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant TEMPLATE_CLOSE_TAG must go before methods in the class __ at testdata/underscore/underscore.php:869
     |
 869 |  const TEMPLATE_CLOSE_TAG= 'd228a8fa36bd7db108b01eddfb03a30899987a2b';
-    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant TEMPLATE_DEFAULT_EVALUATE must go before methods in the class __ at testdata/underscore/underscore.php:871
     |
 871 |  const TEMPLATE_DEFAULT_EVALUATE   = '/<%([\s\S]+?)%>/';
-    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant TEMPLATE_DEFAULT_INTERPOLATE must go before methods in the class __ at testdata/underscore/underscore.php:872
     |
 872 |  const TEMPLATE_DEFAULT_INTERPOLATE= '/<%=([\s\S]+?)%>/';
-    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Constant TEMPLATE_DEFAULT_ESCAPE must go before methods in the class __ at testdata/underscore/underscore.php:873
     |
 873 |  const TEMPLATE_DEFAULT_ESCAPE     = '/<%-([\s\S]+?)%>/';
-    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $_template_settings must go before methods in the class __ at testdata/underscore/underscore.php:874
     |
 874 |  public $_template_settings = array(
-    |  ^^
+    |  ^^ 
 
 ERROR   classMembersOrder: Property $_memoized must go before methods in the class __ at testdata/underscore/underscore.php:957
     |
 957 |  public $_memoized = array();
-    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $_throttled must go before methods in the class __ at testdata/underscore/underscore.php:986
     |
 986 |  public $_throttled = array();
-    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $_onced must go before methods in the class __ at testdata/underscore/underscore.php:1012
      |
 1012 |  public $_onced = array();
-     |  ^^^^^^^^^^^^^^^^^^^^^^^^^
+     |  ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $_aftered must go before methods in the class __ at testdata/underscore/underscore.php:1057
      |
 1057 |  public $_aftered = array();
-     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $_instance must go before methods in the class __ at testdata/underscore/underscore.php:1075
      |
 1075 |  private static $_instance;
-     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 ERROR   classMembersOrder: Property $_wrapped must go before methods in the class __ at testdata/underscore/underscore.php:1087
      |
 1087 |  public $_wrapped; // Value passed from one chained method to the next
-     |  ^^^^^^^^^^^^^^^^^
+     |  ^^^^^^^^^^^^^^^^^ 
 

--- a/src/tests/golden/testdata/underscore/golden.txt
+++ b/src/tests/golden/testdata/underscore/golden.txt
@@ -1,222 +1,370 @@
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:60
-    if(is_null($collection)) return self::_wrap(array());
-                                                ^^^^^^^
+   |
+60 |    if(is_null($collection)) return self::_wrap(array());
+   |                                                ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:63
-    if(count($collection) === 0) self::_wrap(array());
-                                             ^^^^^^^
+   |
+63 |    if(count($collection) === 0) self::_wrap(array());
+   |                                             ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:65
-    $return = array();
-              ^^^^^^^
+   |
+65 |    $return = array();
+   |              ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:113
-    $return = array();
-              ^^^^^^^
+    |
+113 |    $return = array();
+    |              ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:193
-    $return = array();
-              ^^^^^^^
+    |
+193 |    $return = array();
+    |              ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:207
-    $return = array();
-              ^^^^^^^
+    |
+207 |    $return = array();
+    |              ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:248
-    if($n === 0) return self::_wrap(array());
-                                    ^^^^^^^
+    |
+248 |    if($n === 0) return self::_wrap(array());
+    |                                    ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:284
-    if($n === 0) $result = array();
-                           ^^^^^^^
+    |
+284 |    if($n === 0) $result = array();
+    |                           ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:314
-    $return = array();
-              ^^^^^^^
+    |
+314 |    $return = array();
+    |              ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:360
-    $return = array();
-              ^^^^^^^
+    |
+360 |    $return = array();
+    |              ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:363
-    $calculated = array();
-                  ^^^^^^^
+    |
+363 |    $calculated = array();
+    |                  ^^^^^^^
+
 WARNING unused: Variable $is_sorted is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:356
-    list($collection, $is_sorted, $iterator) = self::_wrapArgs(func_get_args(), 3);
-                      ^^^^^^^^^^
+    |
+356 |    list($collection, $is_sorted, $iterator) = self::_wrapArgs(func_get_args(), 3);
+    |                      ^^^^^^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:448
-        list($start, $stop, $step) = array(0, $args[0], 1);
-                                              ^^^^^
+    |
+448 |        list($start, $stop, $step) = array(0, $args[0], 1);
+    |                                              ^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:448
-        list($start, $stop, $step) = array(0, $args[0], 1);
-                                     ^^^^^^^^^^^^^^^^^^^^^
+    |
+448 |        list($start, $stop, $step) = array(0, $args[0], 1);
+    |                                     ^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:451
-        list($start, $stop, $step) = array($args[0], $args[1], 1);
-                                           ^^^^^
+    |
+451 |        list($start, $stop, $step) = array($args[0], $args[1], 1);
+    |                                           ^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:451
-        list($start, $stop, $step) = array($args[0], $args[1], 1);
-                                                     ^^^^^
+    |
+451 |        list($start, $stop, $step) = array($args[0], $args[1], 1);
+    |                                                     ^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:451
-        list($start, $stop, $step) = array($args[0], $args[1], 1);
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+451 |        list($start, $stop, $step) = array($args[0], $args[1], 1);
+    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:452
-        if($stop < $start) return self::_wrap(array());
-                                              ^^^^^^^
+    |
+452 |        if($stop < $start) return self::_wrap(array());
+    |                                              ^^^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:455
-        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
-                                           ^^^^^
+    |
+455 |        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
+    |                                           ^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:455
-        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
-                                                     ^^^^^
+    |
+455 |        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
+    |                                                     ^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:455
-        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
-                                                               ^^^^^
+    |
+455 |        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
+    |                                                               ^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:455
-        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+455 |        list($start, $stop, $step) = array($args[0], $args[1], $args[2]);
+    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:456
-        if($step > 0 && $step > $stop) return self::_wrap(array($start));
-                                                          ^^^^^^^^^^^^^
+    |
+456 |        if($step > 0 && $step > $stop) return self::_wrap(array($start));
+    |                                                          ^^^^^^^^^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:480
-      if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
-                   ^^^^^^^^^^^^^^
+    |
+480 |      if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
+    |                   ^^^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:480
-      if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
-                                                             ^^^^^^^
+    |
+480 |      if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
+    |                                                             ^^^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|mixed at testdata/underscore/underscore.php:480
-      if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
-                                        ^^^^^^^^^^^^^^
+    |
+480 |      if(!is_array($return_arrays[$k])) $return_arrays[$k] = array();
+    |                                        ^^^^^^^^^^^^^^
+
 MAYBE   ternarySimplify: Could rewrite as `$array[$k] ?? null` at testdata/underscore/underscore.php:483
-        $return_arrays[$k][$a] = array_key_exists($k, $array) ? $array[$k] : null;
-                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+483 |        $return_arrays[$k][$a] = array_key_exists($k, $array) ? $array[$k] : null;
+    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|empty_array[]|mixed at testdata/underscore/underscore.php:483
-        $return_arrays[$k][$a] = array_key_exists($k, $array) ? $array[$k] : null;
-        ^^^^^^^^^^^^^^
+    |
+483 |        $return_arrays[$k][$a] = array_key_exists($k, $array) ? $array[$k] : null;
+    |        ^^^^^^^^^^^^^^
+
 ERROR   varShadow: Variable $array shadow existing variable $array from current function params at testdata/underscore/underscore.php:482
-      foreach($arrays as $a=>$array) {
-                             ^^^^^^
+    |
+482 |      foreach($arrays as $a=>$array) {
+    |                             ^^^^^^
+
 WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:479
-    foreach($return_arrays as $k=>$v) {
-                                  ^^
+    |
+479 |    foreach($return_arrays as $k=>$v) {
+    |                                  ^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:497
-    $results = array();
-               ^^^^^^^
+    |
+497 |    $results = array();
+    |               ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:514
-    $results = array();
-               ^^^^^^^
+    |
+514 |    $results = array();
+    |               ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:529
-    $results = array();
-               ^^^^^^^
+    |
+529 |    $results = array();
+    |               ^^^^^^^
+
 WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:534
-    foreach($results as $k=>$v) {
-                            ^^
+    |
+534 |    foreach($results as $k=>$v) {
+    |                            ^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:545
-    $result = array();
-              ^^^^^^^
+    |
+545 |    $result = array();
+    |              ^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:549
-      if(!array_key_exists($key, $result)) $result[$key] = array();
-                                                           ^^^^^^^
+    |
+549 |      if(!array_key_exists($key, $result)) $result[$key] = array();
+    |                                                           ^^^^^^^
+
 WARNING unused: Variable $__ is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:561
-    $__ = new self;
-    ^^^
+    |
+561 |    $__ = new self;
+    |    ^^^
+
 WARNING unused: Variable $args is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/underscore/underscore.php:615
-    $args = self::_wrapArgs(func_get_args(), 1);
-    ^^^^^
+    |
+615 |    $args = self::_wrapArgs(func_get_args(), 1);
+    |    ^^^^^
+
 ERROR   undefinedProperty: Property {\__|mixed|null}->isEqual does not exist at testdata/underscore/underscore.php:723
-      if(is_object($a) && isset($a->isEqual)) return self::_wrap($a->isEqual($b));
-                                    ^^^^^^^
+    |
+723 |      if(is_object($a) && isset($a->isEqual)) return self::_wrap($a->isEqual($b));
+    |                                    ^^^^^^^
+
 ERROR   undefinedProperty: Property {mixed|null}->isEqual does not exist at testdata/underscore/underscore.php:724
-      if(is_object($b) && isset($b->isEqual)) return self::_wrap($b->isEqual($a));
-                                    ^^^^^^^
+    |
+724 |      if(is_object($b) && isset($b->isEqual)) return self::_wrap($b->isEqual($a));
+    |                                    ^^^^^^^
+
 ERROR   undefinedMethod: Call to undefined method {mixed|null}->isEqual() at testdata/underscore/underscore.php:724
-      if(is_object($b) && isset($b->isEqual)) return self::_wrap($b->isEqual($a));
-                                                                     ^^^^^^^
+    |
+724 |      if(is_object($b) && isset($b->isEqual)) return self::_wrap($b->isEqual($a));
+    |                                                                     ^^^^^^^
+
 MAYBE   arrayAccess: Array access to non-array type \__|mixed|null at testdata/underscore/underscore.php:725
-      if(is_array($a) && array_key_exists('isEqual', $a)) return self::_wrap($a['isEqual']($b));
-                                                                             ^^
+    |
+725 |      if(is_array($a) && array_key_exists('isEqual', $a)) return self::_wrap($a['isEqual']($b));
+    |                                                                             ^^
+
 ERROR   undefinedProperty: Property {mixed}->_uniqueId does not exist at testdata/underscore/underscore.php:822
-    $_instance->_uniqueId++;
-                ^^^^^^^^^
+    |
+822 |    $_instance->_uniqueId++;
+    |                ^^^^^^^^^
+
 ERROR   undefinedProperty: Property {mixed}->_uniqueId does not exist at testdata/underscore/underscore.php:824
-    return (is_null($prefix)) ? self::_wrap($_instance->_uniqueId) : self::_wrap($prefix . $_instance->_uniqueId);
-                                                        ^^^^^^^^^
+    |
+824 |    return (is_null($prefix)) ? self::_wrap($_instance->_uniqueId) : self::_wrap($prefix . $_instance->_uniqueId);
+    |                                                        ^^^^^^^^^
+
 ERROR   undefinedProperty: Property {mixed}->_uniqueId does not exist at testdata/underscore/underscore.php:824
-    return (is_null($prefix)) ? self::_wrap($_instance->_uniqueId) : self::_wrap($prefix . $_instance->_uniqueId);
-                                                                                                       ^^^^^^^^^
+    |
+824 |    return (is_null($prefix)) ? self::_wrap($_instance->_uniqueId) : self::_wrap($prefix . $_instance->_uniqueId);
+    |                                                                                                       ^^^^^^^^^
+
 ERROR   undefinedProperty: Property {mixed}->_mixins does not exist at testdata/underscore/underscore.php:843
-    $mixins =& self::getInstance()->_mixins;
-                                    ^^^^^^^
+    |
+843 |    $mixins =& self::getInstance()->_mixins;
+    |                                    ^^^^^^^
+
 ERROR   undefinedProperty: Property {mixed}->_mixins does not exist at testdata/underscore/underscore.php:853
-    $mixins =& self::getInstance()->_mixins;
-                                    ^^^^^^^
+    |
+853 |    $mixins =& self::getInstance()->_mixins;
+    |                                    ^^^^^^^
+
 ERROR   undefinedProperty: Property {mixed}->_mixins does not exist at testdata/underscore/underscore.php:859
-    $mixins =& self::getInstance()->_mixins;
-                                    ^^^^^^^
+    |
+859 |    $mixins =& self::getInstance()->_mixins;
+    |                                    ^^^^^^^
+
 ERROR   undefinedProperty: Property {mixed}->_template_settings does not exist at testdata/underscore/underscore.php:882
-    $_template_settings =& self::getInstance()->_template_settings;
-                                                ^^^^^^^^^^^^^^^^^^
+    |
+882 |    $_template_settings =& self::getInstance()->_template_settings;
+    |                                                ^^^^^^^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:885
-      $_template_settings = array(
-                            
+    |
+885 |      $_template_settings = array(
+    |                            
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/underscore/underscore.php:888
-        'escape'      => self::TEMPLATE_DEFAULT_ESCAPE
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+888 |        'escape'      => self::TEMPLATE_DEFAULT_ESCAPE
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   undefinedProperty: Property {mixed}->_template_settings does not exist at testdata/underscore/underscore.php:909
-      $ts = $class_name::getInstance()->_template_settings;
-                                        ^^^^^^^^^^^^^^^^^^
+    |
+909 |      $ts = $class_name::getInstance()->_template_settings;
+    |                                        ^^^^^^^^^^^^^^^^^^
+
 MAYBE   deprecated: Call to deprecated function create_function (since: 7.2, reason: Use anonymous functions instead, removed: 8.0) at testdata/underscore/underscore.php:940
-      $func = create_function('$context', $code);
-              ^^^^^^^^^^^^^^^
+    |
+940 |      $func = create_function('$context', $code);
+    |              ^^^^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:970
-        return md5(join('_', array(
-                             
+    |
+970 |        return md5(join('_', array(
+    |                             
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/underscore/underscore.php:972
-          var_export($args, true)
-          ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+972 |          var_export($args, true)
+    |          ^^^^^^^^^^^^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:995
-      $key = md5(join('', array(
-                          
+    |
+995 |      $key = md5(join('', array(
+    |                          
+
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/underscore/underscore.php:997
-        $wait
-        ^^^^^
+    |
+997 |        $wait
+    |        ^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:1036
-      $args = array_merge(array($function), func_get_args());
-                          ^^^^^^^^^^^^^^^^
+     |
+1036 |      $args = array_merge(array($function), func_get_args());
+     |                          ^^^^^^^^^^^^^^^^
+
 MAYBE   arraySyntax: Use the short form '[]' instead of the old 'array()' at testdata/underscore/underscore.php:1102
-    $filled_args = array();
-                   ^^^^^^^
+     |
+1102 |    $filled_args = array();
+     |                   ^^^^^^^
+
 WARNING unused: Foreach key $k is unused, can simplify $k => $v to just $v at testdata/underscore/underscore.php:1107
-      foreach($caller_args as $k=>$v) {
-                              ^^
+     |
+1107 |      foreach($caller_args as $k=>$v) {
+     |                              ^^
+
 ERROR   classMembersOrder: Property $_uniqueId must go before methods in the class __ at testdata/underscore/underscore.php:817
-  public $_uniqueId = -1;
-  ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+817 |  public $_uniqueId = -1;
+    |  ^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $_mixins must go before methods in the class __ at testdata/underscore/underscore.php:839
-  private $_mixins = array();
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+839 |  private $_mixins = array();
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant TEMPLATE_OPEN_TAG must go before methods in the class __ at testdata/underscore/underscore.php:868
-  const TEMPLATE_OPEN_TAG = '760e7dab2836853c63805033e514668301fa9c47';
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+868 |  const TEMPLATE_OPEN_TAG = '760e7dab2836853c63805033e514668301fa9c47';
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant TEMPLATE_CLOSE_TAG must go before methods in the class __ at testdata/underscore/underscore.php:869
-  const TEMPLATE_CLOSE_TAG= 'd228a8fa36bd7db108b01eddfb03a30899987a2b';
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+869 |  const TEMPLATE_CLOSE_TAG= 'd228a8fa36bd7db108b01eddfb03a30899987a2b';
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant TEMPLATE_DEFAULT_EVALUATE must go before methods in the class __ at testdata/underscore/underscore.php:871
-  const TEMPLATE_DEFAULT_EVALUATE   = '/<%([\s\S]+?)%>/';
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+871 |  const TEMPLATE_DEFAULT_EVALUATE   = '/<%([\s\S]+?)%>/';
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant TEMPLATE_DEFAULT_INTERPOLATE must go before methods in the class __ at testdata/underscore/underscore.php:872
-  const TEMPLATE_DEFAULT_INTERPOLATE= '/<%=([\s\S]+?)%>/';
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+872 |  const TEMPLATE_DEFAULT_INTERPOLATE= '/<%=([\s\S]+?)%>/';
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Constant TEMPLATE_DEFAULT_ESCAPE must go before methods in the class __ at testdata/underscore/underscore.php:873
-  const TEMPLATE_DEFAULT_ESCAPE     = '/<%-([\s\S]+?)%>/';
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+873 |  const TEMPLATE_DEFAULT_ESCAPE     = '/<%-([\s\S]+?)%>/';
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $_template_settings must go before methods in the class __ at testdata/underscore/underscore.php:874
-  public $_template_settings = array(
-  ^^
+    |
+874 |  public $_template_settings = array(
+    |  ^^
+
 ERROR   classMembersOrder: Property $_memoized must go before methods in the class __ at testdata/underscore/underscore.php:957
-  public $_memoized = array();
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+957 |  public $_memoized = array();
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $_throttled must go before methods in the class __ at testdata/underscore/underscore.php:986
-  public $_throttled = array();
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+986 |  public $_throttled = array();
+    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $_onced must go before methods in the class __ at testdata/underscore/underscore.php:1012
-  public $_onced = array();
-  ^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1012 |  public $_onced = array();
+     |  ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $_aftered must go before methods in the class __ at testdata/underscore/underscore.php:1057
-  public $_aftered = array();
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1057 |  public $_aftered = array();
+     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $_instance must go before methods in the class __ at testdata/underscore/underscore.php:1075
-  private static $_instance;
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+1075 |  private static $_instance;
+     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ERROR   classMembersOrder: Property $_wrapped must go before methods in the class __ at testdata/underscore/underscore.php:1087
-  public $_wrapped; // Value passed from one chained method to the next
-  ^^^^^^^^^^^^^^^^^
+     |
+1087 |  public $_wrapped; // Value passed from one chained method to the next
+     |  ^^^^^^^^^^^^^^^^^
+


### PR DESCRIPTION
### Before

```
MAYBE   implicitModifiers: Specify the access modifier for \B::f method explicitly at /Users/petrmakhnev/noverify/script.php:106
    function f(): parent {
             ^
<critical> WARNING unused: Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at /Users/petrmakhnev/noverify/script.php:107
        $a = 100;
        ^^
```

### After

```
MAYBE   implicitModifiers: Specify the access modifier for \B::f method explicitly at /Users/petrmakhnev/noverify/script.php:106
    |
106 |    function f(): parent {
    |             ^

<critical> WARNING unused: Variable $a is unused at /Users/petrmakhnev/noverify/script.php:107
    |
107 |        $a = 100;
    |        ^^ use `$_` to ignore (see --unused-var-regex flag)
```