### PR TITLE
inspection: phpdoc type to typehint

### DIFF
--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -3,7 +3,6 @@ package linter
 import (
 	"bytes"
 	"fmt"
-	"github.com/VKCOM/noverify/src/phpdoc"
 	"strings"
 
 	"github.com/VKCOM/noverify/src/constfold"
@@ -12,6 +11,7 @@ import (
 	"github.com/VKCOM/noverify/src/ir/phpcore"
 	"github.com/VKCOM/noverify/src/linter/autogen"
 	"github.com/VKCOM/noverify/src/meta"
+	"github.com/VKCOM/noverify/src/phpdoc"
 	"github.com/VKCOM/noverify/src/quickfix"
 	"github.com/VKCOM/noverify/src/solver"
 	"github.com/VKCOM/noverify/src/types"
@@ -227,11 +227,6 @@ func (b *blockLinter) checkMethodTypeHint(method *ir.ClassMethodStmt) {
 			var typedParam, ok = param.(*ir.Parameter)
 			if ok {
 				var variable = typedParam.Variable
-
-				// maybe we don`t need it and order the same as param
-				if variable.Name != typeContainer.Var[1:] {
-					continue
-				}
 
 				var paramType, ok = typedParam.VariableType.(*ir.Name)
 				if paramType != nil && ok {

--- a/src/linter/quickfix.go
+++ b/src/linter/quickfix.go
@@ -3,6 +3,7 @@ package linter
 import (
 	"bytes"
 	"fmt"
+	"github.com/VKCOM/noverify/src/phpdoc"
 
 	"github.com/VKCOM/noverify/src/ir"
 	"github.com/VKCOM/noverify/src/quickfix"
@@ -44,6 +45,22 @@ func (g *QuickFixGenerator) NullForNotNullableProperty(prop *ir.PropertyStmt) qu
 		StartPos:    prop.Position.StartPos,
 		EndPos:      prop.Position.EndPos,
 		Replacement: string(withoutAssign),
+	}
+}
+
+func (g *QuickFixGenerator) FunctionParamTypeReplacementFromTypeHint(prop *ir.SimpleVar, variableWithType string) quickfix.TextEdit {
+	return quickfix.TextEdit{
+		StartPos:    prop.Position.StartPos,
+		EndPos:      prop.Position.EndPos,
+		Replacement: variableWithType,
+	}
+}
+
+func (g *QuickFixGenerator) RemoveParamTypeHint(prop *phpdoc.TypeVarCommentPart) quickfix.TextEdit {
+	return quickfix.TextEdit{
+		StartPos:    int(prop.Type.Expr.Begin),
+		EndPos:      int(prop.Type.Expr.End),
+		Replacement: "",
 	}
 }
 

--- a/src/linter/quickfix.go
+++ b/src/linter/quickfix.go
@@ -3,9 +3,9 @@ package linter
 import (
 	"bytes"
 	"fmt"
-	"github.com/VKCOM/noverify/src/phpdoc"
 
 	"github.com/VKCOM/noverify/src/ir"
+	"github.com/VKCOM/noverify/src/phpdoc"
 	"github.com/VKCOM/noverify/src/quickfix"
 	"github.com/VKCOM/noverify/src/workspace"
 )

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -17,6 +17,16 @@ const (
 func addBuiltinCheckers(reg *CheckersRegistry) {
 	allChecks := []CheckerInfo{
 		{
+			Name:     "implicitParamType",
+			Default:  true,
+			Quickfix: true,
+			Comment:  `Report implicitly specifying the type of a parameter.`,
+			Before: `/* @param $str string */
+function test($str){}`,
+			After: `function test(string $str){}`,
+		},
+
+		{
 			Name:     "stripTags",
 			Default:  true,
 			Quickfix: false,

--- a/src/linter/root_checker.go
+++ b/src/linter/root_checker.go
@@ -73,11 +73,6 @@ func (r *rootChecker) CheckFunctionTypeHint(fun *ir.FunctionStmt) {
 			if ok {
 				var variable = typedParam.Variable
 
-				// maybe we don`t need it and order the same as param
-				if variable.Name != typeContainer.Var[1:] {
-					continue
-				}
-
 				var paramType, ok = typedParam.VariableType.(*ir.Name)
 				if paramType != nil && ok {
 					// TODO: quickFix -> remove @param from typeHint
@@ -86,6 +81,10 @@ func (r *rootChecker) CheckFunctionTypeHint(fun *ir.FunctionStmt) {
 
 				converted := phpdoctypes.ToRealType(r.normalizer.ClassFQNProvider(), r.normalizer.KPHP(), typeContainer.Type)
 				if cap(converted.Types) > 1 {
+					continue
+				}
+
+				if converted.Types == nil {
 					continue
 				}
 
@@ -98,6 +97,7 @@ func (r *rootChecker) CheckFunctionTypeHint(fun *ir.FunctionStmt) {
 				var variableWithType = typeParam + " " + varDollar
 				r.walker.Report(variable, LevelWarning, "implicitParamType", "Type for %s can be wrote explicitly from typeHint", varDollar)
 				r.walker.addQuickFix("implicitParamType", r.quickfix.FunctionParamTypeReplacementFromTypeHint(variable, variableWithType))
+				break
 			}
 		}
 	}

--- a/src/linter/root_checker.go
+++ b/src/linter/root_checker.go
@@ -80,7 +80,7 @@ func (r *rootChecker) CheckFunctionTypeHint(fun *ir.FunctionStmt) {
 
 				var paramType, ok = typedParam.VariableType.(*ir.Name)
 				if paramType != nil && ok {
-					//TODO: quickFix -> remove @param from typeHint
+					// TODO: quickFix -> remove @param from typeHint
 					break
 				}
 
@@ -93,9 +93,7 @@ func (r *rootChecker) CheckFunctionTypeHint(fun *ir.FunctionStmt) {
 					continue
 				}
 
-				//TODO: quickFix -> remove @param from typeHint
-
-				//quickFix -> add type to param
+				// TODO: quickFix -> remove @param from typeHint
 				var varDollar = typeContainer.Var
 				var variableWithType = typeParam + " " + varDollar
 				r.walker.Report(variable, LevelWarning, "implicitParamType", "Type for %s can be wrote explicitly from typeHint", varDollar)

--- a/src/tests/checkers/basic_test.go
+++ b/src/tests/checkers/basic_test.go
@@ -555,6 +555,8 @@ function f1() {}
 		`Void type can only be used as a standalone type for the return type`,
 		`Void type can only be used as a standalone type for the return type`,
 		`Void type can only be used as a standalone type for the return type`,
+		`Type for $x can be wrote explicitly from typeHint`,
+		`Type for $y can be wrote explicitly from typeHint`,
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/checkers/closure_test.go
+++ b/src/tests/checkers/closure_test.go
@@ -66,6 +66,7 @@ function f(callable $s, callable $s1, callable $s2) {}
 	)
 	test.Expect = []string{
 		"Lost return type for callable(...), if the function returns nothing, specify void explicitly",
+		"Type for $s can be wrote explicitly from typeHint",
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/checkers/oop_test.go
+++ b/src/tests/checkers/oop_test.go
@@ -765,7 +765,9 @@ func TestStaticResolutionInsideSameClass(t *testing.T) {
 }
 
 func TestStaticResolutionInsideOtherStaticResolution(t *testing.T) {
-	linttest.SimpleNegativeTest(t, `<?php
+	test := linttest.NewSuite(t)
+
+	test.AddFile(`<?php
 	class SomeMainClass extends ParentClass {
 		/**
 		* @var string
@@ -807,6 +809,9 @@ func TestStaticResolutionInsideOtherStaticResolution(t *testing.T) {
 		$result .= $objectB->testProperty;
 		echo $result;
 	}`)
+
+	test.Expect = []string{"Type for $testProperty can be wrote explicitly from typeHint"}
+	test.RunAndMatch()
 }
 
 func TestInheritanceLoop(t *testing.T) {

--- a/src/tests/checkers/paramClobber_test.go
+++ b/src/tests/checkers/paramClobber_test.go
@@ -18,7 +18,8 @@ function f($x, $y) {
 }
 
 func TestParamClobberReferenced(t *testing.T) {
-	linttest.SimpleNegativeTest(t, `<?php
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
 /**
  * @param mixed[] $x
  */
@@ -27,6 +28,8 @@ function f(array $x) {
   return $x;
 }
 `)
+	test.Expect = []string{"Type for $x can be wrote explicitly from typeHint"}
+	test.RunAndMatch()
 }
 
 func TestParamClobberConditional(t *testing.T) {

--- a/src/tests/checkers/phpdoc_test.go
+++ b/src/tests/checkers/phpdoc_test.go
@@ -367,6 +367,10 @@ func TestPHPDocSyntax(t *testing.T) {
 		`Expected a type, found '-'; if you want to express 'any' type, use 'mixed'`,
 		`Malformed @param $a tag (maybe type is missing?)`,
 		`Malformed @param tag (maybe var is missing?)`,
+		`Type for $x can be wrote explicitly from typeHint`,
+		`Type for $y can be wrote explicitly from typeHint`,
+		`Type for $z can be wrote explicitly from typeHint`,
+		`Type for  can be wrote explicitly from typeHint`,
 	}
 	test.RunAndMatch()
 }
@@ -445,6 +449,7 @@ func TestPHPDocType(t *testing.T) {
 		`Use bool type instead of boolean`,
 		`Nullable syntax is ?T, not T?`,
 		`Array syntax is T[], not []T`,
+		`Type for $x1 can be wrote explicitly from typeHint`,
 	}
 	test.RunAndMatch()
 }
@@ -522,6 +527,10 @@ function f2($a) {
 		`Multiline PHPDoc comment should start with /**, not /*`,
 		`Multiline PHPDoc comment should start with /**, not /*`,
 		`Multiline PHPDoc comment should start with /**, not /*`,
+		`Type for $a can be wrote explicitly from typeHint`,
+		`Type for $a can be wrote explicitly from typeHint`,
+		`Type for $item can be wrote explicitly from typeHint`,
+		`Type for $item2 can be wrote explicitly from typeHint`,
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/checkers/printf_test.go
+++ b/src/tests/checkers/printf_test.go
@@ -37,6 +37,7 @@ function f($s, array $a) {
 		`'-flag expects a char, found end of string`,
 		`potential array to string conversion`,
 		`potential array to string conversion`,
+		`Type for $a can be wrote explicitly from typeHint`,
 	}
 	test.RunAndMatch()
 }
@@ -72,6 +73,7 @@ function f($s, array $a) {
 		`'-flag expects a char, found end of string`,
 		`potential array to string conversion`,
 		`potential array to string conversion`,
+		`Type for $a can be wrote explicitly from typeHint`,
 	}
 	test.RunAndMatch()
 }

--- a/src/tests/checkers/shape_test.go
+++ b/src/tests/checkers/shape_test.go
@@ -134,7 +134,8 @@ echo $t->good6['y']->value;
 }
 
 func TestShapeReturn(t *testing.T) {
-	linttest.SimpleNegativeTest(t, `<?php
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
 class MyList {
   /** @var \MyList */
   public $next;
@@ -146,10 +147,15 @@ function new_shape1() { return []; }
 $s1 = new_shape1();
 echo $s1['list']->next->next;
 `)
+	test.Expect = []string{
+		`Type for $next can be wrote explicitly from typeHint`,
+	}
+	test.RunAndMatch()
 }
 
 func TestTuple(t *testing.T) {
-	linttest.SimpleNegativeTest(t, `<?php
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
 class Box { public $value; }
 
 class T {
@@ -167,4 +173,8 @@ $t = new T();
 echo $t->good2[0]->value;
 echo $t->good3[1][0]->value;
 `)
+	test.Expect = []string{
+		`Type for $good1 can be wrote explicitly from typeHint`,
+	}
+	test.RunAndMatch()
 }

--- a/src/tests/checkers/typehint_test.go
+++ b/src/tests/checkers/typehint_test.go
@@ -96,6 +96,12 @@ function f4() {
   };
 }
 `)
+	test.Expect = []string{
+		`Type for $a can be wrote explicitly from typeHint`,
+		`Type for $a can be wrote explicitly from typeHint`,
+		`Type for $a can be wrote explicitly from typeHint`,
+		`Type for $a can be wrote explicitly from typeHint`,
+	}
 	test.RunAndMatch()
 }
 

--- a/src/tests/checkers/typehint_test.go
+++ b/src/tests/checkers/typehint_test.go
@@ -139,3 +139,66 @@ function f2() {
 	}
 	linttest.RunFilterMatch(test, "typeHint")
 }
+
+func TestTypeHintToFunParam(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+declare(strict_types = 1);
+/* @param $str string */
+function test($str){}
+`)
+	test.Expect = []string{
+		`Non-canonical order of variable and type`,
+		`Type for $str can be wrote explicitly from typeHint`,
+	}
+	test.RunAndMatch()
+}
+
+func TestTypeHintClassAndFunc(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+declare(strict_types = 1);
+
+class SimpleClass
+{
+
+/**
+ * This is what the variable does. The var line contains the type stored in this variable.
+ * @var string
+ */
+private string $foo;
+
+
+/**
+ * This is what the variable does. The var line contains the type stored in this variable.
+ * @var string
+ */
+private $foo2 ;
+
+/**
+ * @param $str string
+ * @param $str2 string
+ */
+function test($str, string $str){
+}
+}
+
+/**
+ * @param $str string
+ */
+function test2($str){
+}
+`)
+	test.Expect = []string{
+		`Specify the access modifier for \SimpleClass::test method explicitly`,
+		`Non-canonical order of variable and type `,
+		`@param for non-existing argument $str2`,
+		`Non-canonical order of variable and type`,
+		`Type for $foo2 can be wrote explicitly from typeHint`,
+		`Type for $str can be wrote explicitly from typeHint`,
+		`Type for $str2 can be wrote explicitly from typeHint`,
+		`Non-canonical order of variable and type`,
+		`Type for $str can be wrote explicitly from typeHint`,
+	}
+	test.RunAndMatch()
+}

--- a/src/tests/golden/testdata/embeddedrules/golden.txt
+++ b/src/tests/golden/testdata/embeddedrules/golden.txt
@@ -67,6 +67,9 @@ WARNING bitwiseOps: Used | bitwise operator over bool operands, perhaps || is in
 MAYBE   callSimplify: Could simplify to array_key_exists('abc', $array) at testdata/embeddedrules/callSimplify.php:7
     $_ = in_array('abc', array_keys($array)); // bad
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $array can be wrote explicitly from typeHint at testdata/embeddedrules/callSimplify.php:6
+function in_array_over_array_keys(array $array) {
+                                        ^^^^^^
 MAYBE   callSimplify: Could simplify to $str[$index] at testdata/embeddedrules/callSimplify.php:14
     $_ = substr($str, $index, 1);
          ^^^^^^^^^^^^^^^^^^^^^^^
@@ -82,6 +85,12 @@ MAYBE   callSimplify: Could simplify to $array[] = $val at testdata/embeddedrule
 MAYBE   callSimplify: Could simplify to $array[] = 10 at testdata/embeddedrules/callSimplify.php:28
     array_push($array, 10);
     ^^^^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $array can be wrote explicitly from typeHint at testdata/embeddedrules/callSimplify.php:26
+function some_array_push(array $array, int $val) {
+                               ^^^^^^
+WARNING implicitParamType: Type for $val can be wrote explicitly from typeHint at testdata/embeddedrules/callSimplify.php:26
+function some_array_push(array $array, int $val) {
+                               ^^^^^^
 WARNING indexingSyntax: a{i} indexing is deprecated since PHP 7.4, use a[i] instead at testdata/embeddedrules/indexingSyntax.php:14
     $_ = $a{0};
          ^^^^^
@@ -157,6 +166,15 @@ WARNING offBy1: Probably intended to use sizeof-1 as an index at testdata/embedd
 WARNING offBy1: Probably intended to use count-1 as an index at testdata/embeddedrules/offBy1.php:14
   if ($tabs[count($tabs)] == "") {
       ^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $xs can be wrote explicitly from typeHint at testdata/embeddedrules/offBy1.php:7
+function test_countindex_bad(array $xs, array $tabs) {
+                                   ^^^
+WARNING implicitParamType: Type for $tabs can be wrote explicitly from typeHint at testdata/embeddedrules/offBy1.php:7
+function test_countindex_bad(array $xs, array $tabs) {
+                                   ^^^
+WARNING implicitParamType: Type for $xs can be wrote explicitly from typeHint at testdata/embeddedrules/offBy1.php:24
+function test_countindex_good(array $xs) {
+                                    ^^^
 WARNING precedence: == has higher precedence than & at testdata/embeddedrules/precedence.php:4
   $_ = 0 == $mask & $x;
        ^^^^^^^^^^^^^^^
@@ -310,3 +328,6 @@ MAYBE   ternarySimplify: Could rewrite as `$x_arr[10] ?? null` at testdata/embed
 MAYBE   ternarySimplify: Could rewrite as `(bool)($flags & SOME_MASK)` at testdata/embeddedrules/ternarySimplify.php:46
     sink(($flags & SOME_MASK) ? true : false);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $flags can be wrote explicitly from typeHint at testdata/embeddedrules/ternarySimplify.php:45
+function ternarySimplify_issue540($flags) {
+                                  ^^^^^^

--- a/src/tests/golden/testdata/flysystem/golden.txt
+++ b/src/tests/golden/testdata/flysystem/golden.txt
@@ -1,9 +1,45 @@
+WARNING implicitParamType: Type for $pathSeparator can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractAdapter.php:17
+    protected $pathSeparator = '/';
+              ^^^^^^^^^^^^^^
 MAYBE   regexpSimplify: May re-write '/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/' as '/^\d{2,4}-\d{2}-\d{2}/' at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:536
         return preg_match('/^[0-9]{2,4}-[0-9]{2}-[0-9]{2}/', $item) ? 'windows' : 'unix';
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 MAYBE   callSimplify: Could simplify to $permissions[0] at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:548
         return substr($permissions, 0, 1) === 'd' ? 'dir' : 'file';
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $connection can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:17
+    protected $connection;
+              ^^^^^^^^^^^
+WARNING implicitParamType: Type for $host can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:22
+    protected $host;
+              ^^^^^
+WARNING implicitParamType: Type for $port can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:27
+    protected $port = 21;
+              ^^^^^
+WARNING implicitParamType: Type for $ssl can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:32
+    protected $ssl = false;
+              ^^^^
+WARNING implicitParamType: Type for $timeout can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:37
+    protected $timeout = 90;
+              ^^^^^^^^
+WARNING implicitParamType: Type for $passive can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:42
+    protected $passive = true;
+              ^^^^^^^^
+WARNING implicitParamType: Type for $separator can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:47
+    protected $separator = '/';
+              ^^^^^^^^^^
+WARNING implicitParamType: Type for $permPublic can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:57
+    protected $permPublic = 0744;
+              ^^^^^^^^^^^
+WARNING implicitParamType: Type for $permPrivate can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:62
+    protected $permPrivate = 0700;
+              ^^^^^^^^^^^^
+WARNING implicitParamType: Type for $systemType can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:72
+    protected $systemType;
+              ^^^^^^^^^^^
+WARNING implicitParamType: Type for $enableTimestampsOnUnixListings can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/AbstractFtpAdapter.php:84
+    protected $enableTimestampsOnUnixListings = false;
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:134
             $this->connection = @ftp_ssl_connect($this->getHost(), $this->getPort(), $this->getTimeout());
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,6 +58,18 @@ MAYBE   regexpSimplify: May re-write '/^total [0-9]*$/' as '/^total \d*$/' at te
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftp.php:570
         $response = @ftp_raw($this->connection, trim($command));
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $transferMode can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/Ftp.php:22
+    protected $transferMode = FTP_BINARY;
+              ^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $recurseManually can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/Ftp.php:32
+    protected $recurseManually = false;
+              ^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $utf8 can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/Ftp.php:37
+    protected $utf8 = false;
+              ^^^^^
+WARNING implicitParamType: Type for $isPureFtpd can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/Ftp.php:64
+    protected $isPureFtpd;
+              ^^^^^^^^^^^
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/flysystem/src/Adapter/Ftpd.php:15
         if (@ftp_chdir($this->getConnection(), $path) === true) {
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,6 +97,15 @@ WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/
 MAYBE   invalidDocblockType: Void type can only be used as a standalone type for the return type at testdata/flysystem/src/Adapter/Local.php:444
      * @return array|void
                ^^^^^^^^^^
+WARNING implicitParamType: Type for $pathSeparator can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/Local.php:47
+    protected $pathSeparator = DIRECTORY_SEPARATOR;
+              ^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $writeFlags can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/Local.php:57
+    protected $writeFlags;
+              ^^^^^^^^^^^
+WARNING implicitParamType: Type for $linkHandling can be wrote explicitly from typeHint at testdata/flysystem/src/Adapter/Local.php:62
+    private $linkHandling;
+            ^^^^^^^^^^^^^
 WARNING invalidDocblockRef: @see tag refers to unknown symbol League\Flysystem\ReadInterface::readStream at testdata/flysystem/src/Adapter/Polyfill/StreamedReadingTrait.php:17
      * @see League\Flysystem\ReadInterface::readStream()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,6 +118,18 @@ MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\Adapter\Polyfill\Str
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\Adapter\Polyfill\StreamedWritingTrait::update public method at testdata/flysystem/src/Adapter/Polyfill/StreamedWritingTrait.php:59
     abstract public function update($pash, $contents, Config $config);
                              ^^^^^^
+WARNING implicitParamType: Type for $path can be wrote explicitly from typeHint at testdata/flysystem/src/FileExistsException.php:12
+    protected $path;
+              ^^^^^
+WARNING implicitParamType: Type for $path can be wrote explicitly from typeHint at testdata/flysystem/src/FileNotFoundException.php:12
+    protected $path;
+              ^^^^^
+WARNING implicitParamType: Type for $previous can be wrote explicitly from typeHint at testdata/flysystem/src/FileNotFoundException.php:21
+    public function __construct($path, $code = 0, BaseException $previous = null)
+                                ^^^^^
+WARNING implicitParamType: Type for $previous can be wrote explicitly from typeHint at testdata/flysystem/src/FileNotFoundException.php:21
+    public function __construct($path, $code = 0, BaseException $previous = null)
+                                       ^^^^^
 MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Filesystem.php:63
     public function write($path, $contents, array $config = [])
                     ^^^^^
@@ -85,6 +154,9 @@ MAYBE   typeHint: Specify the type for the parameter $config in PHPDoc, 'array' 
 WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Handler.php:129
         } catch (BadMethodCallException $e) {
                                         ^^
+WARNING implicitParamType: Type for $path can be wrote explicitly from typeHint at testdata/flysystem/src/Handler.php:15
+    protected $path;
+              ^^^^^
 WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/MountManager.php:275
         } catch (PluginNotFoundException $e) {
                                          ^^
@@ -106,6 +178,9 @@ MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\SafeStorage::storeSa
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\SafeStorage::retrieveSafely public method at testdata/flysystem/src/SafeStorage.php:28
     public function retrieveSafely($key)
                     ^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $hash can be wrote explicitly from typeHint at testdata/flysystem/src/SafeStorage.php:10
+    private $hash;
+            ^^^^^
 MAYBE   missingPhpdoc: Missing PHPDoc for \League\Flysystem\UnreadableFileException::forFileInfo public method at testdata/flysystem/src/UnreadableFileException.php:9
     public static function forFileInfo(SplFileInfo $fileInfo)
                            ^^^^^^^^^^^
@@ -121,9 +196,21 @@ MAYBE   regexpSimplify: May re-write '#^[a-zA-Z]{1}:$#' as '#^[a-zA-Z]:$#' at te
 MAYBE   typeHint: Specify the type for the parameter $entry in PHPDoc, 'array' type hint too generic at testdata/flysystem/src/Util/ContentListingFormatter.php:52
     private function addPathInfo(array $entry)
                      ^^^^^^^^^^^
+WARNING implicitParamType: Type for $directory can be wrote explicitly from typeHint at testdata/flysystem/src/Util/ContentListingFormatter.php:15
+    private $directory;
+            ^^^^^^^^^^
+WARNING implicitParamType: Type for $recursive can be wrote explicitly from typeHint at testdata/flysystem/src/Util/ContentListingFormatter.php:20
+    private $recursive;
+            ^^^^^^^^^^
+WARNING implicitParamType: Type for $caseSensitive can be wrote explicitly from typeHint at testdata/flysystem/src/Util/ContentListingFormatter.php:25
+    private $caseSensitive;
+            ^^^^^^^^^^^^^^
 WARNING unused: Variable $e is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/flysystem/src/Util/MimeType.php:208
         } catch (ErrorException $e) {
                                 ^^
 MAYBE   ternarySimplify: Could rewrite as `static::$extensionToMimeTypeMap[$extension] ?? 'text/plain'` at testdata/flysystem/src/Util/MimeType.php:222
         return isset(static::$extensionToMimeTypeMap[$extension])
                ^^^^^^^^^^^
+WARNING implicitParamType: Type for $algo can be wrote explicitly from typeHint at testdata/flysystem/src/Util/StreamHasher.php:10
+    private $algo;
+            ^^^^^

--- a/src/tests/golden/testdata/inflector/golden.txt
+++ b/src/tests/golden/testdata/inflector/golden.txt
@@ -22,3 +22,18 @@ WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/
 WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/inflector/lib/Doctrine/Common/Inflector/Inflector.php:181
         @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $pattern can be wrote explicitly from typeHint at testdata/inflector/lib/Doctrine/Inflector/Rules/Pattern.php:12
+    private $pattern;
+            ^^^^^^^^
+WARNING implicitParamType: Type for $regex can be wrote explicitly from typeHint at testdata/inflector/lib/Doctrine/Inflector/Rules/Pattern.php:15
+    private $regex;
+            ^^^^^^
+WARNING implicitParamType: Type for $regex can be wrote explicitly from typeHint at testdata/inflector/lib/Doctrine/Inflector/Rules/Patterns.php:17
+    private $regex;
+            ^^^^^^
+WARNING implicitParamType: Type for $replacement can be wrote explicitly from typeHint at testdata/inflector/lib/Doctrine/Inflector/Rules/Transformation.php:16
+    private $replacement;
+            ^^^^^^^^^^^^
+WARNING implicitParamType: Type for $word can be wrote explicitly from typeHint at testdata/inflector/lib/Doctrine/Inflector/Rules/Word.php:10
+    private $word;
+            ^^^^^

--- a/src/tests/golden/testdata/math/golden.txt
+++ b/src/tests/golden/testdata/math/golden.txt
@@ -1,9 +1,18 @@
 WARNING unused: Variable $a is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/math/src/BigDecimal.php:292
         [$a, $b] = $this->scaleValues($this, $that);
          ^^
+WARNING implicitParamType: Type for $value can be wrote explicitly from typeHint at testdata/math/src/BigDecimal.php:28
+    private $value;
+            ^^^^^^
+WARNING implicitParamType: Type for $scale can be wrote explicitly from typeHint at testdata/math/src/BigDecimal.php:37
+    private $scale;
+            ^^^^^^
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/math/src/BigInteger.php:435
             new BigInteger($remainder)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $value can be wrote explicitly from typeHint at testdata/math/src/BigInteger.php:32
+    private $value;
+            ^^^^^^
 MAYBE   ternarySimplify: Could rewrite as `$matches['fractional'] ?? ''` at testdata/math/src/BigNumber.php:90
             $fractional = isset($matches['fractional']) ? $matches['fractional'] : '';
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,6 +28,9 @@ MAYBE   trailingComma: Last element in a multi-line array should have a trailing
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/math/src/Internal/Calculator/NativeCalculator.php:187
                     (string) $r
                     ^^^^^^^^^^^
+WARNING implicitParamType: Type for $maxDigits can be wrote explicitly from typeHint at testdata/math/src/Internal/Calculator/NativeCalculator.php:28
+    private $maxDigits;
+            ^^^^^^^^^^
 ERROR   classMembersOrder: Constant UNNECESSARY must go before methods in the class RoundingMode at testdata/math/src/RoundingMode.php:33
     public const UNNECESSARY = 0;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -172,3 +172,6 @@ WARNING errorSilence: Don't use @, silencing errors is bad practice at testdata/
 WARNING unused: Variable $v is unused (use $_ to ignore this inspection or specify --unused-var-regex flag) at testdata/mustache/src/Mustache/Template.php:122
                 foreach ($value as $k => $v) {
                                          ^^
+WARNING implicitParamType: Type for $strictCallables can be wrote explicitly from typeHint at testdata/mustache/src/Mustache/Template.php:27
+    protected $strictCallables = false;
+              ^^^^^^^^^^^^^^^^

--- a/src/tests/golden/testdata/phpdoc/golden.txt
+++ b/src/tests/golden/testdata/phpdoc/golden.txt
@@ -37,6 +37,9 @@ MAYBE   invalidDocblockType: Repeated nullable doesn't make sense at testdata/ph
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
 /*
 ^^
+WARNING implicitParamType: Type for $a can be wrote explicitly from typeHint at testdata/phpdoc/phpdoc.php:34
+function g($a) {
+           ^^
 WARNING invalidDocblockRef: @see tag refers to unknown symbol FooUnExisting at testdata/phpdoc/phpdoc.php:54
  * @see  FooUnExisting
          ^^^^^^^^^^^^^
@@ -85,6 +88,30 @@ MAYBE   invalidDocblockType: Shape param #1: want key:type, found x at testdata/
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:70
   /*
 ^^^^
+WARNING implicitParamType: Type for $a can be wrote explicitly from typeHint at testdata/phpdoc/phpdoc.php:57
+function f($a, $b, $c, $d, $e, $f, $g, $h, $a1, $b1, $c1, $d1, $e1, $f1, $g1, $h1) {
+           ^^
+WARNING implicitParamType: Type for $unexisting can be wrote explicitly from typeHint at testdata/phpdoc/phpdoc.php:57
+function f($a, $b, $c, $d, $e, $f, $g, $h, $a1, $b1, $c1, $d1, $e1, $f1, $g1, $h1) {
+           ^^
+WARNING implicitParamType: Type for  can be wrote explicitly from typeHint at testdata/phpdoc/phpdoc.php:57
+function f($a, $b, $c, $d, $e, $f, $g, $h, $a1, $b1, $c1, $d1, $e1, $f1, $g1, $h1) {
+           ^^
+WARNING implicitParamType: Type for $b can be wrote explicitly from typeHint at testdata/phpdoc/phpdoc.php:57
+function f($a, $b, $c, $d, $e, $f, $g, $h, $a1, $b1, $c1, $d1, $e1, $f1, $g1, $h1) {
+           ^^
+WARNING implicitParamType: Type for $e can be wrote explicitly from typeHint at testdata/phpdoc/phpdoc.php:57
+function f($a, $b, $c, $d, $e, $f, $g, $h, $a1, $b1, $c1, $d1, $e1, $f1, $g1, $h1) {
+           ^^
+WARNING implicitParamType: Type for $f can be wrote explicitly from typeHint at testdata/phpdoc/phpdoc.php:57
+function f($a, $b, $c, $d, $e, $f, $g, $h, $a1, $b1, $c1, $d1, $e1, $f1, $g1, $h1) {
+           ^^
+WARNING implicitParamType: Type for $h can be wrote explicitly from typeHint at testdata/phpdoc/phpdoc.php:57
+function f($a, $b, $c, $d, $e, $f, $g, $h, $a1, $b1, $c1, $d1, $e1, $f1, $g1, $h1) {
+           ^^
+WARNING implicitParamType: Type for $a can be wrote explicitly from typeHint at testdata/phpdoc/phpdoc.php:21
+  public $a = 100;
+         ^^
 WARNING invalidDocblock: Multiline PHPDoc comment should start with /**, not /* at testdata/phpdoc/phpdoc.php:31
 /*
 ^^

--- a/src/tests/golden/testdata/quickfix/phpTypeHintApply.php
+++ b/src/tests/golden/testdata/quickfix/phpTypeHintApply.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types = 1);
+
+class SimpleClass
+{
+
+/**
+ * This is what the variable does. The var line contains the type stored in this variable.
+ * @var string
+ */
+private string $foo;
+
+
+/**
+ * This is what the variable does. The var line contains the type stored in this variable.
+ * @var string
+ */
+private string $foo2 ;
+
+/**
+ * @param $str string
+ * @param $str2 string
+ */
+function test($str, $str2){
+}
+}
+
+/**
+ * @param $str string
+ */
+function test2($str){
+}

--- a/src/tests/golden/testdata/quickfix/phpTypeHintApply.php.fix.expected
+++ b/src/tests/golden/testdata/quickfix/phpTypeHintApply.php.fix.expected
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types = 1);
+
+class SimpleClass
+{
+
+/**
+ * This is what the variable does. The var line contains the type stored in this variable.
+ * @var string
+ */
+private string $foo;
+
+
+/**
+ * This is what the variable does. The var line contains the type stored in this variable.
+ * @var string
+ */
+private string $foo2 ;
+
+/**
+ * @param $str string
+ * @param $str2 string
+ */
+function test(string $str, string $str){
+}
+}
+
+/**
+ * @param $str string
+ */
+function test2(string $str){
+}

--- a/src/tests/golden/testdata/twitter-api-php/golden.txt
+++ b/src/tests/golden/testdata/twitter-api-php/golden.txt
@@ -25,6 +25,33 @@ MAYBE   trailingComma: Last element in a multi-line array should have a trailing
 MAYBE   invalidDocblockType: Use int type instead of integer at testdata/twitter-api-php/TwitterAPIExchange.php:404
      * @return integer
                ^^^^^^^
+WARNING implicitParamType: Type for $oauth_access_token can be wrote explicitly from typeHint at testdata/twitter-api-php/TwitterAPIExchange.php:20
+    private $oauth_access_token;
+            ^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $oauth_access_token_secret can be wrote explicitly from typeHint at testdata/twitter-api-php/TwitterAPIExchange.php:25
+    private $oauth_access_token_secret;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $consumer_key can be wrote explicitly from typeHint at testdata/twitter-api-php/TwitterAPIExchange.php:30
+    private $consumer_key;
+            ^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $consumer_secret can be wrote explicitly from typeHint at testdata/twitter-api-php/TwitterAPIExchange.php:35
+    private $consumer_secret;
+            ^^^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $getfield can be wrote explicitly from typeHint at testdata/twitter-api-php/TwitterAPIExchange.php:45
+    private $getfield;
+            ^^^^^^^^^
+WARNING implicitParamType: Type for $oauth can be wrote explicitly from typeHint at testdata/twitter-api-php/TwitterAPIExchange.php:50
+    protected $oauth;
+              ^^^^^^
+WARNING implicitParamType: Type for $url can be wrote explicitly from typeHint at testdata/twitter-api-php/TwitterAPIExchange.php:55
+    public $url;
+           ^^^^
+WARNING implicitParamType: Type for $requestMethod can be wrote explicitly from typeHint at testdata/twitter-api-php/TwitterAPIExchange.php:60
+    public $requestMethod;
+           ^^^^^^^^^^^^^^
+WARNING implicitParamType: Type for $httpStatusCode can be wrote explicitly from typeHint at testdata/twitter-api-php/TwitterAPIExchange.php:67
+    protected $httpStatusCode;
+              ^^^^^^^^^^^^^^^
 MAYBE   trailingComma: Last element in a multi-line array should have a trailing comma at testdata/twitter-api-php/index.php:10
     'consumer_secret' => ""
     ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
While working on the task, it was discovered that phpdoc is not an AST tree, which makes it very difficult to remove. This needs to be identified as a separate task.