### PR TITLE
dynamic rules: paths grouping

### DIFF
--- a/docs/dynamic_rules.md
+++ b/docs/dynamic_rules.md
@@ -427,7 +427,7 @@ This rule will now don't apply to files with the `common/` folder in the path.
 
 ##### `@path-group-name`
 
-The `@path-group-name` allow you to group a lot of paths to the named group and give the name.
+The `@path-group-name` allow you to group a lot of paths to the named group and give the name. This tag must be first.
 
 ```php
 /**

--- a/docs/dynamic_rules.md
+++ b/docs/dynamic_rules.md
@@ -425,6 +425,71 @@ function ternarySimplify() {
 
 This rule will now don't apply to files with the `common/` folder in the path.
 
+##### `@path-group-name`
+
+The `@path-group-name` allow you to group a lot of paths to the named group and give the name.
+
+```php
+/**
+ * @path-group-name test
+ * @path my/site/ads_
+ * @path your/site/bad
+ */
+_init_test_group_();
+```
+
+Very important note: you must write any function name after declaring `@path-group-name`. In this example this is `_init_test_group_()`
+
+
+#### `@path-group`
+
+After creating group with `@path-group-name` you can use it in your rules by `@path-group`.
+ 
+
+For example:
+
+```php
+/**
+ * @path-group-name test
+ * @path my/site/ads_
+ * @path your/site/bad
+ */
+_init_test_group_();
+
+/**
+ * @name varEval
+ * @warning don't eval from variable
+ * @path-group test
+ * @path my/site/admin_
+ */
+eval(${"var"});
+```
+
+You can combine @path-group with @path. No conflicts here.
+
+##### `@path-group-exclude`
+
+After creating group with `@path-group-name` you can use it in your rules by `@path-group-exclude`.
+
+``@path-group-exclude`` allow you to add all `@path` in group to exclude. It's the same as if they were written one by one.
+
+```php
+/**
+ * @path-group-name test
+ * @path www/no
+ */
+_init_test_group_();
+
+
+/**
+ * @name varEval
+ * @warning don't eval from variable
+ * @path www/
+ * @path-group-exclude test
+ */
+eval(${"var"});
+```
+
 ##### `@filter`
 
 The `@filter` restriction allows you to restrict the rule by name of matched variable.

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -444,6 +444,8 @@ func (p *parser) parseRule(st ir.Node, proto *Rule) error {
 	}
 
 	// if we parsed new group - we can go next comments
+	// function declaring after @path-group does not matter, because we will ignore it
+	// This used only for separating comments and functions
 	if p.parseRuleGroups(st) {
 		return nil
 	}

--- a/src/rules/parser.go
+++ b/src/rules/parser.go
@@ -156,16 +156,13 @@ func (p *parser) parseRuleGroups(st ir.Node) bool {
 			if pathGroups[tagName] == nil {
 				pathGroups = make(map[string][]string)
 			}
-			pathGroups[groupName] = make([]string, 1)
+			pathGroups[groupName] = make([]string, 0)
 		case "path":
-			pathGroups[groupName] = append(pathGroups[tagName], part.Params...)
+			pathGroups[groupName] = append(pathGroups[groupName], part.Params...)
 		}
 	}
 
-	if pathGroups[groupName] != nil {
-		return true
-	}
-	return false
+	return pathGroups[groupName] != nil
 }
 
 func (p *parser) parseRuleInfo(st ir.Node, labelStmt ir.Node, proto *Rule) (Rule, error) {

--- a/src/rules/rules.go
+++ b/src/rules/rules.go
@@ -11,6 +11,8 @@ import (
 
 type Parser struct{}
 
+var pathGroups map[string][]string
+
 func NewParser() *Parser {
 	return &Parser{}
 }

--- a/src/rules/util.go
+++ b/src/rules/util.go
@@ -30,6 +30,10 @@ func formatRule(r *Rule) string {
 		}
 	}
 
+	if r.Link != "" {
+		buf.WriteString(" * @link " + r.Link + "\n")
+	}
+
 	if r.Location != "" {
 		buf.WriteString(" * @location $" + r.Location + "\n")
 	}

--- a/src/tests/rules/rules_test.go
+++ b/src/tests/rules/rules_test.go
@@ -201,6 +201,37 @@ eval(${"var"});
 	test.RunRulesTest()
 }
 
+func TestRuleExcludeWithPathGroupExclude(t *testing.T) {
+	rfile := `<?php
+/**
+ * @path-group-name test
+ * @path www/no
+ */
+_init_test_group_();
+
+
+/**
+ * @name varEval
+ * @warning don't eval from variable
+ * @path www/
+ * @path-group-exclude test
+ * @path-exclude www/bad
+ */
+eval(${"var"});
+`
+	test := linttest.NewSuite(t)
+	test.RuleFile = rfile
+	code := `<?php
+          $hello = 'echo 123;';
+          eval($hello);
+          eval('echo 456;');
+        `
+	test.AddNamedFile("www/no", code)
+	test.AddNamedFile("www/bad", code)
+
+	test.RunRulesTest()
+}
+
 func TestAnyRules(t *testing.T) {
 	rfile := `<?php
 /**

--- a/src/tests/rules/rules_test.go
+++ b/src/tests/rules/rules_test.go
@@ -232,6 +232,96 @@ eval(${"var"});
 	test.RunRulesTest()
 }
 
+func TestMultiplePathGroupsInitialization(t *testing.T) {
+	rfile := `<?php
+/**
+ * @path-group-name group1
+ * @path www/no
+ * @path www/yes
+ */
+_init_test_group1_();
+
+/**
+ * @path-group-name group2
+ * @path www/no
+ * @path www/yes
+ */
+_init_test_group2_();
+
+/**
+ * @name testRuleGroup1
+ * @warning don't eval from variable: Group1
+ * @path-group group1
+ */
+eval(${"var"});
+`
+	test := linttest.NewSuite(t)
+	test.RuleFile = rfile
+
+	code := `<?php
+          $hello = 'echo 123;';
+          eval($hello);
+        `
+
+	test.AddNamedFile("www/no", code)
+	test.AddNamedFile("www/yes", code)
+
+	test.Expect = []string{
+		`don't eval from variable`,
+		`don't eval from variable`,
+	}
+
+	test.RunRulesTest()
+}
+
+func TestMultiplePathGroupExclude(t *testing.T) {
+	rfile := `<?php
+/**
+ * @path-group-name safe
+ * @path www/safe
+ */
+_init_test_safe_();
+
+/**
+ * @path-group-name dangerous
+ * @path www/dangerous
+ */
+_init_test_dangerous_();
+
+/**
+ * @name testRule
+ * @warning This rule applies only for dangerous
+ * @path www/
+ * @path-group dangerous
+ * @path-group-exclude safe
+ */
+eval(${"var"});
+`
+	test := linttest.NewSuite(t)
+	test.RuleFile = rfile
+
+	codeSafe := `<?php
+          eval('echo safe;');
+        `
+	codeDangerous := `<?php
+          $hello = 'echo 123;';
+          eval($hello);
+        `
+	codeOther := `<?php
+          eval('echo other;');
+        `
+
+	test.AddNamedFile("www/safe/index.php", codeSafe)
+	test.AddNamedFile("www/dangerous/index.php", codeDangerous)
+	test.AddNamedFile("www/other/index.php", codeOther)
+
+	test.Expect = []string{
+		`This rule applies only for dangerous`,
+	}
+
+	test.RunRulesTest()
+}
+
 func TestAnyRules(t *testing.T) {
 	rfile := `<?php
 /**

--- a/src/tests/rules/rules_test.go
+++ b/src/tests/rules/rules_test.go
@@ -142,7 +142,7 @@ func TestRulePathGroup(t *testing.T) {
  * @path-group-name test
  * @path my/site/ads_
  */
-_init_path_group_();
+_init_test_group_();
 
 /**
  * @name varEval
@@ -178,7 +178,7 @@ func TestRulePathGroupExclude(t *testing.T) {
  * @path-group-name test
  * @path www/no
  */
-_init_path_group_();
+_init_test_group_();
 
 
 /**


### PR DESCRIPTION
It would be convenient to group a list of paths so that the rules are more compact.
```

/**
 * @path-group-name GROUP1 <- something like id for group
 * @path VK/Connect <- path in GROUP1
 * @path ... <- another path in GROUP1
 */

/**
 * @path-group GROUP1
 * @warning please, use AppFacade::getApp() in GROUP1 code
 */
getApp();

/**
 * @path /
 * @path-group-exclude GROUP1
 * @warning please, use getApp() outside GROUP1 code
 */
AppFacade::getApp();

/**
 * @path-group GROUP1
 * @path-exlude TestApp/Connect/Apps
 * @warning please, use AppFacade::getApp() in GROUP1 code
 */
rpcCall(CLUSTER_APPLICATIONS); 
```