### PR TITLE
phpgrep: fix functions alias matching

### DIFF
--- a/src/ir/phpcore/phpcore.go
+++ b/src/ir/phpcore/phpcore.go
@@ -16,6 +16,14 @@ func ResolveAlias(function ir.Node) ir.Node {
 	return function
 }
 
+func ResolveAliasName(n *ir.Name) *ir.Name {
+	alias, ok := funcAliases[n.Value]
+	if ok {
+		return alias
+	}
+	return n
+}
+
 var funcAliases = map[string]*ir.Name{
 	// See https://www.php.net/manual/ru/aliases.php
 

--- a/src/phpgrep/phpgrep.go
+++ b/src/phpgrep/phpgrep.go
@@ -53,6 +53,8 @@ func (m *Matcher) Clone() *Matcher {
 // Returned match data should only be examined if the
 // second return value is true.
 func (m *Matcher) Match(n ir.Node) (MatchData, bool) {
+	// TODO: allow the used to pass already existing matcherState
+	// to increase the efficiency?
 	var state matcherState
 	return m.m.match(&state, n)
 }


### PR DESCRIPTION
When matching things like `sizeof(...)` phpgrep would interpret it as `count(...)`, since sizeof is just an alias.

It breaks when we actually need to get the `sizeof` identifier position as `phpcore.ResolveAlias` returns a node without pos info.

This causes a runtime panic in phpgrep when such node is being rendered.

The current fix is to create a new node that has the resolved name value and original source location info.