### PR TITLE
linter: function param type mismatch with phpdoc

### DIFF
--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -44,10 +44,12 @@ func (b *blockLinter) enterNode(n ir.Node) {
 		b.checkFunctionCall(n)
 
 	case *ir.ArrowFunctionExpr:
-		b.walker.CheckParamNullability(n.Params)
+		phpDocParamTypes := b.walker.getParamsTypesFromPhpDoc(n.Doc)
+		b.walker.CheckParamNullability(n.Params, phpDocParamTypes)
 
 	case *ir.ClosureExpr:
-		b.walker.CheckParamNullability(n.Params)
+		phpDocParamTypes := b.walker.getParamsTypesFromPhpDoc(n.Doc)
+		b.walker.CheckParamNullability(n.Params, phpDocParamTypes)
 
 	case *ir.MethodCallExpr:
 		b.checkMethodCall(n)
@@ -238,7 +240,8 @@ func (b *blockLinter) checkTrait(n *ir.TraitStmt) {
 	for _, stmt := range n.Stmts {
 		method, ok := stmt.(*ir.ClassMethodStmt)
 		if ok {
-			b.walker.CheckParamNullability(method.Params)
+			phpDocParamTypes := b.walker.getParamsTypesFromPhpDoc(method.Doc)
+			b.walker.CheckParamNullability(method.Params, phpDocParamTypes)
 		}
 	}
 }
@@ -252,7 +255,8 @@ func (b *blockLinter) checkClass(class *ir.ClassStmt) {
 		switch value := stmt.(type) {
 		case *ir.ClassMethodStmt:
 			members = append(members, classMethod)
-			b.walker.CheckParamNullability(value.Params)
+			phpDocParamTypes := b.walker.getParamsTypesFromPhpDoc(value.Doc)
+			b.walker.CheckParamNullability(value.Params, phpDocParamTypes)
 		case *ir.PropertyListStmt:
 			for _, element := range value.Doc.Parsed {
 				if element.Name() == "deprecated" {
@@ -1611,7 +1615,8 @@ func (b *blockLinter) checkInterfaceStmt(iface *ir.InterfaceStmt) {
 					b.report(x, LevelWarning, "nonPublicInterfaceMember", "'%s' can't be %s", methodName, modifier.Value)
 				}
 			}
-			b.walker.CheckParamNullability(x.Params)
+			phpDocParamTypes := b.walker.getParamsTypesFromPhpDoc(x.Doc)
+			b.walker.CheckParamNullability(x.Params, phpDocParamTypes)
 		case *ir.ClassConstListStmt:
 			for _, modifier := range x.Modifiers {
 				if strings.EqualFold(modifier.Value, "private") || strings.EqualFold(modifier.Value, "protected") {

--- a/src/linter/block_linter.go
+++ b/src/linter/block_linter.go
@@ -257,13 +257,6 @@ func (b *blockLinter) checkClass(class *ir.ClassStmt) {
 			members = append(members, classMethod)
 			phpDocParamTypes := b.walker.getParamsTypesFromPhpDoc(value.Doc)
 			b.walker.CheckParamNullability(value.Params, phpDocParamTypes)
-		case *ir.PropertyListStmt:
-			for _, element := range value.Doc.Parsed {
-				if element.Name() == "deprecated" {
-					b.report(stmt, LevelNotice, "deprecated", "Has deprecated field in class %s", class.ClassName.Value)
-				}
-			}
-			members = append(members, classOtherMember)
 		default:
 			members = append(members, classOtherMember)
 		}

--- a/src/linter/report.go
+++ b/src/linter/report.go
@@ -1356,6 +1356,31 @@ class Main {
 			Before:   `if (gettype($a) == "string") { ... }`,
 			After:    `if (is_string($a)) { ... }`,
 		},
+
+		{
+			Name:     "funcParamTypeMissMatch",
+			Default:  true,
+			Quickfix: false,
+			Comment:  `Report function typehint and phpdoc mismatch.`,
+			Before: `
+/**
+ *
+ * @param ?string $name
+ * @return string
+ */
+function wrongParam(string $name): string {
+    return "Hello, $name";
+}`,
+			After: `
+/**
+ *
+ * @param ?string $name
+ * @return string
+ */
+function wrongParam(?string $name): string {
+    return "Hello, $name";
+}`,
+		},
 	}
 
 	for _, info := range allChecks {

--- a/src/tests/checkers/func_params_type_mismatch_phpdoc_test.go
+++ b/src/tests/checkers/func_params_type_mismatch_phpdoc_test.go
@@ -215,17 +215,17 @@ testCallable(function($a, $b) {
 func TestInterfaceCorrect(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
-interface Responsable {}
+interface Responsible {}
 
 /**
- * Uses Responsable interface value.
+ * Uses Responsible interface value.
  *
- * @param \Responsable $r
+ * @param \Responsible $r
  */
-function reference_iface(Responsable $r) {
+function reference_iface(Responsible $r) {
 }
 
-reference_iface(new class implements Responsable {});
+reference_iface(new class implements Responsible {});
 `)
 	test.Expect = []string{}
 	test.RunAndMatch()
@@ -283,5 +283,45 @@ function funcArray(array $a, array $b) {
 funcArray([], []);
 `)
 	test.Expect = []string{}
+	test.RunAndMatch()
+}
+
+func TestBoolSynonym(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+/**
+ * Function with boolean type synonym.
+ *
+ * @param boolean $flag
+ */
+function testBool(bool $flag) {
+}
+`)
+	test.Expect = []string{
+		`Use bool type instead of boolean`,
+	}
+	test.RunAndMatch()
+}
+
+func TestAliasNormalization(t *testing.T) {
+	test := linttest.NewSuite(t)
+	test.AddFile(`<?php
+namespace Test;
+
+use A as B;
+
+/**
+ * Function with aliased type.
+ *
+ * @param \A $item
+ */
+function testAlias(B $item) {
+}
+
+`)
+	test.Expect = []string{
+		`Class or interface named \A does not exist`,
+		`Class or interface named \A does not exist`,
+	}
 	test.RunAndMatch()
 }

--- a/src/tests/checkers/not_explicit_nullable_types_test.go
+++ b/src/tests/checkers/not_explicit_nullable_types_test.go
@@ -18,7 +18,7 @@ function nullableString(?string $a = null) {}
 func TestNotNullableArray(t *testing.T) {
 	test := linttest.NewSuite(t)
 	test.AddFile(`<?php
-/** @param string[] array */
+/** @param string[] $a */
 function nullableArray(array $a = null) {}
 `)
 

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -127,6 +127,9 @@ WARNING notNullSafetyFunctionArgumentVariable: not null safety call in function 
 MAYBE   callSimplify: Could simplify to $id[0] at testdata/mustache/src/Mustache/Compiler.php:646
             if (substr($id, 0, 1) === '.') {
                 ^^^^^^^^^^^^^^^^^
+WARNING funcParamTypeMissMatch: param $tree miss matched with phpdoc type <<string>> at testdata/mustache/src/Mustache/Compiler.php:43
+    public function compile($source, array $tree, $name, $customEscape = false, $charset = 'UTF-8', $strictCallables = false, $entityFlags = ENT_COMPAT)
+                                     ^^^^^^^^^^^
 ERROR   classMembersOrder: Constant KLASS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:184
     const KLASS = '<?php
     ^^^^^^^

--- a/src/tests/golden/testdata/mustache/golden.txt
+++ b/src/tests/golden/testdata/mustache/golden.txt
@@ -129,7 +129,7 @@ MAYBE   callSimplify: Could simplify to $id[0] at testdata/mustache/src/Mustache
                 ^^^^^^^^^^^^^^^^^
 WARNING funcParamTypeMissMatch: param $tree miss matched with phpdoc type <<string>> at testdata/mustache/src/Mustache/Compiler.php:43
     public function compile($source, array $tree, $name, $customEscape = false, $charset = 'UTF-8', $strictCallables = false, $entityFlags = ENT_COMPAT)
-                                     ^^^^^^^^^^^
+                                     ^^^^^
 ERROR   classMembersOrder: Constant KLASS must go before methods in the class Mustache_Compiler at testdata/mustache/src/Mustache/Compiler.php:184
     const KLASS = '<?php
     ^^^^^^^

--- a/src/types/map.go
+++ b/src/types/map.go
@@ -280,7 +280,7 @@ func (m Map) IsBoolean() bool {
 	for typ := range m.m {
 		if UnwrapElemOf(typ) == "bool" || strings.HasSuffix(typ, "bool") ||
 			strings.HasSuffix(typ, "true") ||
-			strings.HasSuffix(typ, "false") {
+			strings.HasSuffix(typ, "false") || strings.HasSuffix(typ, "boolean") {
 			return true
 		}
 	}

--- a/src/types/predicates.go
+++ b/src/types/predicates.go
@@ -12,6 +12,10 @@ func IsShape(s string) bool {
 	return strings.HasPrefix(s, `\shape$`)
 }
 
+func IsBoolean(s string) bool {
+	return strings.HasPrefix(s, "bool") || strings.HasPrefix(s, "boolean")
+}
+
 func IsClosure(s string) bool {
 	return strings.HasPrefix(s, `\Closure`)
 }


### PR DESCRIPTION
We have rule for nullability and i wanna extend checking the compliance of what is in typehints and phpdoc:

- [x]  array support
- [x]  union types support
- [x]  callable support
- [x] classic types
- [x] interfaces
- [x] classes

