### PR TITLE
Update "go get" install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -79,7 +79,7 @@ Make sure you have [Go](https://golang.org/dl/) version 1.16 or higher installed
 Run the following command:
 
 ```shell
-$ go get github.com/VKCOM/noverify
+$ GO111MODULE=off go get github.com/VKCOM/noverify
 ```
 
 NoVerify will be installed to `$GOPATH/bin/noverify`, which usually expands to `$HOME/go/bin/noverify`.


### PR DESCRIPTION
It won't work without it in more recent versions of Go.