### PR TITLE
linter: improved `unused` checker

### DIFF
--- a/src/linter/block.go
+++ b/src/linter/block.go
@@ -1097,9 +1097,7 @@ func (b *blockWalker) handleMethodCall(e *ir.MethodCallExpr) bool {
 	e.Variable.Walk(b)
 	e.Method.Walk(b)
 
-	if !call.isMagic {
-		b.handleCallArgs(e.Args, call.info)
-	}
+	b.handleCallArgs(e.Args, call.info)
 	b.ctx.exitFlags |= call.info.ExitFlags
 
 	return false

--- a/src/linter/cache_test.go
+++ b/src/linter/cache_test.go
@@ -149,7 +149,7 @@ main();
 		//
 		// If cache encoding changes, there is a very high chance that
 		// encoded data lengh will change as well.
-		wantLen := 5953
+		wantLen := 5952
 		haveLen := buf.Len()
 		if haveLen != wantLen {
 			t.Errorf("cache len mismatch:\nhave: %d\nwant: %d", haveLen, wantLen)
@@ -158,7 +158,7 @@ main();
 		// 2. Check cache "strings" hash.
 		//
 		// It catches new fields in cached types, field renames and encoding of additional named attributes.
-		wantStrings := "df69cfe531807fe5e317e5f894ac1ad2a68020edf03a053a30b25c70488b741b6d992d37e7a76ac4b8a760756631ee9ae309ba57e29253ffae896c3492b90939"
+		wantStrings := "690e77c94ecdd7878de0bf6f6881d786cf1fafa4588f7905f54d700646c4952aad359008ae2dcddb1c7f29163ecee62355d525672090ac30257bc414f690006f"
 		haveStrings := collectCacheStrings(buf.String())
 		if haveStrings != wantStrings {
 			t.Errorf("cache strings mismatch:\nhave: %q\nwant: %q", haveStrings, wantStrings)

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -970,6 +970,26 @@ function f3() {
 `)
 }
 
+func TestUnusedInMagicMethodCall(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+class Boo {
+	public function __call($name, $args) {}
+
+	/** @return int */
+	public function foo() {
+		$boo = new Boo();
+		$arg = 1;
+
+		$boo->some($arg); // OK, $arg is used
+	}
+}
+`)
+
+	test.Expect = []string{}
+	test.RunAndMatch()
+}
+
 func TestUnusedInVarPropFetch(t *testing.T) {
 	linttest.SimpleNegativeTest(t, `<?php
 class Foo {}


### PR DESCRIPTION
In the following cases:

$bar = 1;
$obj->foo($bar);

no need to throw a warning about an unused variable, if it inside magic method call.